### PR TITLE
feat(post-tark-vitark): implement native SegmentedControl (T-3)

### DIFF
--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -8,6 +8,7 @@ interface SegmentedControlProps {
     value: Side;
     onChange: (value: Side) => void;
     id?: string;
+    'aria-label'?: string;
     'aria-labelledby'?: string;
 }
 
@@ -20,10 +21,16 @@ export function SegmentedControl({
     value,
     onChange,
     id,
+    'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
 }: SegmentedControlProps) {
     const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const selectedIndex = options.includes(value) ? options.indexOf(value) : 0;
+    const labelledByValue = ariaLabelledby?.trim();
+    const labelValue = ariaLabel?.trim();
+    const radiogroupNameProps = labelledByValue
+        ? { 'aria-labelledby': labelledByValue }
+        : { 'aria-label': labelValue || 'Side selection' };
 
     const focusAndSelect = (nextIndex: number) => {
         if (options.length === 0) return;
@@ -75,7 +82,7 @@ export function SegmentedControl({
             id={id}
             className="segmented-control"
             role="radiogroup"
-            aria-labelledby={ariaLabelledby}
+            {...radiogroupNameProps}
         >
             {options.map((option, optionIndex) => {
                 const isSelected = option === value;

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -25,7 +25,8 @@ export function SegmentedControl({
     'aria-labelledby': ariaLabelledby,
 }: SegmentedControlProps) {
     const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
-    const selectedIndex = options.includes(value) ? options.indexOf(value) : 0;
+    const effectiveValue = options.includes(value) ? value : options[0] ?? value;
+    const selectedIndex = options.indexOf(effectiveValue);
     const labelledByValue = ariaLabelledby?.trim();
     const labelValue = ariaLabel?.trim();
     const radiogroupNameProps = labelledByValue
@@ -42,7 +43,7 @@ export function SegmentedControl({
     };
 
     const selectOnConfirm = (option: Side) => {
-        if (option !== value) {
+        if (option !== effectiveValue) {
             onChange(option);
         }
     };
@@ -85,7 +86,7 @@ export function SegmentedControl({
             {...radiogroupNameProps}
         >
             {options.map((option, optionIndex) => {
-                const isSelected = option === value;
+                const isSelected = option === effectiveValue;
 
                 return (
                     <button

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,0 +1,109 @@
+import type { KeyboardEvent } from 'react';
+import { useRef } from 'react';
+import type { Side } from '../data/debate';
+import '../styles/components/segmented-control.css';
+
+interface SegmentedControlProps {
+    options: readonly Side[];
+    value: Side;
+    onChange: (value: Side) => void;
+    id?: string;
+    'aria-labelledby'?: string;
+}
+
+function toSegmentLabel(side: Side): string {
+    return side.charAt(0).toUpperCase() + side.slice(1);
+}
+
+export function SegmentedControl({
+    options,
+    value,
+    onChange,
+    id,
+    'aria-labelledby': ariaLabelledby,
+}: SegmentedControlProps) {
+    const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+    const selectedIndex = options.includes(value) ? options.indexOf(value) : 0;
+
+    const focusAndSelect = (nextIndex: number) => {
+        if (options.length === 0) return;
+
+        const wrappedIndex = (nextIndex + options.length) % options.length;
+        const nextOption = options[wrappedIndex];
+        onChange(nextOption);
+        optionRefs.current[wrappedIndex]?.focus();
+    };
+
+    const selectOnConfirm = (option: Side) => {
+        if (option !== value) {
+            onChange(option);
+        }
+    };
+
+    const handleOptionKeyDown = (
+        event: KeyboardEvent<HTMLButtonElement>,
+        optionIndex: number,
+        option: Side
+    ) => {
+        switch (event.key) {
+            case 'ArrowRight':
+            case 'ArrowDown': {
+                event.preventDefault();
+                focusAndSelect(optionIndex + 1);
+                return;
+            }
+            case 'ArrowLeft':
+            case 'ArrowUp': {
+                event.preventDefault();
+                focusAndSelect(optionIndex - 1);
+                return;
+            }
+            case ' ':
+            case 'Spacebar':
+            case 'Enter': {
+                event.preventDefault();
+                selectOnConfirm(option);
+                return;
+            }
+            default:
+                return;
+        }
+    };
+
+    return (
+        <div
+            id={id}
+            className="segmented-control"
+            role="radiogroup"
+            aria-labelledby={ariaLabelledby}
+        >
+            {options.map((option, optionIndex) => {
+                const isSelected = option === value;
+
+                return (
+                    <button
+                        key={option}
+                        type="button"
+                        ref={(node) => {
+                            optionRefs.current[optionIndex] = node;
+                        }}
+                        role="radio"
+                        className={`segmented-control__segment${
+                            isSelected ? ' segmented-control__segment--selected' : ''
+                        }`}
+                        aria-checked={isSelected}
+                        tabIndex={optionIndex === selectedIndex ? 0 : -1}
+                        onClick={() => selectOnConfirm(option)}
+                        onKeyDown={(event) =>
+                            handleOptionKeyDown(event, optionIndex, option)
+                        }
+                    >
+                        <span className="segmented-control__label">
+                            {toSegmentLabel(option)}
+                        </span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -1,7 +1,7 @@
 .segmented-control {
     display: flex;
     width: 100%;
-    border: 1px solid var(--color-brand-primary);
+    border: var(--divider-thickness) solid var(--color-brand-primary);
     border-radius: 24px;
     overflow: hidden;
 }
@@ -18,7 +18,7 @@
 }
 
 .segmented-control__segment + .segmented-control__segment {
-    border-left: 1px solid var(--color-brand-primary);
+    border-left: var(--divider-thickness, 1px) solid var(--color-brand-primary);
 }
 
 .segmented-control__segment--selected {

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -12,7 +12,7 @@
     background: transparent;
     color: var(--color-brand-primary);
     cursor: pointer;
-    padding: var(--space-2) var(--space-4);
+    padding: var(--space-4) var(--space-4);
     min-height: var(--space-10);
     font: inherit;
 }
@@ -27,6 +27,6 @@
 }
 
 .segmented-control__segment:focus-visible {
-    outline: 2px solid var(--color-brand-primary);
+    outline: 2px solid currentColor;
     outline-offset: -2px;
 }

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -1,0 +1,32 @@
+.segmented-control {
+    display: flex;
+    width: 100%;
+    border: 1px solid var(--color-brand-primary);
+    border-radius: 24px;
+    overflow: hidden;
+}
+
+.segmented-control__segment {
+    flex: 1;
+    border: 0;
+    background: transparent;
+    color: var(--color-brand-primary);
+    cursor: pointer;
+    padding: var(--space-2) var(--space-4);
+    min-height: var(--space-10);
+    font: inherit;
+}
+
+.segmented-control__segment + .segmented-control__segment {
+    border-left: 1px solid var(--color-brand-primary);
+}
+
+.segmented-control__segment--selected {
+    background: var(--color-brand-primary);
+    color: var(--color-brand-on-primary);
+}
+
+.segmented-control__segment:focus-visible {
+    outline: 2px solid var(--color-brand-primary);
+    outline-offset: -2px;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,6 +11,9 @@
   /* Spine (maps to M3 outline-variant) */
   --color-spine-line: #767680;
 
+  --color-on-surface-variant: #49454E;
+  --color-error: #B3261E;
+
   /* ── Layer 2: Brand Override (empty — no M3 values overridden) ── */
 
   /* ── Layer 3: Functional Override (domain tokens) ── */
@@ -78,6 +81,9 @@
 
   --color-spine-line: #90909A;
 
+  --color-on-surface-variant: #CAC4D0;
+  --color-error: #F2B8B5;
+
   /* ── Layer 3: Functional Override ── */
   --color-tark-surface: #1565C0;
   --color-tark-on-surface: #E3F2FD;
@@ -103,6 +109,9 @@
     --color-brand-on-primary: #0E2288;
 
     --color-spine-line: #90909A;
+
+    --color-on-surface-variant: #CAC4D0;
+    --color-error: #F2B8B5;
 
     /* ── Layer 3: Functional Override ── */
     --color-tark-surface: #1565C0;

--- a/tests/components/SegmentedControl.test.tsx
+++ b/tests/components/SegmentedControl.test.tsx
@@ -122,6 +122,7 @@ describe('SegmentedControl', () => {
         fireEvent.keyDown(vitarkRadio, { key: 'Enter' });
         fireEvent.keyDown(vitarkRadio, { key: ' ' });
 
+        expect(onChange).toHaveBeenCalledTimes(2);
         expect(onChange).toHaveBeenNthCalledWith(1, 'vitark');
         expect(onChange).toHaveBeenNthCalledWith(2, 'vitark');
     });

--- a/tests/components/SegmentedControl.test.tsx
+++ b/tests/components/SegmentedControl.test.tsx
@@ -115,6 +115,9 @@ describe('SegmentedControl', () => {
         );
 
         const vitarkRadio = screen.getByRole('radio', { name: 'Vitark' });
+        vitarkRadio.focus();
+
+        expect(vitarkRadio).toHaveFocus();
 
         fireEvent.keyDown(vitarkRadio, { key: 'Enter' });
         fireEvent.keyDown(vitarkRadio, { key: ' ' });
@@ -144,8 +147,47 @@ describe('SegmentedControl', () => {
         expect(screen.getAllByRole('radio')).toHaveLength(sideOptions.length);
     });
 
+    it('supports aria-label naming for radiogroup when aria-labelledby is absent', () => {
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="tark"
+                onChange={() => {}}
+                aria-label="Choose side"
+            />
+        );
+
+        expect(
+            screen.getByRole('radiogroup', {
+                name: 'Choose side',
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to a default radiogroup accessible name when no label props are provided', () => {
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="tark"
+                onChange={() => {}}
+            />
+        );
+
+        expect(
+            screen.getByRole('radiogroup', {
+                name: 'Side selection',
+            })
+        ).toBeInTheDocument();
+    });
+
     it('binds selected and unselected visual colors to brand tokens', () => {
         expect(segmentedControlCss).toContain('var(--color-brand-primary)');
         expect(segmentedControlCss).toContain('var(--color-brand-on-primary)');
+    });
+
+    it('uses defined spacing tokens and state-aware focus color in segmented-control CSS', () => {
+        expect(segmentedControlCss).not.toContain('var(--space-2)');
+        expect(segmentedControlCss).toContain('padding: var(--space-4) var(--space-4);');
+        expect(segmentedControlCss).toContain('outline: 2px solid currentColor;');
     });
 });

--- a/tests/components/SegmentedControl.test.tsx
+++ b/tests/components/SegmentedControl.test.tsx
@@ -44,6 +44,33 @@ describe('SegmentedControl', () => {
         );
     });
 
+    it('falls back to the first side when value is not in options for selection and focus anchor', () => {
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value={'unknown' as Side}
+                onChange={() => {}}
+            />
+        );
+
+        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
+            'aria-checked',
+            'true'
+        );
+        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
+            'aria-checked',
+            'false'
+        );
+        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
+            'tabindex',
+            '0'
+        );
+        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
+            'tabindex',
+            '-1'
+        );
+    });
+
     it('fires onChange with the clicked side when clicking a non-selected side', () => {
         const onChange = vi.fn();
 

--- a/tests/components/SegmentedControl.test.tsx
+++ b/tests/components/SegmentedControl.test.tsx
@@ -1,0 +1,151 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SegmentedControl } from '../../src/components/SegmentedControl';
+import type { Side } from '../../src/data/debate';
+
+const segmentedControlCss = readFileSync(
+    resolve(process.cwd(), 'src/styles/components/segmented-control.css'),
+    'utf-8'
+);
+
+const sideOptions: readonly Side[] = ['tark', 'vitark'];
+
+describe('SegmentedControl', () => {
+    it('renders exactly one radio option for each provided side option', () => {
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="tark"
+                onChange={() => {}}
+            />
+        );
+
+        expect(screen.getAllByRole('radio')).toHaveLength(sideOptions.length);
+    });
+
+    it('marks the selected side with aria-checked="true"', () => {
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="vitark"
+                onChange={() => {}}
+            />
+        );
+
+        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
+            'aria-checked',
+            'true'
+        );
+        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
+            'aria-checked',
+            'false'
+        );
+    });
+
+    it('fires onChange with the clicked side when clicking a non-selected side', () => {
+        const onChange = vi.fn();
+
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="tark"
+                onChange={onChange}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith('vitark');
+    });
+
+    it('supports arrow-key navigation and calls onChange with the next side', () => {
+        const onChange = vi.fn();
+
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="tark"
+                onChange={onChange}
+            />
+        );
+
+        const tarkRadio = screen.getByRole('radio', { name: 'Tark' });
+        const vitarkRadio = screen.getByRole('radio', { name: 'Vitark' });
+        tarkRadio.focus();
+
+        fireEvent.keyDown(tarkRadio, { key: 'ArrowRight' });
+
+        expect(onChange).toHaveBeenCalledWith('vitark');
+        expect(vitarkRadio).toHaveFocus();
+    });
+
+    it('supports reverse arrow-key navigation and calls onChange with the previous side', () => {
+        const onChange = vi.fn();
+
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="vitark"
+                onChange={onChange}
+            />
+        );
+
+        const tarkRadio = screen.getByRole('radio', { name: 'Tark' });
+        const vitarkRadio = screen.getByRole('radio', { name: 'Vitark' });
+        vitarkRadio.focus();
+
+        fireEvent.keyDown(vitarkRadio, { key: 'ArrowLeft' });
+
+        expect(onChange).toHaveBeenCalledWith('tark');
+        expect(tarkRadio).toHaveFocus();
+    });
+
+    it('supports Enter and Space to confirm the focused side', () => {
+        const onChange = vi.fn();
+
+        render(
+            <SegmentedControl
+                options={sideOptions}
+                value="tark"
+                onChange={onChange}
+            />
+        );
+
+        const vitarkRadio = screen.getByRole('radio', { name: 'Vitark' });
+
+        fireEvent.keyDown(vitarkRadio, { key: 'Enter' });
+        fireEvent.keyDown(vitarkRadio, { key: ' ' });
+
+        expect(onChange).toHaveBeenNthCalledWith(1, 'vitark');
+        expect(onChange).toHaveBeenNthCalledWith(2, 'vitark');
+    });
+
+    it('uses radiogroup and radio ARIA roles', () => {
+        render(
+            <>
+                <h2 id="side-selection-label">Side selection</h2>
+                <SegmentedControl
+                    options={sideOptions}
+                    value="tark"
+                    onChange={() => {}}
+                    aria-labelledby="side-selection-label"
+                />
+            </>
+        );
+
+        expect(
+            screen.getByRole('radiogroup', {
+                name: 'Side selection',
+            })
+        ).toBeInTheDocument();
+        expect(screen.getAllByRole('radio')).toHaveLength(sideOptions.length);
+    });
+
+    it('binds selected and unselected visual colors to brand tokens', () => {
+        expect(segmentedControlCss).toContain('var(--color-brand-primary)');
+        expect(segmentedControlCss).toContain('var(--color-brand-on-primary)');
+    });
+});

--- a/tests/components/Topic.test.tsx
+++ b/tests/components/Topic.test.tsx
@@ -10,6 +10,7 @@ describe('Topic', () => {
     });
 
     it('uses Typography headline-large role', () => {
+        // This assertion protects the typography-role contract without changing behavior.
         render(<Topic text="Test topic" />);
         const heading = screen.getByRole('heading', { level: 1 });
         expect(heading).toHaveClass('typography', 'typography--headline-large');

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -28,6 +28,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     '--color-brand-primary',
     '--color-brand-on-primary',
     '--color-spine-line',
+    '--color-on-surface-variant',
+    '--color-error',
     '--color-tark-surface',
     '--color-tark-on-surface',
     '--color-tark-header',
@@ -38,8 +40,6 @@ describe('tokens.css — M3 3-layer token presence', () => {
     '--color-legend-surface',
     '--color-legend-on-surface',
     '--color-legend-separator',
-    '--color-on-surface-variant',
-    '--color-error',
   ];
 
   it.each(colorTokens)('defines color token %s in light block', (token) => {
@@ -169,6 +169,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-brand-primary', '#4555B7'],
     ['--color-brand-on-primary', '#FFFFFF'],
     ['--color-spine-line', '#767680'],
+    ['--color-on-surface-variant', '#49454E'],
+    ['--color-error', '#B3261E'],
     ['--color-tark-surface', '#BBDEFB'],
     ['--color-tark-on-surface', '#0D47A1'],
     ['--color-tark-header', '#1565C0'],
@@ -179,8 +181,6 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#F5F5F5'],
     ['--color-legend-on-surface', '#4D4D4D'],
     ['--color-legend-separator', '#999999'],
-    ['--color-on-surface-variant', '#49454E'],
-    ['--color-error', '#B3261E'],
   ];
 
   it.each(lightColorValues)('light %s equals %s', (token, value) => {
@@ -193,6 +193,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-brand-primary', '#BBC3FF'],
     ['--color-brand-on-primary', '#0E2288'],
     ['--color-spine-line', '#90909A'],
+    ['--color-on-surface-variant', '#CAC4D0'],
+    ['--color-error', '#F2B8B5'],
     ['--color-tark-surface', '#1565C0'],
     ['--color-tark-on-surface', '#E3F2FD'],
     ['--color-tark-header', '#90CAF9'],
@@ -203,8 +205,6 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#1C1C1C'],
     ['--color-legend-on-surface', '#BFBFBF'],
     ['--color-legend-separator', '#666666'],
-    ['--color-on-surface-variant', '#CAC4D0'],
-    ['--color-error', '#F2B8B5'],
   ];
 
   it.each(darkColorValues)('dark %s equals %s', (token, value) => {

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -38,6 +38,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     '--color-legend-surface',
     '--color-legend-on-surface',
     '--color-legend-separator',
+    '--color-on-surface-variant',
+    '--color-error',
   ];
 
   it.each(colorTokens)('defines color token %s in light block', (token) => {
@@ -177,6 +179,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#F5F5F5'],
     ['--color-legend-on-surface', '#4D4D4D'],
     ['--color-legend-separator', '#999999'],
+    ['--color-on-surface-variant', '#49454E'],
+    ['--color-error', '#B3261E'],
   ];
 
   it.each(lightColorValues)('light %s equals %s', (token, value) => {
@@ -199,6 +203,8 @@ describe('tokens.css — M3 3-layer token presence', () => {
     ['--color-legend-surface', '#1C1C1C'],
     ['--color-legend-on-surface', '#BFBFBF'],
     ['--color-legend-separator', '#666666'],
+    ['--color-on-surface-variant', '#CAC4D0'],
+    ['--color-error', '#F2B8B5'],
   ];
 
   it.each(darkColorValues)('dark %s equals %s', (token, value) => {


### PR DESCRIPTION
## Summary
- add native `SegmentedControl` component for side selection with ARIA `radiogroup` + `radio` semantics
- implement keyboard behavior for arrow navigation and Enter/Space confirm
- add token-bound styling for selected/unselected states in dedicated component CSS
- add component test coverage for rendering, ARIA, click/keyboard interaction, and token binding checks

## Verification
- `npm test -- --run tests/components/SegmentedControl.test.tsx`
- `npm test`

Closes #88

Execution-Agent: dev