### PR TITLE
feat(tokens): add --color-on-surface-variant and --color-error (T-1 #86)

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,6 +11,9 @@
   /* Spine (maps to M3 outline-variant) */
   --color-spine-line: #767680;
 
+  --color-on-surface-variant: #49454E;
+  --color-error: #B3261E;
+
   /* ── Layer 2: Brand Override (empty — no M3 values overridden) ── */
 
   /* ── Layer 3: Functional Override (domain tokens) ── */
@@ -78,6 +81,9 @@
 
   --color-spine-line: #90909A;
 
+  --color-on-surface-variant: #CAC4D0;
+  --color-error: #F2B8B5;
+
   /* ── Layer 3: Functional Override ── */
   --color-tark-surface: #1565C0;
   --color-tark-on-surface: #E3F2FD;
@@ -103,6 +109,9 @@
     --color-brand-on-primary: #0E2288;
 
     --color-spine-line: #90909A;
+
+    --color-on-surface-variant: #CAC4D0;
+    --color-error: #F2B8B5;
 
     /* ── Layer 3: Functional Override ── */
     --color-tark-surface: #1565C0;

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -28,6 +28,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     '--color-brand-primary',
     '--color-brand-on-primary',
     '--color-spine-line',
+    '--color-on-surface-variant',
+    '--color-error',
     '--color-tark-surface',
     '--color-tark-on-surface',
     '--color-tark-header',
@@ -38,8 +40,6 @@ describe('tokens.css — M3 3-layer token presence', () => {
     '--color-legend-surface',
     '--color-legend-on-surface',
     '--color-legend-separator',
-    '--color-on-surface-variant',
-    '--color-error',
   ];
 
   it.each(colorTokens)('defines color token %s in light block', (token) => {
@@ -169,6 +169,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-brand-primary', '#4555B7'],
     ['--color-brand-on-primary', '#FFFFFF'],
     ['--color-spine-line', '#767680'],
+    ['--color-on-surface-variant', '#49454E'],
+    ['--color-error', '#B3261E'],
     ['--color-tark-surface', '#BBDEFB'],
     ['--color-tark-on-surface', '#0D47A1'],
     ['--color-tark-header', '#1565C0'],
@@ -179,8 +181,6 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#F5F5F5'],
     ['--color-legend-on-surface', '#4D4D4D'],
     ['--color-legend-separator', '#999999'],
-    ['--color-on-surface-variant', '#49454E'],
-    ['--color-error', '#B3261E'],
   ];
 
   it.each(lightColorValues)('light %s equals %s', (token, value) => {
@@ -193,6 +193,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-brand-primary', '#BBC3FF'],
     ['--color-brand-on-primary', '#0E2288'],
     ['--color-spine-line', '#90909A'],
+    ['--color-on-surface-variant', '#CAC4D0'],
+    ['--color-error', '#F2B8B5'],
     ['--color-tark-surface', '#1565C0'],
     ['--color-tark-on-surface', '#E3F2FD'],
     ['--color-tark-header', '#90CAF9'],
@@ -203,8 +205,6 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#1C1C1C'],
     ['--color-legend-on-surface', '#BFBFBF'],
     ['--color-legend-separator', '#666666'],
-    ['--color-on-surface-variant', '#CAC4D0'],
-    ['--color-error', '#F2B8B5'],
   ];
 
   it.each(darkColorValues)('dark %s equals %s', (token, value) => {

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -38,6 +38,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     '--color-legend-surface',
     '--color-legend-on-surface',
     '--color-legend-separator',
+    '--color-on-surface-variant',
+    '--color-error',
   ];
 
   it.each(colorTokens)('defines color token %s in light block', (token) => {
@@ -177,6 +179,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#F5F5F5'],
     ['--color-legend-on-surface', '#4D4D4D'],
     ['--color-legend-separator', '#999999'],
+    ['--color-on-surface-variant', '#49454E'],
+    ['--color-error', '#B3261E'],
   ];
 
   it.each(lightColorValues)('light %s equals %s', (token, value) => {
@@ -199,6 +203,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#1C1C1C'],
     ['--color-legend-on-surface', '#BFBFBF'],
     ['--color-legend-separator', '#666666'],
+    ['--color-on-surface-variant', '#CAC4D0'],
+    ['--color-error', '#F2B8B5'],
   ];
 
   it.each(darkColorValues)('dark %s equals %s', (token, value) => {


### PR DESCRIPTION
## Summary

Implements **T-1** from the `post-tark-vitark` slice.

Adds two missing M3 Baseline tokens to `src/styles/tokens.css` required by the Podium Composer (TextField placeholder colour and validation error state).

Closes #86

**Slice tracker:** https://github.com/nishantnaagnihotri/tark-vitark/issues/85

---

## Changes

### `src/styles/tokens.css`
Added to all three theme blocks (`:root`/`[data-theme="light"]`, `[data-theme="dark"]`, `@media (prefers-color-scheme: dark) :root:not([data-theme])`):

| Token | Light | Dark |
|---|---|---|
| `--color-on-surface-variant` | `#49454E` | `#CAC4D0` |
| `--color-error` | `#B3261E` | `#F2B8B5` |

Placed in Layer 1 (M3 Baseline) after `--color-spine-line` per §4 of `docs/slices/post-tark-vitark/05-architecture.md`.

### `tests/tokens.test.ts`
Extended three arrays:
- `colorTokens` — adds both tokens to presence checks (light, dark, media fallback)
- `lightColorValues` — value-locks light theme hex values
- `darkColorValues` — value-locks dark theme hex values

10 new test cases; 129 total pass.

---

## Verification Evidence

```
✓ tests/tokens.test.ts (129 tests) 4ms
Test Files  1 passed (1)
Tests  129 passed (119 pre-existing + 10 new)
```

## BDD Evidence

| Scenario | Test | Status |
|---|---|---|
| `--color-on-surface-variant` present in light block | `colorTokens` presence + light value lock | ✅ |
| `--color-on-surface-variant` present in dark block | `colorTokens` dark presence + dark value lock | ✅ |
| `--color-on-surface-variant` present in media fallback | `it.each(colorTokens)` media fallback loop | ✅ |
| `--color-error` present in light block | `colorTokens` presence + light value lock | ✅ |
| `--color-error` present in dark block | `colorTokens` dark presence + dark value lock | ✅ |
| `--color-error` present in media fallback | `it.each(colorTokens)` media fallback loop | ✅ |

Test-first: Node.js inline check confirmed all 6 assertions FAIL before implementation, PASS after.

## Architecture Reference

`docs/slices/post-tark-vitark/05-architecture.md` §4 Token Additions.

## Rollback Note

Revert this PR. The two CSS custom properties are additive; removal is safe and has no cascading effect on existing components.

## Runtime QA

Not required — CSS custom property additions only. No DOM, layout, or interaction behaviour changes.

---

Execution-Agent: dev