### PR TITLE
docs: align requirement-challenger and PRD agent with Gate1→Gate2 contract lock

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -19,10 +19,19 @@ This repository follows a human-led, agent-executed workflow.
 
 1. Requirement challenge gate must pass before PRD freeze.
 2. PRD drafting uses Requirement Context Package and must pass PRD quality gate before PRD freeze.
-3. Design freeze must happen before coding. Gate 3 is the full design gate and includes UX, Figma, and Design QA substeps.
-4. Design artifact is mandatory for every UX task: each Gate 3A UX output must include a Figma or Penpot artifact reference (file URL or file key) before progression.
-5. Architecture signoff must happen before coding.
-6. Merge requires passing tests, review closure, docs update, and rollback note.
+3. Gate 2 (PRD) must preserve Gate 1 intent: no silent reinterpretation of requirement statement, scope boundaries, or acceptance criteria.
+4. Design freeze must happen before coding. Gate 3 is the full design gate and includes UX, Figma, and Design QA substeps.
+5. Design artifact is mandatory for every UX task: each Gate 3A UX output must include a Figma or Penpot artifact reference (file URL or file key) before progression.
+6. Architecture signoff must happen before coding.
+7. Merge requires passing tests, review closure, docs update, and rollback note.
+
+## Requirement-To-PRD Alignment Protocol
+
+1. `01-requirement.md` is the source contract for Gate 2 and must be treated as immutable input during PRD drafting.
+2. Requirement statement, in-scope/out-of-scope boundaries, and AC IDs (AC-1..AC-N) must carry forward unchanged unless Product Owner explicitly approves a change.
+3. PRD must include a Requirement-to-PRD Alignment Check section showing one-to-one mapping from requirement IDs to PRD sections and user stories.
+4. If PRD introduces new scope, changed wording, or rewritten AC intent without explicit owner decision, Gate 2 must loop back.
+5. Templates should only be filled after requirement refinement is complete: no unresolved placeholders in Gate 1 output except explicitly accepted open questions.
 
 ## Environment Routing
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -99,6 +99,7 @@ Context transfer rule:
 1. Require `Requirement Context Package` from challenger when Gate 1 passes.
 2. Persist it as the slice context source of truth for Gate 2.
 3. Use this package as the primary input to PRD drafting handoff.
+4. Freeze the Gate 1 contract for Gate 2: requirement statement, scope boundaries, and AC intent cannot change without explicit Product Owner decision recorded in context.
 
 ## PRD Gate Handoff Trigger
 
@@ -115,7 +116,8 @@ Proceeding rule:
 
 1. Continue only when PRD result is `PRD Readiness: Ready` and `Gate Decision: can proceed to design`.
 2. If open questions remain, continue only when they are explicitly marked as accepted by Product Owner.
-3. Otherwise, return quality gaps to Product Owner and loop PRD clarification.
+3. Continue only when PRD output includes an explicit Requirement-to-PRD Alignment Check with one-to-one mapping from Gate 1 inputs.
+4. Otherwise, return quality gaps to Product Owner and loop PRD clarification.
 
 Cloud-return rule:
 
@@ -123,6 +125,7 @@ Cloud-return rule:
 2. Validate the returned package in Local against the PRD gate checklist before advancing gate status.
 3. Verify the `PR Description` block is present in the returned package. If missing, request it before merge is authorized.
 4. Verify every open question in the package has a populated `Resolution` field. If any are blank, loop back to PRD Agent.
+5. Verify PRD did not alter Gate 1 requirement statement, scope boundaries, or AC intent unless owner-approved and logged.
 
 ## Design Gate Substep A: UX Handoff Trigger
 
@@ -338,12 +341,13 @@ Additional Product Owner updates (optional):
 Return only:
 1) PRD Readiness: Ready | Needs Clarification | Blocked
 2) PRD v0
-3) Traceability Map
-4) Quality Gaps
-5) Open Questions (full table: ID, Question, Source, Status, Resolution — no blank Resolution fields)
-6) Gate Decision: can proceed to design | must loop back
-7) PRD Draft Package (for UX/design handoff)
-8) PR Description (ready-to-paste GitHub PR body including: one-line PRD summary, slice folder path, gate status, open questions table with Status and Resolution columns, which unresolved questions block which future gate, artifact path)
+3) Requirement-to-PRD Alignment Check (explicit one-to-one mapping from Gate 1 inputs to PRD sections; highlight any owner-approved deltas)
+4) Traceability Map
+5) Quality Gaps
+6) Open Questions (full table: ID, Question, Source, Status, Resolution — no blank Resolution fields)
+7) Gate Decision: can proceed to design | must loop back
+8) PRD Draft Package (for UX/design handoff)
+9) PR Description (ready-to-paste GitHub PR body including: one-line PRD summary, slice folder path, gate status, open questions table with Status and Resolution columns, which unresolved questions block which future gate, artifact path)
 ```
 
 Use this message when invoking `ux-agent` at Gate 3:
@@ -532,12 +536,13 @@ Additional Product Owner updates (optional):
 Return only:
 1) PRD Readiness: Ready | Needs Clarification | Blocked
 2) PRD v0
-3) Traceability Map
-4) Quality Gaps
-5) Open Questions (full table: ID, Question, Source, Status, Resolution — no blank Resolution fields)
-6) Gate Decision: can proceed to design | must loop back
-7) PRD Draft Package (for UX/design handoff)
-8) PR Description (ready-to-paste GitHub PR body including: one-line PRD summary, slice folder path, gate status, open questions table with Status and Resolution columns, which unresolved questions block which future gate, artifact path)
+3) Requirement-to-PRD Alignment Check (explicit one-to-one mapping from Gate 1 inputs to PRD sections; highlight any owner-approved deltas)
+4) Traceability Map
+5) Quality Gaps
+6) Open Questions (full table: ID, Question, Source, Status, Resolution — no blank Resolution fields)
+7) Gate Decision: can proceed to design | must loop back
+8) PRD Draft Package (for UX/design handoff)
+9) PR Description (ready-to-paste GitHub PR body including: one-line PRD summary, slice folder path, gate status, open questions table with Status and Resolution columns, which unresolved questions block which future gate, artifact path)
 ```
 
 ## Example Handoff Message (Copy-Paste)

--- a/.github/orchestrator-context.md
+++ b/.github/orchestrator-context.md
@@ -317,6 +317,13 @@ Template:
 - Next micro-goal: Test protocol on next new slice; verify BDD scenario definitions and test-first execution enforced by Build gate checklist.
 - Blockers/owner decisions: Owner requested three specific hardening requirements: (1) Test-First Development (tests before code), (2) BDD with GWT at acceptance criteria level (not module level), (3) Domain-Oriented Development (code uses domain terminology, not infrastructure terms). All three implemented in protocol and templates. Decision rationale: TFD ensures tests drive design and prevent test-last brittleness. GWT at AC level ensures functional behavior (not module internals) drives development. Domain language ensures code reads as specification for the problem domain, making it maintainable and clear to non-technical stakeholders.
 
+### 2026-03-30 (Gate1-Gate2 Alignment)
+- Gate status: Requirement challenge and PRD drafting alignment hardened.
+- Artifact changes: Added Requirement-To-PRD Alignment Protocol to .github/AGENTS.md. Updated orchestrator Gate 1->2 rules to freeze requirement statement/scope/AC intent unless owner-approved. Added mandatory Requirement-to-PRD Alignment Check output in PRD handoff contracts (local and cloud prompts). Updated slice templates: 01-requirement.md now includes requirement IDs (R-1..R-N) and completeness lock; 02-prd.md now includes mandatory alignment table mapping requirements to PRD sections/user stories/AC IDs.
+- Open questions status: No open questions.
+- Next micro-goal: Enforce new alignment lock on the next slice by rejecting PRD drafts that reinterpret Gate 1 content without explicit owner approval.
+- Blockers/owner decisions: Owner requested that challenger and PRD agents move in the same direction and that templates only be filled after proper requirement gathering/refinement. Selected approach: explicit contract freeze + alignment table + loop-back on unauthorized deltas.
+
 
 ### 2026-03-30
 - Gate status: Slice/story maintenance protocol standardized across repo and GitHub.

--- a/.github/templates/slice-template/01-requirement.md
+++ b/.github/templates/slice-template/01-requirement.md
@@ -46,6 +46,14 @@
 
 **Note:** Each AC should map to one success criterion and be verifiable without ambiguity.
 
+## Requirement IDs (For PRD Alignment)
+
+- R-1: [Core requirement statement in plain language]
+- R-2: [User/value requirement]
+- R-3: [Scope boundary requirement]
+- R-4: [Constraint/non-goal requirement]
+- R-5: [Quality or success requirement]
+
 ## Open Questions (None / Accepted by Product Owner)
 
 - Q-1: [Question text] → **Status:** Resolved | Accepted as non-blocking | **Resolution:** [owner decision]
@@ -57,4 +65,6 @@
 - [ ] No hidden assumptions
 - [ ] Acceptance criteria are testable
 - [ ] Scope boundaries are clear
+- [ ] Requirement IDs (R-1..R-N) are defined for traceability
+- [ ] No unresolved placeholders remain (except explicitly accepted open questions)
 - [ ] Ready for PRD drafting (Gate 2)

--- a/.github/templates/slice-template/02-prd.md
+++ b/.github/templates/slice-template/02-prd.md
@@ -21,6 +21,17 @@
 - [Confirm all acceptance criteria are testable]
 - [Confirm no ambiguity remains]
 - [Confirm all open questions are resolved or explicitly accepted]
+- [Confirm Gate 1 contract was preserved without silent reinterpretation]
+
+### 1.1 Requirement-to-PRD Alignment Check (Mandatory)
+
+| Requirement ID (from 01) | Requirement Statement | PRD Section | User Story | AC IDs | Delta Status |
+|---|---|---|---|---|---|
+| R-1 | [Copied from 01-requirement.md] | [2.x] | [US-x] | [AC-x] | Unchanged / Owner-approved change |
+| R-2 | [Copied from 01-requirement.md] | [2.x] | [US-x] | [AC-x] | Unchanged / Owner-approved change |
+| R-3 | [Copied from 01-requirement.md] | [2.x] | [US-x] | [AC-x] | Unchanged / Owner-approved change |
+
+**Alignment rule:** If any requirement wording, scope boundary, or AC intent changed, record explicit Product Owner approval and rationale.
 
 ---
 


### PR DESCRIPTION
This hardens the workflow so Gate 2 cannot drift from Gate 1.

What this enforces:
- Requirement challenge output is a frozen contract for PRD drafting
- PRD cannot silently reinterpret requirement statement, scope boundaries, or AC intent
- Any delta requires explicit Product Owner approval recorded in context
- PRD output now must include a Requirement-to-PRD Alignment Check

Changes:
- .github/AGENTS.md: Added Requirement-To-PRD Alignment Protocol and gate rule
- .github/agents/architect-orchestrator.agent.md: Added Gate 1 contract freeze, PRD proceeding lock, and alignment output requirements in local/cloud PRD handoff prompts
- .github/templates/slice-template/01-requirement.md: Added requirement IDs (R-1..R-N) and completeness lock
- .github/templates/slice-template/02-prd.md: Added mandatory alignment table mapping requirements to PRD sections, stories, and AC IDs
- .github/orchestrator-context.md: Added decision log entry and next-step enforcement note

Outcome:
Templates are now intended to be filled only after proper requirement gathering/refinement, and Gate 2 progression is blocked if alignment proof is missing.