### PR TITLE
fix(theme-toggle): reposition to top on mobile/tablet to avoid Podium overlap

### DIFF
--- a/src/styles/components/legend-bar.css
+++ b/src/styles/components/legend-bar.css
@@ -9,7 +9,7 @@
     justify-content: center;
     align-items: center;
     gap: 8px;
-    height: 32px;
+    height: var(--space-8);
     background-color: var(--color-legend-surface);
     color: var(--color-legend-on-surface);
 }

--- a/src/styles/components/theme-toggle.css
+++ b/src/styles/components/theme-toggle.css
@@ -19,3 +19,10 @@
     padding: 0;
     line-height: 1;
 }
+
+@media (max-width: 1023px) {
+    .theme-toggle {
+        bottom: unset;
+        top: var(--space-4);
+    }
+}

--- a/src/styles/components/theme-toggle.css
+++ b/src/styles/components/theme-toggle.css
@@ -23,6 +23,6 @@
 @media (max-width: 1023px) {
     .theme-toggle {
         bottom: unset;
-        top: var(--space-4);
+        top: calc(var(--space-4) + var(--space-8));
     }
 }


### PR DESCRIPTION
## Summary

Fixes Gate 5.5 Runtime QA finding F-1: `ThemeToggle` button (`position: fixed; bottom: var(--space-4); right: var(--space-4)`) overlapped and fully occluded the Podium Publish button at mobile/tablet viewports.

## Change

**File:** `src/styles/components/theme-toggle.css`

Adds `@media (max-width: 1023px)` rule that repositions `.theme-toggle` from bottom-right to top-right on mobile/tablet, offset below the sticky LegendBar:

```css
@media (max-width: 1023px) {
    .theme-toggle {
        bottom: unset;
        top: calc(var(--space-4) + var(--space-8));
    }
}
```

**Why `calc(var(--space-4) + var(--space-8))`:**
- `--space-4` (16px) = standard gutter margin
- `--space-8` (32px) = sticky LegendBar height (`position: sticky; top: 0; height: 32px`)
- Without this offset, the ThemeToggle (40px tall) would overlap the LegendBar at y=16–32px
- Combined offset (48px) places the toggle fully below the LegendBar

Desktop (≥1024px): no change — ThemeToggle remains at bottom-right.

## Acceptance Criteria

| AC | Requirement | Status |
|----|-------------|--------|
| AC1 | At 360×800 mobile, ThemeToggle does not overlap Publish button or LegendBar | ✅ |
| AC2 | At 768×1024 tablet, ThemeToggle does not overlap Publish button or LegendBar | ✅ |
| AC3 | At 1366×768 desktop, ThemeToggle remains at bottom-right (unchanged) | ✅ |
| AC4 | Fix is CSS-only — no ThemeToggle component logic or test changes | ✅ |

## Evidence

- 259/259 tests pass, 0 failures
- Live screenshot at 360×800 confirms ThemeToggle at top-right (below LegendBar), Publish button fully visible

Closes #105

---
Execution-Agent: dev  
Slice: post-tark-vitark  
Base: slice/post-tark-vitark