### PR TITLE
feat(post-tark-vitark): implement Podium composer component

### DIFF
--- a/src/components/Podium.tsx
+++ b/src/components/Podium.tsx
@@ -1,0 +1,83 @@
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+import type { Side } from '../data/debate';
+import { validatePost } from '../lib/validatePost';
+import { SegmentedControl } from './SegmentedControl';
+import '../styles/components/podium.css';
+
+interface PodiumProps {
+    selectedSide: Side;
+    onSideChange: (side: Side) => void;
+    onPublish: (text: string, side: Side) => void;
+}
+
+const sideOptions: readonly Side[] = ['tark', 'vitark'];
+
+export function Podium({ selectedSide, onSideChange, onPublish }: PodiumProps) {
+    const [text, setText] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [isBusy, setIsBusy] = useState(false);
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isBusy) {
+            return;
+        }
+
+        const validation = validatePost(text);
+        if (!validation.valid) {
+            setError(validation.message);
+            return;
+        }
+
+        setError(null);
+        setIsBusy(true);
+
+        try {
+            await Promise.resolve(onPublish(text.trim(), selectedSide));
+            setText('');
+        } finally {
+            setIsBusy(false);
+        }
+    };
+
+    return (
+        <form className="podium" onSubmit={handleSubmit} aria-label="Post composer">
+            {/* Divider/Native: inline horizontal separator, not DS Divider. */}
+            <div className="podium__divider" role="separator" aria-orientation="horizontal" />
+
+            <SegmentedControl
+                options={sideOptions}
+                value={selectedSide}
+                onChange={onSideChange}
+                aria-label="Post side"
+            />
+
+            <div className="podium__composer-row">
+                <textarea
+                    className="podium__textarea"
+                    value={text}
+                    onChange={(event) => setText(event.target.value)}
+                    placeholder="Post text"
+                    aria-label="Post text"
+                    aria-describedby="podium-error"
+                    aria-invalid={error !== null}
+                />
+
+                <button
+                    type="submit"
+                    className="podium__publish"
+                    disabled={text.length === 0 || isBusy}
+                    aria-label="Publish post"
+                >
+                    Publish
+                </button>
+            </div>
+
+            <p id="podium-error" className="podium__error" role="alert" aria-live="polite">
+                {error ?? ''}
+            </p>
+        </form>
+    );
+}

--- a/src/components/Podium.tsx
+++ b/src/components/Podium.tsx
@@ -71,7 +71,7 @@ export function Podium({ selectedSide, onSideChange, onPublish }: PodiumProps) {
                     disabled={text.length === 0 || isBusy}
                     aria-label="Publish post"
                 >
-                    Publish
+                    <span aria-hidden="true">&uarr;</span>
                 </button>
             </div>
 

--- a/src/styles/components/podium.css
+++ b/src/styles/components/podium.css
@@ -1,0 +1,92 @@
+:root {
+    --podium-height: calc(187px + env(safe-area-inset-bottom, 0px));
+}
+
+.podium {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--space-4) - var(--radius-sharp));
+    padding: calc(var(--space-4) - var(--radius-sharp)) var(--space-4) 0;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    background-color: var(--color-surface-default);
+    z-index: 20;
+}
+
+.podium__divider {
+    display: block;
+    width: calc(100% + (var(--space-4) * 2));
+    height: 1px;
+    margin-inline: calc(var(--space-4) * -1);
+    background-color: var(--color-spine-line);
+}
+
+.podium__composer-row {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--space-4) - var(--radius-sharp));
+}
+
+.podium__textarea {
+    flex: 1;
+    min-height: 56px;
+    padding: 0 var(--space-4);
+    border: 1px solid var(--color-spine-line);
+    border-radius: var(--radius-sharp);
+    background-color: var(--color-surface-default);
+    color: var(--color-on-surface);
+    font: inherit;
+    line-height: var(--typescale-body-lg-line-height);
+    resize: none;
+}
+
+.podium__textarea::placeholder {
+    color: var(--color-on-surface-variant);
+}
+
+.podium__textarea:focus-visible {
+    outline: none;
+    border-color: var(--color-brand-primary);
+}
+
+.podium__textarea[aria-invalid='true'] {
+    border-color: var(--color-error);
+}
+
+.podium__publish {
+    width: var(--space-10);
+    height: var(--space-10);
+    border: 0;
+    border-radius: 999px;
+    background-color: var(--color-brand-primary);
+    color: var(--color-brand-on-primary);
+    font: inherit;
+    cursor: pointer;
+}
+
+.podium__publish:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.podium__error {
+    min-height: var(--typescale-label-md-line-height);
+    margin: 0;
+    color: var(--color-error);
+    font-size: var(--typescale-label-md-size);
+    font-weight: var(--typescale-label-md-weight);
+    line-height: var(--typescale-label-md-line-height);
+    letter-spacing: var(--typescale-label-md-tracking);
+}
+
+@media (min-width: 1024px) {
+    .podium {
+        max-width: 600px;
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+    }
+}

--- a/src/styles/components/podium.css
+++ b/src/styles/components/podium.css
@@ -19,7 +19,7 @@
 .podium__divider {
     display: block;
     width: calc(100% + (var(--space-4) * 2));
-    height: 1px;
+    height: var(--divider-thickness);
     margin-inline: calc(var(--space-4) * -1);
     background-color: var(--color-spine-line);
 }
@@ -34,7 +34,7 @@
     flex: 1;
     min-height: 56px;
     padding: 0 var(--space-4);
-    border: 1px solid var(--color-spine-line);
+    border: var(--divider-thickness) solid var(--color-spine-line);
     border-radius: var(--radius-sharp);
     background-color: var(--color-surface-default);
     color: var(--color-on-surface);

--- a/tests/components/Podium.test.tsx
+++ b/tests/components/Podium.test.tsx
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Podium } from '../../src/components/Podium';
+
+const podiumCss = readFileSync(
+    resolve(process.cwd(), 'src/styles/components/podium.css'),
+    'utf-8'
+);
+
+describe('Podium', () => {
+    it('renders segmented control, textarea, publish button, and native divider', () => {
+        render(
+            <Podium
+                selectedSide="tark"
+                onSideChange={() => {}}
+                onPublish={() => {}}
+            />
+        );
+
+        expect(screen.getByRole('radiogroup', { name: 'Post side' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
+
+        const nativeDivider = screen.getByRole('separator');
+        expect(nativeDivider.tagName).toBe('DIV');
+    });
+
+    it('disables publish only when textarea is empty', () => {
+        render(
+            <Podium
+                selectedSide="tark"
+                onSideChange={() => {}}
+                onPublish={() => {}}
+            />
+        );
+
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+
+        expect(publishButton).toBeDisabled();
+
+        fireEvent.change(textarea, { target: { value: '   ' } });
+
+        expect(publishButton).not.toBeDisabled();
+    });
+
+    it('validates on submit only and shows a whitespace-only error when submitted', () => {
+        const onPublish = vi.fn();
+
+        render(
+            <Podium
+                selectedSide="tark"
+                onSideChange={() => {}}
+                onPublish={onPublish}
+            />
+        );
+
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+
+        fireEvent.change(textarea, { target: { value: '       ' } });
+        expect(screen.getByRole('alert')).toHaveTextContent('');
+
+        fireEvent.click(publishButton);
+
+        expect(onPublish).not.toHaveBeenCalled();
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            'Text cannot be empty or whitespace only.'
+        );
+        expect(textarea).toHaveAttribute('aria-describedby', 'podium-error');
+        expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('calls onPublish with trimmed text and selected side, then clears textarea', async () => {
+        const onPublish = vi.fn();
+
+        render(
+            <Podium
+                selectedSide="vitark"
+                onSideChange={() => {}}
+                onPublish={onPublish}
+            />
+        );
+
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+
+        fireEvent.change(textarea, {
+            target: { value: '   This is a valid post body.   ' },
+        });
+        fireEvent.click(publishButton);
+
+        await waitFor(() => {
+            expect(onPublish).toHaveBeenCalledWith('This is a valid post body.', 'vitark');
+        });
+
+        expect(textarea).toHaveValue('');
+        expect(screen.getByRole('alert')).toHaveTextContent('');
+    });
+
+    it('prevents a second publish while an in-flight publish is still busy', async () => {
+        let resolvePublish: () => void = () => {};
+        const onPublish = vi.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolvePublish = () => resolve();
+                })
+        );
+
+        render(
+            <Podium
+                selectedSide="tark"
+                onSideChange={() => {}}
+                onPublish={onPublish}
+            />
+        );
+
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+
+        fireEvent.change(textarea, {
+            target: { value: 'This text has enough length.' },
+        });
+        fireEvent.click(publishButton);
+
+        expect(onPublish).toHaveBeenCalledTimes(1);
+        expect(publishButton).toBeDisabled();
+
+        fireEvent.click(publishButton);
+
+        expect(onPublish).toHaveBeenCalledTimes(1);
+
+        resolvePublish();
+
+        await waitFor(() => {
+            expect(textarea).toHaveValue('');
+            expect(publishButton).toBeDisabled();
+        });
+
+        fireEvent.change(textarea, {
+            target: { value: 'Second valid body text.' },
+        });
+        expect(publishButton).not.toBeDisabled();
+    });
+
+    it('delegates side changes through SegmentedControl interaction', () => {
+        const onSideChange = vi.fn();
+
+        render(
+            <Podium
+                selectedSide="tark"
+                onSideChange={onSideChange}
+                onPublish={() => {}}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+
+        expect(onSideChange).toHaveBeenCalledTimes(1);
+        expect(onSideChange).toHaveBeenCalledWith('vitark');
+    });
+
+    it('defines fixed and desktop-centered layout rules in podium.css source', () => {
+        expect(podiumCss).toContain('position: fixed;');
+        expect(podiumCss).toContain('--podium-height: calc(187px + env(safe-area-inset-bottom, 0px));');
+        expect(podiumCss).toContain('@media (min-width: 1024px)');
+        expect(podiumCss).toContain('max-width: 600px;');
+        expect(podiumCss).toContain('transform: translateX(-50%);');
+    });
+});

--- a/tests/components/Podium.test.tsx
+++ b/tests/components/Podium.test.tsx
@@ -21,7 +21,10 @@ describe('Podium', () => {
 
         expect(screen.getByRole('radiogroup', { name: 'Post side' })).toBeInTheDocument();
         expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+        expect(publishButton).toBeInTheDocument();
+        expect(publishButton).toHaveAttribute('aria-label', 'Publish post');
+        expect(publishButton).not.toHaveTextContent(/publish/i);
 
         const nativeDivider = screen.getByRole('separator');
         expect(nativeDivider.tagName).toBe('DIV');


### PR DESCRIPTION
## Summary
- cherry-picked T-2 dependency commit so this stacked branch has `validatePost` available from `src/lib/validatePost.ts`
- added `Podium` as a fixed bottom composer using `SegmentedControl`, a native multiline textarea, and publish button
- implemented submit-only validation flow via `validatePost`, with busy-lock protection and ARIA error wiring
- added Podium CSS with the architecture-correct root variable `--podium-height: calc(187px + env(safe-area-inset-bottom, 0px))`
- rendered Divider/Native as inline `` (not DS Divider)
- added Podium tests including behavior coverage and CSS source assertions for fixed/desktop rules

## Verification
- `npm run test -- tests/components/Podium.test.tsx tests/components/SegmentedControl.test.tsx tests/lib/validatePost.test.ts`
- `npm run test`
- `npm run build`

Closes #89
Execution-Agent: dev

---

## Visual Evidence

> Figma node IDs fetched via Figma MCP (`get_screenshot`) on file `CsPAyUdLSStdmNpmiBMESQ`.
> Live app screenshots taken at http://localhost:5173 via Chrome DevTools MCP.
> Screenshots captured: 2026-04-16.

### Figma vs Live Comparison

| Viewport | Figma Node | Figma URL | Result |
|---|---|---|---|
| Mobile 390×844 Light | `304:2` | [Default/Light/Mobile](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=304-2) | D-1: Side selector (arch-mandated) — all other properties match |
| Mobile 390×844 Dark | `414:78` | [Default/Dark/Mobile](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=414-78) | D-1: Side selector (arch-mandated) — all other properties match |
| Desktop 1440×900 Light | `582:50` | [Default/Light/Desktop](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=582-50) | D-1: Side selector (arch-mandated) — all other properties match |
| Desktop 1440×900 Dark | `583:62` | [Default/Dark/Desktop](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=583-62) | D-1: Side selector (arch-mandated) — all other properties match |

**Properties verified matching across all viewports:**
- `position: fixed; bottom: 0; left: 0; right: 0` (mobile)
- `max-width: 600px; left: 50%; transform: translateX(-50%)` (desktop ≥1024px)
- Surface background (`var(--color-surface-default)`) — correct Light/Dark token application
- Tark brand color on selected side control
- Divider above composer bar
- Textarea placeholder ("Post text") and `min-height: 56px`
- Publish button (↑ circle, `var(--color-brand-primary)`, `border-radius: 999px`, 40×40px) — visible and correctly disabled in empty state
- Argument card layout (single-column mobile, two-column desktop)

### Deviations

| ID | Viewport | Element | Figma | Implementation |
|---|---|---|---|---|
| D-1 | All viewports | Side selector | `ChipFilter` — single selected-side chip (52px, pill, inline with textarea in one composer row) | `SegmentedControl` — dual-option Tark/Vitark full-width row above textarea row |

### Architecture-sanctioned deviations

| ID | Sanction source |
|---|---|
| D-1 | **Architecture-mandated.** Issue #89 acceptance criteria explicitly require `SegmentedControl` from T-3. §2.6 of `docs/slices/post-tark-vitark/05-architecture.md` specifies the `SegmentedControl` layout. The Figma Default frame shows a chip representation, but the architecture contract overrides it. PO-accepted at Gate 4 closure. |

Checked: 2026-04-16
Checked-by: dev (Figma MCP `get_screenshot` × 4 nodes + Chrome DevTools MCP live app comparison)