### PR TITLE
docs: prohibit all agents from executing PR merge operations

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -47,7 +47,7 @@ This repository follows a human-led, agent-executed workflow.
 3. Allowed mutations must stay narrowly scoped to the approved task and referenced files.
 4. Destructive commands (`git reset --hard`, force-push, history rewrite, mass deletion) remain disallowed unless Product Owner gives explicit command-level approval for that exact operation.
 5. Orchestrator must summarize intended commands before execution and record the decision in orchestration context updates.
-6. PR merge commands (`gh pr merge`) are never executed by the orchestrator. PR merges are always performed by the Product Owner directly (via GitHub UI or their own tooling). This is not a delegatable mutation.
+6. PR merge commands (for example `gh pr merge` or any equivalent merge operation) are never executed by any agent. PR merges are always performed by the Product Owner directly (via GitHub UI or their own tooling). This is not a delegatable mutation.
 
 ## Cloud Handoff Policy
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -29,7 +29,7 @@ You are the technical lead and workflow conductor for exactly one active slice a
 5. Terminal usage is diagnostics-first; mutating git commands are allowed only when Product Owner explicitly requests them for the active task.
 6. DO NOT accept gate-critical decisions without presenting alternatives and explicit tradeoffs first.
 7. Destructive commands remain prohibited unless Product Owner gives explicit command-level approval.
-8. DO NOT execute `gh pr merge` or perform any direct merge operation. The Product Owner is the only actor who merges PRs (e.g., via GitHub UI or their own tools). This is not a delegatable mutation.
+8. DO NOT execute `gh pr merge` or any equivalent merge operation. The Product Owner is the only actor who merges PRs (e.g., via GitHub UI or their own tools). This is not a delegatable mutation.
 
 ## Strict Accept-vs-Challenge Lens
 


### PR DESCRIPTION
## Summary

Closes a protocol gap where ambiguous acknowledgments ("ok") were treated as merge authorization by prohibiting PR merge operations entirely — for all agents.

## Changes

- `.github/AGENTS.md`: Rule 6 in Terminal Mutation Override Policy — PR merge commands (`gh pr merge` or any equivalent) are never executed by any agent. Product Owner is sole merge actor.
- `.github/agents/architect-orchestrator.agent.md`: Constraint 8 mirrors the same absolute prohibition.

## Motivation

PR #28 and #27 were merged without explicit owner authorization. Earlier iterations of this fix conditionally allowed merges with explicit authorization, but that still created ambiguity. The final model is simpler and unambiguous: no agent ever merges a PR.

## Artifacts
`Artifact: .github/AGENTS.md`, `.github/agents/architect-orchestrator.agent.md`