### PR TITLE
T-7: add post-tark-vitark Cucumber scenarios and step definitions

### DIFF
--- a/features/post-tark-vitark.feature
+++ b/features/post-tark-vitark.feature
@@ -1,0 +1,89 @@
+Feature: Post Tark or Vitark to the Debate Screen
+  As a public visitor on the Debate Screen
+  I want to compose and publish a Tark or Vitark post
+  So that my argument appears immediately in the debate
+
+  Scenario: Composer is visible on initial load
+    Given the debate screen is loaded
+    Then the composer controls are visible
+
+  Scenario: Tark is preselected by default on load
+    Given the debate screen is loaded
+    Then Tark is selected by default
+
+  Scenario: Visitor changes side to Vitark; last-selected side is remembered
+    Given the debate screen is loaded
+    When the visitor selects the Vitark side
+    Then Vitark remains selected
+
+  Scenario: Whitespace-only input is rejected with an error message
+    Given the debate screen is loaded
+    When the visitor enters whitespace-only post text
+    And the visitor submits the post
+    Then a validation error appears saying "Text cannot be empty or whitespace only."
+    And no new debate post is added
+
+  Scenario: Input of fewer than 10 characters is rejected
+    Given the debate screen is loaded
+    When the visitor enters a post with 9 characters
+    And the visitor submits the post
+    Then a validation error appears saying "Text must be between 10 and 300 characters."
+    And no new debate post is added
+
+  Scenario: Input of exactly 10 characters is accepted
+    Given the debate screen is loaded
+    When the visitor enters a post with 10 characters
+    And the visitor submits the post
+    Then one new debate post is added
+    And no validation error is shown
+
+  Scenario: Input of exactly 300 characters is accepted
+    Given the debate screen is loaded
+    When the visitor enters a post with 300 characters
+    And the visitor submits the post
+    Then one new debate post is added
+    And no validation error is shown
+
+  Scenario: Input of more than 300 characters is rejected
+    Given the debate screen is loaded
+    When the visitor enters a post with 301 characters
+    And the visitor submits the post
+    Then a validation error appears saying "Text must be between 10 and 300 characters."
+    And no new debate post is added
+
+  Scenario: Text with internal spaces and newlines is accepted when length is in range
+    Given the debate screen is loaded
+    When the visitor enters valid multiline post text
+    And the visitor submits the post
+    Then one new debate post is added
+    And no validation error is shown
+
+  Scenario: Valid post is appended at the bottom of the debate
+    Given the debate screen is loaded
+    When the visitor publishes the post text "This post should appear at the bottom."
+    Then one new debate post is added
+    And the latest debate post text is "This post should appear at the bottom."
+
+  Scenario: Composer input is cleared after a valid publish
+    Given the debate screen is loaded
+    When the visitor publishes the post text "This post should clear the composer input."
+    Then one new debate post is added
+    And the composer input is cleared
+
+  Scenario: Selected side is preserved after a valid publish
+    Given the debate screen is loaded
+    When the visitor selects the Vitark side
+    And the visitor publishes the post text "This Vitark post should keep the side selected."
+    Then one new debate post is added
+    And Vitark remains selected
+
+  Scenario: Second publish attempt is blocked while first is in progress (busy lock)
+    Given a publish is already in progress in the composer
+    When the visitor attempts another publish while busy
+    Then the second publish attempt is blocked
+
+  Scenario: Full page refresh resets the debate to baseline static content
+    Given the debate screen is loaded
+    When the visitor publishes the post text "Session-only post that should disappear on refresh."
+    And the page is refreshed
+    Then the debate resets to baseline static content

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -1,0 +1,218 @@
+import {
+  After,
+  Before,
+  Given,
+  Then,
+  When,
+  World,
+  setWorldConstructor,
+} from '@cucumber/cucumber';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  type RenderResult,
+} from '@testing-library/react';
+import * as assert from 'assert';
+import { createElement } from 'react';
+import { DebateScreen } from '../../src/components/DebateScreen';
+import { Podium } from '../../src/components/Podium';
+import { DEBATE } from '../../src/data/debate';
+
+function activeRender(world: PostTarkVitarkWorld): RenderResult {
+  assert.ok(world.renderResult, 'Expected an active rendered view.');
+  return world.renderResult;
+}
+
+function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
+  return activeRender(world).getByRole('textbox', {
+    name: 'Post text',
+  }) as HTMLTextAreaElement;
+}
+
+function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
+  return activeRender(world).getByRole('button', {
+    name: 'Publish post',
+  }) as HTMLButtonElement;
+}
+
+function debateItems(world: PostTarkVitarkWorld): HTMLElement[] {
+  return activeRender(world).getAllByRole('listitem');
+}
+
+function buildText(length: number): string {
+  return 'a'.repeat(length);
+}
+
+async function submitComposer(world: PostTarkVitarkWorld): Promise<void> {
+  await waitFor(() => {
+    assert.equal(publishButton(world).disabled, false);
+  });
+
+  fireEvent.click(publishButton(world));
+}
+
+class PostTarkVitarkWorld extends World {
+  baselineCount = DEBATE.arguments.length;
+  latestPublishedText = '';
+  publishCalls = 0;
+  resolvePendingPublish: (() => void) | null = null;
+  renderResult: RenderResult | null = null;
+
+  renderDebateScreen(): void {
+    cleanup();
+    this.renderResult = render(createElement(DebateScreen));
+    this.baselineCount = debateItems(this).length;
+  }
+}
+
+setWorldConstructor(PostTarkVitarkWorld);
+
+Before(function (this: PostTarkVitarkWorld) {
+  cleanup();
+  this.baselineCount = DEBATE.arguments.length;
+  this.latestPublishedText = '';
+  this.publishCalls = 0;
+  this.resolvePendingPublish = null;
+  this.renderResult = null;
+});
+
+After(function (this: PostTarkVitarkWorld) {
+  this.resolvePendingPublish?.();
+  this.resolvePendingPublish = null;
+  this.renderResult?.unmount();
+  this.renderResult = null;
+  cleanup();
+});
+
+Given('the debate screen is loaded', function (this: PostTarkVitarkWorld) {
+  this.renderDebateScreen();
+});
+
+Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
+  const view = activeRender(this);
+
+  assert.ok(view.getByRole('radiogroup', { name: 'Post side' }));
+  assert.ok(composerInput(this));
+  assert.ok(publishButton(this));
+  assert.equal(view.queryByRole('button', { name: /sign in|log in/i }), null);
+  assert.equal(view.queryByLabelText(/image|media|upload/i), null);
+});
+
+Then('Tark is selected by default', function (this: PostTarkVitarkWorld) {
+  const view = activeRender(this);
+
+  assert.equal(view.getByRole('radio', { name: 'Tark' }).getAttribute('aria-checked'), 'true');
+  assert.equal(view.getByRole('radio', { name: 'Vitark' }).getAttribute('aria-checked'), 'false');
+});
+
+When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
+  fireEvent.click(activeRender(this).getByRole('radio', { name: 'Vitark' }));
+});
+
+Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
+  const view = activeRender(this);
+
+  assert.equal(view.getByRole('radio', { name: 'Vitark' }).getAttribute('aria-checked'), 'true');
+  assert.equal(view.getByRole('radio', { name: 'Tark' }).getAttribute('aria-checked'), 'false');
+});
+
+When('the visitor enters whitespace-only post text', function (this: PostTarkVitarkWorld) {
+  fireEvent.change(composerInput(this), { target: { value: '      ' } });
+});
+
+When('the visitor enters a post with {int} characters', function (this: PostTarkVitarkWorld, length: number) {
+  this.latestPublishedText = buildText(length);
+  fireEvent.change(composerInput(this), { target: { value: this.latestPublishedText } });
+});
+
+When('the visitor enters valid multiline post text', function (this: PostTarkVitarkWorld) {
+  this.latestPublishedText = 'Line one has spaces\nLine two stays valid.';
+  fireEvent.change(composerInput(this), { target: { value: this.latestPublishedText } });
+});
+
+When('the visitor submits the post', async function (this: PostTarkVitarkWorld) {
+  await submitComposer(this);
+});
+
+When('the visitor publishes the post text {string}', async function (this: PostTarkVitarkWorld, text: string) {
+  this.latestPublishedText = text;
+  fireEvent.change(composerInput(this), { target: { value: text } });
+  await submitComposer(this);
+});
+
+Then('a validation error appears saying {string}', function (this: PostTarkVitarkWorld, message: string) {
+  assert.equal(activeRender(this).getByRole('alert').textContent?.trim(), message);
+  assert.equal(composerInput(this).getAttribute('aria-invalid'), 'true');
+});
+
+Then('no new debate post is added', function (this: PostTarkVitarkWorld) {
+  assert.equal(debateItems(this).length, this.baselineCount);
+});
+
+Then('one new debate post is added', async function (this: PostTarkVitarkWorld) {
+  await waitFor(() => {
+    assert.equal(debateItems(this).length, this.baselineCount + 1);
+  });
+});
+
+Then('no validation error is shown', function (this: PostTarkVitarkWorld) {
+  assert.equal(activeRender(this).getByRole('alert').textContent?.trim(), '');
+});
+
+Then('the latest debate post text is {string}', async function (this: PostTarkVitarkWorld, expected: string) {
+  await waitFor(() => {
+    const items = debateItems(this);
+    const latestItem = items[items.length - 1];
+    assert.ok(latestItem);
+    assert.ok(latestItem.textContent?.includes(expected));
+  });
+});
+
+Then('the composer input is cleared', async function (this: PostTarkVitarkWorld) {
+  await waitFor(() => {
+    assert.equal(composerInput(this).value, '');
+  });
+});
+
+Given('a publish is already in progress in the composer', async function (this: PostTarkVitarkWorld) {
+  cleanup();
+  this.renderResult = render(
+    createElement(Podium, {
+      selectedSide: 'tark',
+      onSideChange: () => {},
+      onPublish: () =>
+        new Promise<void>((resolve) => {
+          this.publishCalls += 1;
+          this.resolvePendingPublish = resolve;
+        }),
+    })
+  );
+
+  fireEvent.change(composerInput(this), { target: { value: 'This text has enough length.' } });
+  await submitComposer(this);
+
+  await waitFor(() => {
+    assert.equal(this.publishCalls, 1);
+  });
+});
+
+When('the visitor attempts another publish while busy', function (this: PostTarkVitarkWorld) {
+  fireEvent.click(publishButton(this));
+});
+
+Then('the second publish attempt is blocked', function (this: PostTarkVitarkWorld) {
+  assert.equal(this.publishCalls, 1);
+  assert.equal(publishButton(this).disabled, true);
+});
+
+When('the page is refreshed', function (this: PostTarkVitarkWorld) {
+  cleanup();
+  this.renderResult = render(createElement(DebateScreen));
+});
+
+Then('the debate resets to baseline static content', function (this: PostTarkVitarkWorld) {
+  assert.equal(debateItems(this).length, DEBATE.arguments.length);
+  assert.equal(activeRender(this).queryByText(this.latestPublishedText), null);
+});

--- a/features/support/css-loader.mjs
+++ b/features/support/css-loader.mjs
@@ -1,0 +1,22 @@
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.endsWith('.css')) {
+    return {
+      url: new URL(specifier, context.parentURL).href,
+      shortCircuit: true,
+    };
+  }
+
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.css')) {
+    return {
+      format: 'module',
+      source: 'export default {};',
+      shortCircuit: true,
+    };
+  }
+
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/features/support/jsdom-setup.mjs
+++ b/features/support/jsdom-setup.mjs
@@ -1,0 +1,62 @@
+import { JSDOM } from 'jsdom';
+
+function defineGlobalValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost/',
+});
+const win = dom.window;
+
+defineGlobalValue('window', win);
+defineGlobalValue('document', win.document);
+defineGlobalValue('navigator', win.navigator);
+defineGlobalValue('self', win);
+defineGlobalValue('HTMLElement', win.HTMLElement);
+defineGlobalValue('Node', win.Node);
+defineGlobalValue('Text', win.Text);
+defineGlobalValue('Event', win.Event);
+defineGlobalValue('MouseEvent', win.MouseEvent);
+defineGlobalValue('KeyboardEvent', win.KeyboardEvent);
+defineGlobalValue('CustomEvent', win.CustomEvent);
+defineGlobalValue('MutationObserver', win.MutationObserver);
+defineGlobalValue('getComputedStyle', win.getComputedStyle.bind(win));
+defineGlobalValue('localStorage', win.localStorage);
+defineGlobalValue('sessionStorage', win.sessionStorage);
+defineGlobalValue(
+  'requestAnimationFrame',
+  win.requestAnimationFrame
+    ? win.requestAnimationFrame.bind(win)
+    : (callback) =>
+        setTimeout(() => {
+          callback(Date.now());
+        }, 0)
+);
+defineGlobalValue(
+  'cancelAnimationFrame',
+  win.cancelAnimationFrame
+    ? win.cancelAnimationFrame.bind(win)
+    : (id) => clearTimeout(id)
+);
+defineGlobalValue('IS_REACT_ACT_ENVIRONMENT', true);
+
+if (!win.matchMedia) {
+  Object.defineProperty(win, 'matchMedia', {
+    writable: true,
+    value: (query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:bdd": "node --import tsx/esm node_modules/@cucumber/cucumber/bin/cucumber.js --import 'features/step-definitions/**/*.ts'"
+    "test:bdd": "node --import tsx/esm --loader ./features/support/css-loader.mjs node_modules/@cucumber/cucumber/bin/cucumber.js --import 'features/support/jsdom-setup.mjs' --import 'features/step-definitions/**/*.ts'"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",


### PR DESCRIPTION
## Summary
- add `features/post-tark-vitark.feature` with all 14 required Issue #92 scenarios using explicit Given/When/Then flow
- add `features/step-definitions/post-tark-vitark.steps.ts` with runnable, non-pending step bindings using React Testing Library + JSDOM
- add Cucumber support bootstrapping for CSS imports and preloaded JSDOM setup so component-level BDD steps run in Node
- update `test:bdd` script to load support bootstrap before step definitions

## Verification
- `npm run test:bdd`
- `npm run test -- tests/components/DebateScreen.test.tsx tests/components/Podium.test.tsx tests/lib/validatePost.test.ts`
- `npm run test`
- `npm run build`

Closes #92
Execution-Agent: dev