### PR TITLE
feat: wire Podium into DebateScreen with publish state flow

### DIFF
--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -1,18 +1,40 @@
+import { useState } from 'react';
+import type { Argument, Side } from '../data/debate';
 import { DEBATE } from '../data/debate';
 import { Topic } from './Topic';
 import { LegendBar } from './LegendBar';
 import { Timeline } from './Timeline';
+import { Podium } from './Podium';
 import { ThemeToggle } from './ThemeToggle';
 import '../styles/debate-screen.css';
 
 export function DebateScreen() {
+    const [localPosts, setLocalPosts] = useState<Argument[]>([]);
+    const [selectedSide, setSelectedSide] = useState<Side>('tark');
+
+    function handlePublish(text: string, side: Side): void {
+        setLocalPosts((existingPosts) => [
+            ...existingPosts,
+            {
+                id: DEBATE.arguments.length + existingPosts.length + 1,
+                side,
+                text,
+            },
+        ]);
+    }
+
     return (
         <main role="main" className="debate-screen">
             <header className="debate-header">
                 <Topic text={DEBATE.topic} />
             </header>
             <LegendBar />
-            <Timeline arguments={DEBATE.arguments} />
+            <Timeline arguments={[...DEBATE.arguments, ...localPosts]} />
+            <Podium
+                selectedSide={selectedSide}
+                onSideChange={setSelectedSide}
+                onPublish={handlePublish}
+            />
             <ThemeToggle />
         </main>
     );

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -4,6 +4,9 @@
 .debate-screen {
     min-height: 100vh;
     min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    padding-bottom: var(--podium-height);
     background-color: var(--color-surface-default);
     color: var(--color-on-surface);
 }

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -6,7 +6,7 @@
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
-    padding-bottom: var(--podium-height);
+    padding-bottom: var(--podium-height, 0px);
     background-color: var(--color-surface-default);
     color: var(--color-on-surface);
 }

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -103,7 +103,7 @@ describe('DebateScreen', () => {
         await waitFor(() => {
             const items = screen.getAllByRole('listitem');
             expect(items).toHaveLength(DEBATE.arguments.length + 1);
-            expect(items.at(-1)).toHaveTextContent('This post has enough length.');
+            expect(items[items.length - 1]).toHaveTextContent('This post has enough length.');
         });
     });
 
@@ -162,6 +162,6 @@ describe('DebateScreen', () => {
     it('uses shared podium height variable for debate screen clearance', () => {
         expect(debateScreenCss).toContain('display: flex;');
         expect(debateScreenCss).toContain('flex-direction: column;');
-        expect(debateScreenCss).toContain('padding-bottom: var(--podium-height);');
+        expect(debateScreenCss).toContain('padding-bottom: var(--podium-height, 0px);');
     });
 });

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -1,7 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import { DEBATE } from '../../src/data/debate';
+
+const debateScreenCss = readFileSync(
+    resolve(process.cwd(), 'src/styles/debate-screen.css'),
+    'utf-8'
+);
 
 describe('DebateScreen', () => {
     afterEach(() => {
@@ -43,10 +50,100 @@ describe('DebateScreen', () => {
         expect(timeline).toBeInTheDocument();
     });
 
+    it('composes Podium controls', () => {
+        render(<DebateScreen />);
+
+        expect(screen.getByRole('radiogroup', { name: 'Post side' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
+    });
+
     it('renders all arguments from DEBATE data', () => {
         render(<DebateScreen />);
         const items = screen.getAllByRole('listitem');
         expect(items).toHaveLength(DEBATE.arguments.length);
+    });
+
+    it('defaults selected side to tark on mount', () => {
+        render(<DebateScreen />);
+
+        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
+            'aria-checked',
+            'true'
+        );
+        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
+            'aria-checked',
+            'false'
+        );
+    });
+
+    it('passes side changes to Podium by updating selected side state', () => {
+        render(<DebateScreen />);
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+
+        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
+            'aria-checked',
+            'true'
+        );
+        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
+            'aria-checked',
+            'false'
+        );
+    });
+
+    it('appends a valid published post as the last timeline item', async () => {
+        render(<DebateScreen />);
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
+            target: { value: 'This post has enough length.' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Publish post' }));
+
+        await waitFor(() => {
+            const items = screen.getAllByRole('listitem');
+            expect(items).toHaveLength(DEBATE.arguments.length + 1);
+            expect(items.at(-1)).toHaveTextContent('This post has enough length.');
+        });
+    });
+
+    it('resets localPosts to empty after remount', async () => {
+        const { unmount } = render(<DebateScreen />);
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
+            target: { value: 'Session-only argument text.' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Publish post' }));
+
+        await waitFor(() => {
+            expect(screen.getAllByRole('listitem')).toHaveLength(
+                DEBATE.arguments.length + 1
+            );
+        });
+
+        unmount();
+        render(<DebateScreen />);
+
+        expect(screen.getAllByRole('listitem')).toHaveLength(DEBATE.arguments.length);
+        expect(screen.queryByText('Session-only argument text.')).not.toBeInTheDocument();
+    });
+
+    it('resets selected side to tark after remount', () => {
+        const { unmount } = render(<DebateScreen />);
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
+            'aria-checked',
+            'true'
+        );
+
+        unmount();
+        render(<DebateScreen />);
+
+        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
+            'aria-checked',
+            'true'
+        );
     });
 
     it('applies debate-screen CSS class to main element', () => {
@@ -55,11 +152,16 @@ describe('DebateScreen', () => {
         expect(main).toHaveClass('debate-screen');
     });
 
-    it('has no input controls or forms (read-only except theme toggle)', () => {
-        const { container } = render(<DebateScreen />);
-        expect(screen.queryAllByRole('button')).toHaveLength(0);
+    it('keeps ThemeToggle present alongside composer controls', () => {
+        render(<DebateScreen />);
+
         expect(screen.getByRole('switch', { name: /dark mode/i })).toBeInTheDocument();
-        expect(screen.queryAllByRole('textbox')).toHaveLength(0);
-        expect(container.querySelector('form')).not.toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
+    });
+
+    it('uses shared podium height variable for debate screen clearance', () => {
+        expect(debateScreenCss).toContain('display: flex;');
+        expect(debateScreenCss).toContain('flex-direction: column;');
+        expect(debateScreenCss).toContain('padding-bottom: var(--podium-height);');
     });
 });


### PR DESCRIPTION
## Summary
- wire `Podium` into `DebateScreen` render tree
- make `DebateScreen` state owner for `localPosts` and `selectedSide`
- append published local posts into `Timeline` using combined list
- add `.debate-screen` layout clearance with shared `--podium-height` variable
- extend `DebateScreen` tests for Podium wiring, publish append, remount reset, and layout rule

## Verification
- `npm test -- tests/components/DebateScreen.test.tsx`
- `npm test`

Closes #90
Execution-Agent: dev

---

## Visual Evidence

### Figma vs Live Comparison

All 4 Figma screenshots fetched via Figma MCP `get_screenshot` — all node IDs confirmed valid.

| Viewport | Theme | Figma Node | Figma URL | Result |
|---|---|---|---|---|
| Mobile 390×844 | Light | `304:2` | [Open in Figma](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=304-2) | ✅ Match |
| Mobile 390×844 | Dark | `414:78` | [Open in Figma](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=414-78) | ✅ Match |
| Desktop 1440×900 | Light | `582:50` | [Open in Figma](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=582-50) | ✅ Match |
| Desktop 1440×900 | Dark | `583:62` | [Open in Figma](https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=583-62) | ✅ Match |

### Key Properties Verified

**Layout & Structure**
- `<Podium />` present in `DebateScreen` render tree ✅
- `.debate-screen` has `display: flex; flex-direction: column; padding-bottom: var(--podium-height, 0px)` ✅
- `--podium-height: calc(187px + env(safe-area-inset-bottom, 0px))` declared on `:root` in `podium.css` ✅
- `selectedSide` state defaults to `'tark'` ✅
- Timeline content clears the fixed Podium — all 8 argument cards reachable by scroll ✅

**Podium Position & Behaviour**
- Mobile: `position: fixed; bottom: 0; left: 0; right: 0` — spans full viewport width ✅
- Desktop (≥1024px): `max-width: 600px; left: 50%; right: auto; transform: translateX(-50%)` — centred ✅
- Podium appears at viewport bottom in both mobile and desktop screenshots ✅

**Theme**
- Light mode: blue primary header, light surface background, blue/yellow argument cards ✅
- Dark mode: lavender-purple primary header, dark surface background, dark-navy/dark-red argument cards ✅
- Both themes applied correctly via `data-theme` attribute ✅

**SegmentedControl / Side Selection**
- Podium shows "Tark" selected by default at initial load ✅

### Deviations

**D-1 — Architecture-Sanctioned (Low, no PO action required)**
- Property: Podium composer side-selector UI component
- Expected (Figma 304:2 / 414:78): Single `ChipFilter` pill showing selected side
- Actual: Full `SegmentedControl` with "Tark" and "Vitark" options
- Severity: Low — intentional divergence; Gate 4 architecture spec (AD-7, T-3) explicitly mandates `SegmentedControl`. Figma showed a placeholder chip; architecture upgraded it to a full two-option toggle.

**D-2 — Expected Dev Feature (Informational, no PO action required)**
- Property: `ThemeToggle` button (floating circle, right edge)
- Expected (Figma frames): Not present — `ThemeToggle` is a dev-convenience feature added separately
- Actual: Visible as floating circular button at right viewport edge across all viewports/themes
- Severity: Informational — not a regression; feature renders as designed

### Architecture-sanctioned deviations
- D-1: `SegmentedControl` mandated by AD-7/T-3 in `05-architecture.md` (Gate 4 architecture spec overrides Figma placeholder chip)

Checked: 2026-04-16
Checked-by: dev
Figma-frames-fetched-by: Figma MCP (`get_screenshot`) — node IDs `304:2`, `414:78`, `582:50`, `583:62` all confirmed valid
Live-app-screenshots: `http://localhost:5173` at 390×844 (mobile) and 1440×900 (desktop), light and dark themes