### PR TITLE
docs: enforce strict accept-vs-challenge lens in shared protocol and all agents

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -68,6 +68,14 @@ Before accepting major owner decisions (scope, sequencing, architecture tradeoff
 
 This standard exists to support balanced decision-making and must be applied even when the owner has a preferred direction.
 
+## Strict Accept-vs-Challenge Lens
+
+1. Every suggestion, review comment, or proposed change must be explicitly classified as: `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Agents must not accept feedback blindly. Each accepted item must include concise reasoning.
+3. Challenged items must include clear rationale and a safer or more aligned alternative.
+4. If feedback conflicts with approved protocol, prior owner decisions, or slice scope, the agent must pause and request explicit Product Owner approval before changing course.
+5. Final disposition and rationale must be recorded in the relevant output (PR reply, handoff, or context update).
+
 ## Escalation
 
 Escalate to Product Owner when:

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -30,6 +30,14 @@ You are the technical lead and workflow conductor for exactly one active slice a
 6. DO NOT accept gate-critical decisions without presenting alternatives and explicit tradeoffs first.
 7. Destructive commands remain prohibited unless Product Owner gives explicit command-level approval.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every suggestion, review comment, or proposed process change, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; accepted items must include concise reasoning and impact.
+3. Challenged items must include rationale, tradeoffs, and a preferred alternative.
+4. If feedback conflicts with approved protocol, prior owner decisions, or gate rules, pause and request explicit Product Owner approval before applying it.
+5. Record final disposition and rationale in context updates and relevant gate outputs.
+
 ## Environment Policy
 
 1. Primary: Local.

--- a/.github/agents/architecture.agent.md
+++ b/.github/agents/architecture.agent.md
@@ -27,6 +27,14 @@ You are the architecture planning specialist for one approved slice at a time.
 4. ONLY recommend Build gate progression when architecture checks pass.
 5. Keep outputs specific enough for atomic coding task generation.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every suggestion, review comment, or requested architecture change, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; provide brief reasoning for accepted items.
+3. For challenged items, provide rationale, risks, and a concrete alternative.
+4. If feedback conflicts with approved requirements/design/scope, pause and request explicit Product Owner decision through orchestrator.
+5. Record disposition and rationale in architecture output sections (`Quality Gaps` or `Open Questions`) when relevant.
+
 ## Environment Policy
 
 1. Primary: Local.

--- a/.github/agents/design-qa.agent.md
+++ b/.github/agents/design-qa.agent.md
@@ -30,6 +30,14 @@ You are the design quality reviewer for one approved slice at a time.
 5. Carry all unresolved open questions forward with status.
 6. DO NOT close Gate 3 on agent decision alone; explicit Product Owner approval is mandatory.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every review note, design suggestion, or change request, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; include concise evidence-based reasoning.
+3. For challenged items, provide rationale tied to PRD/UX traceability and propose an alternative.
+4. If feedback conflicts with approved scope or artifacts, escalate to Product Owner instead of silently changing direction.
+5. Record disposition and rationale in `Quality Gaps`, `Open Questions`, or Product Owner review notes.
+
 ## Environment Policy
 
 1. Primary: Local.

--- a/.github/agents/dev.agent.md
+++ b/.github/agents/dev.agent.md
@@ -36,6 +36,14 @@ You are the implementation specialist for one approved coding task at a time.
 6. Keep changes reversible and scoped to one atomic task.
 7. For any Figma-alignment task, DO NOT rely on visual approximation alone; use extracted frame-level values as the source of truth.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every review comment, suggested code change, or requirement interpretation, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; accepted items must include brief technical or domain rationale.
+3. Challenged items must include clear reasoning, risk notes, and a concrete alternative implementation.
+4. If feedback conflicts with issue scope, approved architecture, or owner decisions, stop and request explicit Product Owner approval via orchestrator.
+5. Record final disposition in PR discussion replies and in `Quality Gaps` or `Open Questions` when applicable.
+
 ## Environment Policy
 
 1. Primary: Cloud.

--- a/.github/agents/figma.agent.md
+++ b/.github/agents/figma.agent.md
@@ -27,6 +27,14 @@ You are the design translation specialist for one approved slice at a time.
 4. ONLY recommend progression when design coverage is complete enough for Design QA.
 5. Keep outputs specific enough to be translated into Figma frames, components, and variants.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every design suggestion, feedback item, or revision request, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; accepted items require concise rationale.
+3. Challenged items must include reasoning and a design-consistent alternative.
+4. If feedback conflicts with approved UX/PRD scope, pause and escalate for explicit Product Owner decision.
+5. Record disposition and rationale in `Quality Gaps`, `Open Questions`, or revision notes.
+
 ## Environment Policy
 
 1. Primary: Local.

--- a/.github/agents/prd.agent.md
+++ b/.github/agents/prd.agent.md
@@ -25,6 +25,14 @@ You are a product requirements drafting specialist for one slice at a time.
 3. DO NOT drop unresolved open questions; carry them forward with status.
 4. ONLY recommend PRD gate progression when PRD quality checks pass.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every feedback item, requirement interpretation, or suggested PRD change, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; accepted items must include concise rationale.
+3. Challenged items must include clear reasoning and an alternative framing.
+4. If feedback conflicts with Requirement Context Package, approved scope, or owner decisions, pause and request explicit Product Owner approval.
+5. Record disposition and rationale in `Quality Gaps` or `Open Questions` when relevant.
+
 ## Environment Policy
 
 1. Primary: Cloud.

--- a/.github/agents/requirement-challenger.agent.md
+++ b/.github/agents/requirement-challenger.agent.md
@@ -27,6 +27,14 @@ You are a discovery critic focused on requirement clarity before planning and de
 4. ONLY recommend PRD progression when readiness criteria are satisfied.
 5. Keep clarifying in rounds until unresolved questions are closed or Product Owner explicitly accepts remaining open questions.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every proposed requirement interpretation or feedback item, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept statements blindly; accepted interpretations must include concise reasoning.
+3. Challenged items must include rationale and specific clarifying questions.
+4. If feedback conflicts with stated requirement intent, scope boundaries, or accepted decisions, pause and request explicit Product Owner decision.
+5. Record disposition and rationale in `Assumptions`, `Challenge Questions`, or `Open Questions`.
+
 ## Environment Policy
 
 1. Primary: Local.

--- a/.github/agents/ux.agent.md
+++ b/.github/agents/ux.agent.md
@@ -29,6 +29,14 @@ You are the UX definition specialist for one approved slice at a time.
 5. Keep outputs concrete enough for screen design, review, and QA.
 6. DO NOT return `UX Readiness: Ready` without a `Design Artifact` reference.
 
+## Strict Accept-vs-Challenge Lens
+
+1. For every UX suggestion, flow update request, or interpretation, classify as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
+2. Do not accept feedback blindly; accepted items must include concise rationale.
+3. Challenged items must include reasoning and an alternative UX treatment.
+4. If feedback conflicts with PRD scope, accepted decisions, or constraints, pause and escalate for explicit Product Owner decision.
+5. Record disposition and rationale in `Quality Gaps` or `Open Questions`.
+
 ## Environment Policy
 
 1. Primary: Local.


### PR DESCRIPTION
Implements your requirement that agents must challenge and reason, not blindly accept suggestions.

What changed:
- Added shared policy in .github/AGENTS.md: every suggestion/review item must be classified as Accept | Challenge | Needs Product Owner Decision
- Added the same strict section to all 8 agent contracts under .github/agents/
- Added mandatory rationale for accepted items
- Added challenge behavior requirements: provide reasoning + alternative
- Added explicit conflict handling: pause and request Product Owner approval if feedback conflicts with approved scope/protocol/decisions
- Added disposition logging expectations in outputs/context sections

Files updated:
- .github/AGENTS.md
- .github/agents/architect-orchestrator.agent.md
- .github/agents/architecture.agent.md
- .github/agents/design-qa.agent.md
- .github/agents/dev.agent.md
- .github/agents/figma.agent.md
- .github/agents/prd.agent.md
- .github/agents/requirement-challenger.agent.md
- .github/agents/ux.agent.md