### PR TITLE
docs: add canonical slice template scaffolding for all gates

### DIFF
--- a/.github/templates/slice-template/01-requirement.md
+++ b/.github/templates/slice-template/01-requirement.md
@@ -1,0 +1,60 @@
+# Requirement Context Package
+
+**Template Note:** This is Gate 1 output from requirement-challenger agent. Fill in all sections below based on requirement statement validation.
+
+- **Requirement statement:** [One-line product intent — what problem does this solve?]
+- **Problem and expected outcome:** [Why is this needed? What does success look like?]
+
+## Users And Scenarios
+
+- **User 1:** [Who uses this? What is their context?]
+- **User 2:** [Are there multiple user roles/personas?]
+- **Primary scenario:** [What is the main use case? What triggers it?]
+- **Secondary/edge scenarios:** [What other flows matter?]
+
+## Scope Boundaries
+
+**In scope:**
+- [Feature A]
+- [Feature B]
+- [Constraint C]
+
+**Out of scope:**
+- [Explicitly NOT included and why]
+- [Deferred to future slice]
+- [Dependencies not owned by this slice]
+
+## Constraints And Non-Goals
+
+- [Technical or operational constraint]
+- [What we are NOT optimizing for]
+- [Known limitations or acceptable tradeoffs]
+
+## Success Criteria
+
+- [Observable, measurable outcome 1]
+- [Observable, measurable outcome 2]
+- [User sentiment or satisfaction signal (if applicable)]
+
+## Proposed Acceptance Criteria
+
+- AC-1: [Testable acceptance criterion]
+- AC-2: [Testable acceptance criterion]
+- AC-3: [Testable acceptance criterion]
+- AC-4: [Testable acceptance criterion]
+- AC-5: [Testable acceptance criterion]
+
+**Note:** Each AC should map to one success criterion and be verifiable without ambiguity.
+
+## Open Questions (None / Accepted by Product Owner)
+
+- Q-1: [Question text] → **Status:** Resolved | Accepted as non-blocking | **Resolution:** [owner decision]
+
+---
+
+**Gate 1 Verification:**
+- [ ] All sections complete and unambiguous
+- [ ] No hidden assumptions
+- [ ] Acceptance criteria are testable
+- [ ] Scope boundaries are clear
+- [ ] Ready for PRD drafting (Gate 2)

--- a/.github/templates/slice-template/02-prd.md
+++ b/.github/templates/slice-template/02-prd.md
@@ -1,0 +1,147 @@
+# PRD v0 — [Slice Name]
+
+**Template Note:** This is Gate 2 output from prd-agent. Fill in all sections below with expanded detail from Requirement Context Package.
+
+## Slice: `[slice-kebab-name]`
+## Gate: 2 — Product Requirements Document
+## Status: READY | Needs Clarification | Blocked
+## Version: 0.1.0
+## Date: [YYYY-MM-DD]
+## Author: PRD Agent (Gate 2)
+## Source: `docs/slices/[slice-name]/01-requirement.md`
+
+---
+
+## 1. PRD Readiness
+
+**Status: READY**
+
+**Rationale:**
+- [Explain why input was sufficient to write complete PRD]
+- [Confirm all acceptance criteria are testable]
+- [Confirm no ambiguity remains]
+- [Confirm all open questions are resolved or explicitly accepted]
+
+---
+
+## 2. PRD v0
+
+### 2.1 Overview / Purpose
+
+[1-2 paragraph summary of what is being built and why]
+
+---
+
+### 2.2 Target Users
+
+| User | Description |
+|---|---|
+| **User 1** | [Who? Context? Goals?] |
+| **User 2** | [Who? Context? Goals?] |
+
+**Primary scenario:** [Describe the main flow — trigger, user actions, expected outcome]
+
+**Secondary scenarios:** [Edge cases, alternative flows, or different user types]
+
+**Out-of-scope user scenarios:** [Explicitly list who/what is not included]
+
+---
+
+### 2.3 Problem Statement
+
+[Describe the current state and why it is a problem]
+
+**Expected outcome:** [What success looks like from user perspective]
+
+---
+
+### 2.4 User Stories (Expanded from Requirements)
+
+#### US-1: [Story Title]
+- **As a** [user role]
+- **I want** [action/capability]
+- **So that** [benefit/outcome]
+- **Acceptance criteria:** AC-1, AC-2, AC-3
+
+#### US-2: [Story Title]
+- **As a** [user role]
+- **I want** [action/capability]
+- **So that** [benefit/outcome]
+- **Acceptance criteria:** AC-4, AC-5
+
+---
+
+### 2.5 Acceptance Criteria (Detailed)
+
+| ID | Criterion | Verification | Source Requirement |
+|---|---|---|---|
+| AC-1 | [Specific, testable requirement] | [How to verify] | [From 01-requirement.md] |
+| AC-2 | [Specific, testable requirement] | [How to verify] | [From 01-requirement.md] |
+| AC-3 | [Specific, testable requirement] | [How to verify] | [From 01-requirement.md] |
+| AC-4 | [Specific, testable requirement] | [How to verify] | [From 01-requirement.md] |
+| AC-5 | [Specific, testable requirement] | [How to verify] | [From 01-requirement.md] |
+
+---
+
+### 2.6 Scope & Boundaries
+
+**In Scope:**
+- [Feature/component 1]
+- [Feature/component 2]
+
+**Out of Scope:**
+- [Explicitly excluded]
+- [Deferred to later slice]
+
+**Constraints:**
+- [Technical, operational, or business constraint]
+
+---
+
+### 2.7 Traceability Map
+
+From Requirement → PRD → UX/Design → Architecture:
+
+| Requirement | PRD Section | User Story | Acceptance Criteria |
+|---|---|---|---|
+| [from 01] | [2.x section] | US-1/US-2 | AC-1/AC-2/AC-3 |
+| [from 01] | [2.x section] | US-1/US-2 | AC-4/AC-5 |
+
+---
+
+## 3. Quality Gaps
+
+- [Any ambiguities that remain?]
+- [Any acceptance criteria still fuzzy?]
+- [Any dependencies or assumptions that need confirmation?]
+
+---
+
+## 4. Open Questions
+
+| ID | Question | Source | Status | Resolution |
+|---|---|---|---|---|
+| Q-1 | [Question] | [Gate 1 / Gate 2] | Resolved / Accepted | [Owner decision] |
+
+---
+
+## 5. Gate Decision
+
+**Gate Decision: can proceed to design | must loop back**
+
+**Rationale:**
+- PRD is complete and testable.
+- All acceptance criteria are mapped and verifiable.
+- UX/Figma work can proceed with confidence.
+
+---
+
+## Additional Sections (Optional)
+
+### Metrics & Success Signals
+- [How will success be measured?]
+- [What metrics matter?]
+
+### Release Notes (Draft)
+- [High-level description of what is shipping]
+- [User-facing benefit]

--- a/.github/templates/slice-template/03-ux.md
+++ b/.github/templates/slice-template/03-ux.md
@@ -1,0 +1,125 @@
+# UX Flow/State Package
+
+**Template Note:** This is Gate 3A output from ux-agent. Fill in all sections below with UX flows, state matrices, and interaction notes.
+
+## Slice: `[slice-kebab-name]`
+## Gate: 3A — UX Design & Flow Definition
+## Status: READY | Needs Clarification | Blocked
+## Version: 0.1.0
+## Date: [YYYY-MM-DD]
+## Author: UX Agent (Gate 3A)
+## Source: `docs/slices/[slice-name]/02-prd.md`
+
+---
+
+## 1. UX Readiness
+
+**Status: READY**
+
+**Rationale:**
+- [PRD was complete and testable]
+- [All user stories translated to flows]
+- [All states and edge cases identified]
+- [Figma is ready for design handoff]
+
+---
+
+## 2. User Flows
+
+### Flow 1: [Primary Flow Name]
+
+**Trigger:** [What initiates this flow?]
+
+**Steps:**
+1. [User action or system state]
+2. [User action or system state]
+3. [Expected outcome]
+
+**States involved:** S-1, S-2, S-3
+
+**Edge cases:**
+- [What if X happens?] → [Branch behavior]
+- [What if Y happens?] → [Branch behavior]
+
+---
+
+### Flow 2: [Secondary Flow Name]
+
+**Trigger:** [What initiates this flow?]
+
+**Steps:**
+1. [User action or system state]
+2. [User action or system state]
+3. [Expected outcome]
+
+**States involved:** S-2, S-4, S-5
+
+**Edge cases:**
+- [What if X happens?] → [Branch behavior]
+
+---
+
+## 3. State Matrix
+
+| State ID | State Name | Description | Primary Flow(s) | Edge Cases | Acceptance Criteria |
+|---|---|---|---|---|---|
+| S-1 | [State name] | [What is displayed/enabled?] | Flow 1 | [Exceptional conditions] | AC-1, AC-2 |
+| S-2 | [State name] | [What is displayed/enabled?] | Flow 1, Flow 2 | [Exceptional conditions] | AC-2, AC-3 |
+| S-3 | [State name] | [What is displayed/enabled?] | Flow 1 | [Exceptional conditions] | AC-3 |
+| S-4 | [State name] | [What is displayed/enabled?] | Flow 2 | [Exceptional conditions] | AC-4 |
+| S-5 | [Error state] | [Error handling] | Flow 2 | [Recovery path] | AC-5 |
+
+---
+
+## 4. Interaction Notes
+
+### Component/Pattern 1: [Name]
+- **Purpose:** [Why does this exist?]
+- **Behavior:** [What does it do when interacted with?]
+- **States:** [Idle, hover, active, disabled, loading, error]
+- **Related AC:** AC-1, AC-2
+
+### Component/Pattern 2: [Name]
+- **Purpose:** [Why does this exist?]
+- **Behavior:** [What does it do when interacted with?]
+- **States:** [Idle, hover, active, disabled, loading, error]
+- **Related AC:** AC-3, AC-4
+
+---
+
+## 5. Design Artifact Reference
+
+**Figma File:** [Add Figma link or file key]
+
+**Screens/Frames in Figma:**
+- [Screen 1 / State S-1]
+- [Screen 2 / State S-2]
+- [Screen 3 / State S-3]
+- [Error screen / State S-5]
+
+---
+
+## 6. Quality Gaps
+
+- [Any interaction ambiguities?]
+- [Any state transitions unclear?]
+- [Any edge cases not fully specified?]
+
+---
+
+## 7. Open Questions
+
+| ID | Question | Source | Status | Resolution |
+|---|---|---|---|---|
+| Q-1 | [Question] | [from PRD] | Resolved / Accepted | [Owner decision] |
+
+---
+
+## 8. Gate Decision
+
+**Gate Decision: can proceed to figma | must loop back**
+
+**Rationale:**
+- All user flows are mapped and testable.
+- All states are defined.
+- Figma designer has sufficient detail to proceed.

--- a/.github/templates/slice-template/04-design-qa.md
+++ b/.github/templates/slice-template/04-design-qa.md
@@ -1,0 +1,139 @@
+# Design QA Verdict Package
+
+**Template Note:** This is Gate 3C output from design-qa-agent. Fill in all sections below after reviewing Figma design against PRD and UX.
+
+## Slice: `[slice-kebab-name]`
+## Gate: 3C — Design QA & Verification
+## Status: READY | Needs Clarification | Blocked
+## Version: 0.1.0
+## Date: [YYYY-MM-DD]
+## Author: Design QA Agent (Gate 3C)
+## Source: Figma design [link or file key]
+
+---
+
+## 1. Design QA Readiness
+
+**Status: READY**
+
+**Rationale:**
+- [All PRD acceptance criteria mapped to design]
+- [All UX flows implemented in Figma]
+- [All states and edge cases covered]
+- [Component/token consistency verified]
+- [Ready for architecture & implementation]
+
+---
+
+## 2. PRD Traceability Review
+
+### Acceptance Criteria Coverage
+
+| AC ID | Criterion | Design Section | Status | Notes |
+|---|---|---|---|---|
+| AC-1 | [from PRD] | [Figma screen/component] | ✓ Covered | [Why coverage is sufficient] |
+| AC-2 | [from PRD] | [Figma screen/component] | ✓ Covered | [Why coverage is sufficient] |
+| AC-3 | [from PRD] | [Figma screen/component] | ✓ Covered | [Why coverage is sufficient] |
+| AC-4 | [from PRD] | [Figma screen/component] | ✓ Covered | [Why coverage is sufficient] |
+| AC-5 | [from PRD] | [Figma screen/component] | ✓ Covered | [Why coverage is sufficient] |
+
+---
+
+## 3. UX Coverage Review
+
+### Flows & States
+
+| Flow | States | Figma Screens | Status | Coverage Notes |
+|---|---|---|---|---|
+| [Primary flow] | S-1, S-2, S-3 | [Screen 1, Screen 2, Screen 3] | ✓ Complete | [All states represented] |
+| [Secondary flow] | S-2, S-4 | [Screen 2, Screen 4] | ✓ Complete | [All states represented] |
+| [Error flow] | S-5 | [Error screen] | ✓ Complete | [Error handling clear] |
+
+### Edge Case Coverage
+
+- [Edge case 1] → [How design handles it] ✓ Covered
+- [Edge case 2] → [How design handles it] ✓ Covered
+- [Error state] → [How design handles it] ✓ Covered
+
+---
+
+## 4. Component & Token Consistency Review
+
+### Design Tokens Used
+
+| Token Type | Examples | Consistency | Status |
+|---|---|---|---|
+| Colors | [Primary color], [Secondary color] | [Consistent with design system?] | ✓ OK |
+| Typography | [Heading style], [Body style] | [Consistent with design system?] | ✓ OK |
+| Spacing | [Margin/padding units] | [Consistent with design system?] | ✓ OK |
+| Shadows/Effects | [List effects used] | [Consistent with design system?] | ✓ OK |
+
+### Components Used
+
+| Component | Instances | Consistency | Accessibility Notes |
+|---|---|---|---|
+| [Button component] | [# used] | ✓ Consistent | [Focus state, label] |
+| [Input component] | [# used] | ✓ Consistent | [Label, error state] |
+| [Card component] | [# used] | ✓ Consistent | [Semantic structure] |
+
+---
+
+## 5. Edge State Coverage Review
+
+| Edge State | Figma Screen | Design Treatment | Status |
+|---|---|---|---|
+| [Empty state] | [Screen name] | [How handled] | ✓ Designed |
+| [Loading state] | [Screen name] | [How handled] | ✓ Designed |
+| [Error state] | [Screen name] | [Error message, recovery] | ✓ Designed |
+| [Success state] | [Screen name] | [Confirmation/feedback] | ✓ Designed |
+
+---
+
+## 6. Quality Gaps
+
+- [Any missing states?]
+- [Any token inconsistencies?]
+- [Any component misalignment?]
+- [Any accessibility concerns?]
+
+---
+
+## 7. Open Questions
+
+| ID | Question | Source | Status | Resolution |
+|---|---|---|---|---|
+| Q-1 | [Question] | [from PRD/UX] | Resolved / Accepted | [Owner decision] |
+
+---
+
+## 8. Gate Decision
+
+**Gate Decision: can proceed to architecture | must loop back**
+
+**Rationale:**
+- PRD acceptance criteria are fully mapped to design.
+- UX flows are fully represented in Figma.
+- All edge states are handled.
+- Design is production-ready for architecture & implementation.
+
+---
+
+## 9. Figma Design Reference
+
+**File:** [Figma link or file key]
+
+**Screens and Frame Names:**
+- [Screen 1 name / State S-1]
+- [Screen 2 name / State S-2]
+- [Error screen / State S-5]
+
+---
+
+## Product Owner Sign-Off
+
+- **Reviewed by:** [Product Owner name]
+- **Date:** [YYYY-MM-DD]
+- **Status:** ✓ Approved | Requesting changes
+
+**Notes:**
+- [Any feedback or conditions for approval]

--- a/.github/templates/slice-template/05-architecture.md
+++ b/.github/templates/slice-template/05-architecture.md
@@ -1,0 +1,208 @@
+# Architecture Plan
+
+**Template Note:** This is Gate 4 output from architecture-agent. Fill in all sections below with technical design, module boundaries, risks, and task breakdown.
+
+## Slice: `[slice-kebab-name]`
+## Gate: 4 — Architecture & Task Decomposition
+## Status: READY | Needs Clarification | Blocked
+## Version: 0.1.0
+## Date: [YYYY-MM-DD]
+## Author: Architecture Agent (Gate 4)
+## Source: `docs/slices/[slice-name]/04-design-qa.md`
+
+---
+
+## 1. Architecture Readiness
+
+**Status: READY**
+
+**Rationale:**
+- [Design is complete and verified]
+- [Acceptance criteria are mapped to implementation areas]
+- [Module boundaries are clear]
+- [Risk mitigation plans are in place]
+- [Task decomposition is atomic and ordered]
+
+---
+
+## 2. Architecture Overview
+
+### High-Level Design
+
+[2-3 paragraphs describing the overall approach]
+
+**Key Design Decisions:**
+- [Decision 1: Why this approach?]
+- [Decision 2: Why this approach?]
+- [Decision 3: Why this approach?]
+
+**Traceability:** References to AC-1, AC-2, AC-3 (how design choices satisfy acceptance criteria)
+
+---
+
+## 3. Module Responsibilities
+
+### Module 1: [Module Name]
+- **Purpose:** [What does this module do?]
+- **Ownership:** [Who implements?]
+- **Inputs:** [What depends on this?]
+- **Outputs:** [What does it produce?]
+- **Files/Folders:**
+  - `src/[module-name]/`
+  - `tests/[module-name]/`
+- **Related AC:** AC-1, AC-2
+
+### Module 2: [Module Name]
+- **Purpose:** [What does this module do?]
+- **Ownership:** [Who implements?]
+- **Inputs:** [What depends on this?]
+- **Outputs:** [What does it produce?]
+- **Files/Folders:**
+  - `src/[module-name]/`
+  - `tests/[module-name]/`
+- **Related AC:** AC-3, AC-4
+
+---
+
+## 4. Integration Points
+
+| Module A | Module B | Contract | Verification |
+|---|---|---|---|
+| [Module 1] | [Module 2] | [What does Module 1 export? How is it used?] | [How to test they work together?] |
+| [Module 2] | [Module 3] | [What interface between them?] | [How to test they work together?] |
+
+---
+
+## 5. Impact Analysis
+
+### Files to Create
+- `src/[path]/[file1].js`
+- `src/[path]/[file2].js`
+- `tests/[path]/[file1].test.js`
+
+### Files to Modify
+- `[existing-file.js]` — [Why? What changes?]
+- `[package.json]` — [New dependencies?]
+
+### Files to Delete
+- [Any deprecated files?]
+
+### Backward Compatibility
+- [Breaking changes?]
+- [Deprecation warnings needed?]
+
+---
+
+## 6. Risk & Mitigation Plan
+
+### Risk 1: [Risk Description]
+- **Likelihood:** High | Medium | Low
+- **Impact:** Critical | Major | Minor
+- **Mitigation:** [How to prevent or reduce?]
+- **Escalation:** [When do we escalate?]
+- **Related AC:** AC-1
+
+### Risk 2: [Risk Description]
+- **Likelihood:** High | Medium | Low
+- **Impact:** Critical | Major | Minor
+- **Mitigation:** [How to prevent or reduce?]
+- **Escalation:** [When do we escalate?]
+- **Related AC:** AC-2
+
+---
+
+## 7. Verification Strategy
+
+### Unit Tests
+- [Module 1 unit tests] → AC-1, AC-2
+- [Module 2 unit tests] → AC-3, AC-4
+
+### Integration Tests
+- [How modules work together] → AC-1, AC-2, AC-3
+
+### End-to-End Tests
+- [Full flow verification] → AC-1 through AC-5
+
+### Manual Verification
+- [Steps to verify in browser/device?]
+
+---
+
+## 8. Rollback Plan
+
+**Rollback Approach:** [How is this slice rolled back if issues arise?]
+
+**Rollback Steps:**
+1. [Step 1]
+2. [Step 2]
+3. [Verification that rollback succeeded]
+
+**Rollback Risk:** [Residual risk after rollback]
+
+---
+
+## 9. Task Decomposition
+
+### T1: [Task Title]
+- **Objective:** [What delivers?]
+- **Files:** [What changes?]
+- **Acceptance Criteria:** AC-1
+- **Dependencies:** None
+- **Estimated complexity:** Small | Medium | Large
+
+### T2: [Task Title]
+- **Objective:** [What delivers?]
+- **Files:** [What changes?]
+- **Acceptance Criteria:** AC-2
+- **Dependencies:** T1
+- **Estimated complexity:** Small | Medium | Large
+
+### T3: [Task Title]
+- **Objective:** [What delivers?]
+- **Files:** [What changes?]
+- **Acceptance Criteria:** AC-3
+- **Dependencies:** T1, T2
+- **Estimated complexity:** Small | Medium | Large
+
+### T4: [Task Title]
+- **Objective:** [What delivers?]
+- **Files:** [What changes?]
+- **Acceptance Criteria:** AC-4
+- **Dependencies:** T2
+- **Estimated complexity:** Small | Medium | Large
+
+### T5: [Task Title]
+- **Objective:** [What delivers?]
+- **Files:** [What changes?]
+- **Acceptance Criteria:** AC-5
+- **Dependencies:** T1, T2, T3, T4
+- **Estimated complexity:** Small | Medium | Large
+
+---
+
+## 10. Quality Gaps
+
+- [Any ambiguities in module responsibilities?]
+- [Any untested integration points?]
+- [Any unmitigated risks?]
+
+---
+
+## 11. Open Questions
+
+| ID | Question | Source | Status | Resolution |
+|---|---|---|---|---|
+| Q-1 | [Question] | [from PRD/UX] | Resolved / Accepted | [Owner decision] |
+
+---
+
+## 12. Gate Decision
+
+**Gate Decision: can proceed to build | must loop back**
+
+**Rationale:**
+- Architecture stays within approved scope.
+- All module boundaries are clear.
+- All risks have mitigation plans.
+- Task decomposition is atomic and dependency-ordered.
+- Gate 5 (Build) is authorized once tasks are created as GitHub Issues.

--- a/.github/templates/slice-template/06-tasks.md
+++ b/.github/templates/slice-template/06-tasks.md
@@ -1,0 +1,170 @@
+# Task Breakdown & GitHub Issue Mapping
+
+**Template Note:** This is the task ledger created by orchestrator after architecture gate passes. Links each task to a GitHub issue for Gate 5 (Build).
+
+## Slice: `[slice-kebab-name]`
+## Gate: 4 End — Task Decomposition & Issue Creation
+## Status: Issues created and linked
+## Date: [YYYY-MM-DD]
+
+---
+
+## GitHub Slice Tracker
+
+**Slice Tracker Issue:** [#XX](https://github.com/nishantnaagnihotri/tark-vitark/issues/XX)
+
+**Title:** `[Slice] [slice-name]`
+
+**Labels:** `slice`
+
+**Purpose:** Single source of truth for all story issues in this slice. Slice remains closed when slice is complete; links persist as audit trail.
+
+---
+
+## User Stories (Tasks)
+
+### T1: [Task Title]
+
+**GitHub Issue:** [#XX](https://github.com/nishantnaagnihotri/tark-vitark/issues/XX)
+
+**Architecture Reference:** `05-architecture.md` — Section 9, T1
+
+**Objective:** [What is delivered?]
+
+**Scope:** [Boundaries — what is included/excluded?]
+
+**Acceptance Criteria:** AC-1 (from PRD)
+
+**Files Affected:**
+- `src/[path]/[file].js` — [What changes?]
+- `tests/[path]/[file].test.js` — [New tests]
+
+**Dependencies:** None
+
+**Status:** [ ] Not started | [ ] In progress | [x] Complete
+
+---
+
+### T2: [Task Title]
+
+**GitHub Issue:** [#XX](https://github.com/nishantnaagnihotri/tark-vitark/issues/XX)
+
+**Architecture Reference:** `05-architecture.md` — Section 9, T2
+
+**Objective:** [What is delivered?]
+
+**Scope:** [Boundaries — what is included/excluded?]
+
+**Acceptance Criteria:** AC-2 (from PRD)
+
+**Files Affected:**
+- `src/[path]/[file].js` — [What changes?]
+- `tests/[path]/[file].test.js` — [New tests]
+
+**Dependencies:** T1
+
+**Status:** [ ] Not started | [ ] In progress | [x] Complete
+
+---
+
+### T3: [Task Title]
+
+**GitHub Issue:** [#XX](https://github.com/nishantnaagnihotri/tark-vitark/issues/XX)
+
+**Architecture Reference:** `05-architecture.md` — Section 9, T3
+
+**Objective:** [What is delivered?]
+
+**Scope:** [Boundaries — what is included/excluded?]
+
+**Acceptance Criteria:** AC-3 (from PRD)
+
+**Files Affected:**
+- `src/[path]/[file].js` — [What changes?]
+- `tests/[path]/[file].test.js` — [New tests]
+
+**Dependencies:** T1, T2
+
+**Status:** [ ] Not started | [ ] In progress | [x] Complete
+
+---
+
+### T4: [Task Title]
+
+**GitHub Issue:** [#XX](https://github.com/nishantnaagnihotri/tark-vitark/issues/XX)
+
+**Architecture Reference:** `05-architecture.md` — Section 9, T4
+
+**Objective:** [What is delivered?]
+
+**Scope:** [Boundaries — what is included/excluded?]
+
+**Acceptance Criteria:** AC-4 (from PRD)
+
+**Files Affected:**
+- `src/[path]/[file].js` — [What changes?]
+- `tests/[path]/[file].test.js` — [New tests]
+
+**Dependencies:** T2
+
+**Status:** [ ] Not started | [ ] In progress | [x] Complete
+
+---
+
+### T5: [Task Title]
+
+**GitHub Issue:** [#XX](https://github.com/nishantnaagnihotri/tark-vitark/issues/XX)
+
+**Architecture Reference:** `05-architecture.md` — Section 9, T5
+
+**Objective:** [What is delivered?]
+
+**Scope:** [Boundaries — what is included/excluded?]
+
+**Acceptance Criteria:** AC-5 (from PRD)
+
+**Files Affected:**
+- `src/[path]/[file].js` — [What changes?]
+- `tests/[path]/[file].test.js` — [New tests]
+
+**Dependencies:** T1, T2, T3, T4
+
+**Status:** [ ] Not started | [ ] In progress | [x] Complete
+
+---
+
+## Execution Record
+
+| Task | Issue # | Assigned To | PR Link | Status | Merged Date |
+|---|---|---|---|---|---|
+| T1 | [#XX](https://github.com/...) | dev agent | [PR #XX](https://github.com/...) | Complete | [YYYY-MM-DD] |
+| T2 | [#XX](https://github.com/...) | dev agent | [PR #XX](https://github.com/...) | Complete | [YYYY-MM-DD] |
+| T3 | [#XX](https://github.com/...) | dev agent | [PR #XX](https://github.com/...) | Complete | [YYYY-MM-DD] |
+| T4 | [#XX](https://github.com/...) | dev agent | [PR #XX](https://github.com/...) | Complete | [YYYY-MM-DD] |
+| T5 | [#XX](https://github.com/...) | dev agent | [PR #XX](https://github.com/...) | Complete | [YYYY-MM-DD] |
+
+---
+
+## Slice Completion Checklist
+
+- [ ] All T1–T5 issues created with labels `user-story` and `slice:[slice-name]`
+- [ ] All story issues include `Slice tracker:` backlink to [#XX]
+- [ ] Slice tracker issue lists all story issues in `User stories` section
+- [ ] `06-tasks.md` maps all tasks to GitHub issues
+- [ ] Gate 5 (Build) is authorized; each task is ready for independent dev handoff
+- [ ] All PRs are merged
+- [ ] Slice tracker is closed (audit trail remains intact)
+
+---
+
+## Slice Completion Summary
+
+**Slice Completed:** [YYYY-MM-DD]
+
+**Total Tasks:** 5
+
+**Total Merged PRs:** 5
+
+**Scope:** [Verify no scope creep occurred during build]
+
+**Notes:** [Any lessons learned? Known limitations? Future work?]

--- a/.github/templates/slice-template/README.md
+++ b/.github/templates/slice-template/README.md
@@ -1,0 +1,273 @@
+# Slice Template
+
+This template provides a standardized structure for all delivery slices in the tark-vitark project.
+
+## What Is a Slice?
+
+A **slice** is a vertical, end-to-end delivery container that flows through six gates from requirement → design → architecture → build → merge.
+
+Each slice:
+- Exists in **two places**: as versioned markdown artifacts in `docs/slices/<slice-name>/` AND as a GitHub issue tracker with linked story issues
+- Is **atomic**: designed to complete in one sprint or shorter
+- Is **traceable**: every design decision and implementation task is linked back to acceptance criteria
+
+---
+
+## Slice Lifecycle
+
+```
+Gate 1 (Requirement Challenge)
+  ↓ 01-requirement.md created
+Gate 2 (PRD)
+  ↓ 02-prd.md created
+Gate 3 (UX + Design + Design QA)
+  ↓ 03-ux.md created
+  ↓ 04-design-qa.md created
+Gate 4 (Architecture)
+  ↓ 05-architecture.md created
+  ↓ 06-tasks.md created (+ GitHub issues)
+Gate 5 (Build)
+  ↓ One PR per task; all merged
+Gate 6 (Merge Review)
+  ↓ Slice tracker closed; audit trail preserved
+```
+
+---
+
+## File Descriptions
+
+### 01-requirement.md
+
+**Gate:** 1 (Requirement Challenge)
+
+**Owner:** requirement-challenger agent
+
+**Purpose:** Validates the initial product intent for completeness and testability.
+
+**Contains:**
+- Requirement statement (one-line problem + outcome)
+- User scenarios and primary flow
+- Scope boundaries (in-scope, out-of-scope, constraints)
+- Success criteria (5-7 observable outcomes)
+- Proposed acceptance criteria (AC-1 through AC-5, always testable)
+- Open questions (all must be resolved or explicitly accepted)
+
+**How to use:** Fill in from actual requirement statement. Collaborate with Product Owner to ensure no ambiguity.
+
+---
+
+### 02-prd.md
+
+**Gate:** 2 (Product Requirements Document)
+
+**Owner:** prd-agent
+
+**Purpose:** Expands the requirement into a full product specification with traceability.
+
+**Contains:**
+- PRD readiness statement (why input was sufficient)
+- Overview and purpose (what is being built and why)
+- Target users and scenarios (detailed descriptions)
+- Problem statement and expected outcome
+- User stories (expanded from requirements, mapped to ACs)
+- Detailed acceptance criteria (testable, with verification strategy)
+- Scope and boundaries (refined from Gate 1)
+- Traceability map (requirement → PRD → UX → architecture)
+- Quality gaps and open questions (none should remain)
+
+**How to use:** Start from 01-requirement.md. Work with PRD agent to map each requirement to user stories and acceptance criteria. This doc becomes the source of truth for design and architecture.
+
+---
+
+### 03-ux.md
+
+**Gate:** 3A (UX Design & Flow Definition)
+
+**Owner:** ux-agent
+
+**Purpose:** Translates PRD into user flows, state definitions, and interaction specifications.
+
+**Contains:**
+- UX readiness statement (why design can proceed)
+- User flows (steps, states, edge cases for each flow)
+- State matrix (every distinct UI state defined)
+- Interaction notes (component behaviors, focus states, etc.)
+- Design artifact reference (link to Figma file)
+- Traceability to acceptance criteria
+- Quality gaps and open questions
+
+**How to use:** Start from 02-prd.md user stories. Document each flow and state. Produce Figma screens for each state. Link back to AC IDs so designer understands what is being satisfied.
+
+---
+
+### 04-design-qa.md
+
+**Gate:** 3C (Design QA & Verification)
+
+**Owner:** design-qa-agent
+
+**Purpose:** Verifies that Figma design fully implements PRD and UX specifications.
+
+**Contains:**
+- Design QA readiness statement
+- PRD traceability review (every AC mapped to a design element)
+- UX coverage review (every flow and state in Figma)
+- Component and token consistency review (design system compliance)
+- Edge state coverage (empty, loading, error, success)
+- Quality gaps and open questions
+- Product Owner sign-off (approval required before architecture)
+
+**How to use:** Design QA agent reads Figma directly via MCP. Maps each AC to a screen/component. Flags any gaps. Loops back to figma-agent if revisions needed. Only closes when Product Owner approves.
+
+---
+
+### 05-architecture.md
+
+**Gate:** 4 (Architecture & Task Decomposition)
+
+**Owner:** architecture-agent
+
+**Purpose:** Defines technical implementation strategy, module boundaries, risks, and atomic tasks.
+
+**Contains:**
+- Architecture readiness statement
+- High-level design overview (why this technical approach)
+- Module responsibilities (what each part does, boundaries, files)
+- Integration points (how modules talk to each other)
+- Impact analysis (files created, modified, deleted)
+- Risk and mitigation plan (for each technical risk)
+- Verification strategy (unit tests, integration tests, e2e, manual)
+- Rollback plan (how to undo if needed)
+- Task decomposition (T1–T5, dependencies, acceptance criteria)
+
+**How to use:** Start from 04-design-qa.md. Design the codebase structure. Break work into atomic tasks (typically 5–7). Each task should be completable in 4–8 hours. Document dependencies so orchestrator can sequence them properly.
+
+---
+
+### 06-tasks.md
+
+**Gate:** 4 End (Task Ledger & Issue Mapping)
+
+**Owner:** orchestrator (after architecture approved)
+
+**Purpose:** Maps each task to a GitHub issue; serves as single source of truth for build progress.
+
+**Contains:**
+- Slice tracker issue link (the GitHub issue that groups all stories)
+- T1–T5 task definitions with:
+  - GitHub issue link
+  - Architecture section reference
+  - Scope and files affected
+  - Acceptance criteria (linked back to PRD)
+  - Dependencies
+- Execution table (progress tracking as tasks are built and merged)
+- Completion checklist (what must be true when slice is done)
+
+**How to use:** Orchestrator creates this after Gate 4 passes. GitHub issues are created with labels `user-story` and `slice:<slice-name>`. Each issue includes a `Slice tracker:` backlink. This file is the reference for developers handoff at Gate 5.
+
+---
+
+## How to Use This Template
+
+### For a New Slice
+
+1. Copy this template folder to a new location at `docs/slices/<your-slice-name>/`
+2. At Gate 1: orchestrator invokes requirement-challenger, receives Requirement Context Package
+3. requirement-challenger fills in 01-requirement.md and returns it
+4. At Gate 2: orchestrator invokes prd-agent, receives PRD Draft Package
+5. prd-agent fills in 02-prd.md and returns it
+6. At Gate 3A: orchestrator invokes ux-agent, receives UX Flow/State Package
+7. ux-agent fills in 03-ux.md and returns it
+8. At Gate 3B: orchestrator invokes figma-agent, receives Design Draft Package
+9. figma-agent creates Figma screens; design-qa-agent fills in 04-design-qa.md
+10. At Gate 4: orchestrator invokes architecture-agent, receives Architecture Plan
+11. architecture-agent fills in 05-architecture.md and returns it
+12. Orchestrator creates GitHub issues and fills in 06-tasks.md
+13. Gate 5: dev agent works one task at a time, creating PRs
+
+---
+
+## Template Sections Explained
+
+### Standard Headers (All Files)
+
+Every file has:
+- **Slice:** kebab-case slice name (e.g., `coming-soon-splash-page`)
+- **Gate:** Which gate produced this artifact
+- **Status:** READY | Needs Clarification | Blocked
+- **Version:** Semantic versioning (0.1.0 initial, 0.1.1 revision, etc.)
+- **Date:** ISO 8601 (YYYY-MM-DD)
+- **Author:** Which agent created it
+- **Source:** Which file was used as input
+
+### Acceptance Criteria Tables
+
+Every file traces back to PRD acceptance criteria (AC-1, AC-2, etc.) to ensure no requirement is orphaned.
+
+### Open Questions Sections
+
+Every file documents unresolved questions. When status is "Resolved," the resolution is recorded. When status is "Accepted," it means the PO accepted it as non-blocking.
+
+### Quality Gaps Sections
+
+Every file documents gaps or ambiguities found during that gate. These gaps must be closed before progression.
+
+### Gate Decision Sections
+
+Every file ends with an explicit gate decision:
+- **can proceed to [next gate]** — all criteria met, progression authorized
+- **must loop back** — gaps exist, agent will revise and resubmit
+
+---
+
+## Traceability Across Gates
+
+```
+01-requirement.md (AC-1, AC-2, AC-3, AC-4, AC-5)
+       ↓ must map to ↓
+02-prd.md (expand ACs, add user stories)
+       ↓ must map to ↓
+03-ux.md (flows and states that satisfy ACs)
+       ↓ must map to ↓
+04-design-qa.md (Figma screens that cover each AC)
+       ↓ must map to ↓
+05-architecture.md (modules, files, tasks that implement ACs)
+       ↓ must map to ↓
+06-tasks.md (GitHub issues, each tied to AC)
+       ↓ must map to ↓
+Built code (pull requests that close issues)
+```
+
+Every AC must be traceable end-to-end from requirement to merged PR.
+
+---
+
+## Labels & GitHub Integration
+
+All user story issues for this slice must have:
+- **Label:** `user-story` (required)
+- **Label:** `slice:<slice-name>` (required, e.g., `slice:coming-soon-splash-page`)
+- **Issue body includes:** `Slice tracker: [#XX](...)` backlink
+- **Slice tracker issue includes:** `User stories:` section with links to all story issues
+
+---
+
+## When to Create a New Slice
+
+New slices should be created for:
+- Independent, end-to-end user-facing features
+- Bug fixes that require design/architecture review
+- Technical infrastructure work with clear acceptance criteria
+- Refactoring or optimization with measurable outcomes
+
+Do NOT create a new slice for:
+- Bug fixes without design implications
+- Typos or minor copy updates
+- Dependency upgrades without feature impact
+- Comments or internal documentation
+
+---
+
+## Questions?
+
+Refer to `.github/AGENTS.md` for shared protocol and `.github/agents/architect-orchestrator.agent.md` for orchestrator execution rules.


### PR DESCRIPTION
Add standardized slice templates for consistent artifact creation:

- Created .github/templates/slice-template/ with 01-requirement.md through 06-tasks.md
- Each file includes gate-specific headers, placeholder sections, traceability guidance
- Templates enforce acceptance criteria mapping (AC-1-5), bidirectional links, open questions tracking
- README.md explains template structure, gate workflow, traceability flow, GitHub labeling
- Seeds used for all future slices via copying to docs/slices/<slice-name>/