### PR TITLE
feat(post-tark-vitark): merge slice into master

### DIFF
--- a/docs/slices/post-tark-vitark/05-architecture.md
+++ b/docs/slices/post-tark-vitark/05-architecture.md
@@ -1,6 +1,10 @@
 # Architecture Plan — post-tark-vitark
 ## Gate 4 — 2026-04-16
 
+## Gate 4 Amendment — 2026-04-16 (H-4 Retroactive Figma Frame References)
+
+Figma frame node IDs added to UI-impacting task blocks (T-3, T-4, T-5, T-6) per protocol hardening H-4. Node IDs sourced from Section 10 `Figma Active Implementation Reference`.
+
 ---
 
 ## 1. Architecture Readiness
@@ -177,30 +181,30 @@ Per the `03-ux.md` Pass 4 Amendment notes, the following Figma DS library instan
 
 Core layout:
 ```css
+:root {
+  --podium-height: calc(109px + env(safe-area-inset-bottom, 0px));  /* shared layout token: full rendered Podium height (Figma base 109px + safe-area inset) so .debate-screen sibling always has correct bottom clearance via var(--podium-height) */
+  --podium-inline-padding: var(--space-4);
+}
+
 .podium {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 12px 16px 0;
+  display: flex;
+  flex-direction: column;
+  padding: calc(var(--space-4) - var(--radius-sharp)) var(--podium-inline-padding) 0;
   padding-bottom: env(safe-area-inset-bottom, 0px);
   background-color: var(--color-surface-default);
 }
-
-:root {
-  --podium-height: calc(187px + env(safe-area-inset-bottom, 0px));  /* shared ancestor: full rendered Podium height (Figma base 187px + safe-area inset) so .debate-screen sibling can reference it for correct clearance */
-}
 ```
 
-Desktop responsive — Podium is centred on wide viewports to match Design QA desktop frame (`285:3144`, `285:3180`):
+Desktop responsive — Podium stays full-width; horizontal guttering increases via `--podium-inline-padding` at `min-width: 1024px` (matches Design QA desktop frames `582:50`, `583:62`):
 ```css
 /* ── Desktop ── */
 @media (min-width: 1024px) {
   .podium {
-    max-width: 600px;
-    left: 50%;
-    right: auto;
-    transform: translateX(-50%);
+    --podium-inline-padding: var(--space-30);
   }
 }
 ```
@@ -416,16 +420,23 @@ Tasks are ordered by dependency. Tasks with no declared dependency may be worked
 
 **Dependency:** T-1 (tokens).
 
+**Figma Reference:**
+| Frame | Node ID | URL |
+|---|---|---|
+| Default/Light/Mobile | `304:2` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=304-2 |
+| Default/Dark/Mobile | `414:78` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=414-78 |
+
 ---
 
 ### T-4 — `Podium` component (Composer bar)
 
 **Files:** `src/components/Podium.tsx`, `src/styles/components/podium.css`
 
-**Change:** New component. Contains Divider/Native (inline), `SegmentedControl`, native `<textarea>`, Publish `<button>`. `position: fixed; bottom: 0; left: 0; right: 0`. Shared layout custom property declared on `:root` as `--podium-height: calc(187px + env(safe-area-inset-bottom, 0px))` (full rendered height: Figma base 187px + safe-area inset, so `.debate-screen` sibling always has correct bottom clearance via `var(--podium-height)`). Safe-area via `env(safe-area-inset-bottom, 0px)`. Desktop breakpoint at `min-width: 1024px`: `max-width: 600px; left: 50%; right: auto; transform: translateX(-50%)` (matches Design QA desktop frames `285:3144` / `285:3180`). Calls `validatePost` on submit. Error region with `role="alert"` and `aria-live="polite"`. Textarea `aria-invalid` and `aria-describedby`.
+**Change:** New component. Contains Divider/Native (inline), a single side chip `<button>`, native `<textarea>`, and Publish `<button>`. `position: fixed; bottom: 0; left: 0; right: 0`. Shared layout custom property declared on `:root` as `--podium-height: calc(109px + env(safe-area-inset-bottom, 0px))` (full rendered height: base 109px + safe-area inset, so `.debate-screen` sibling always has correct bottom clearance via `var(--podium-height)`). Safe-area via `env(safe-area-inset-bottom, 0px)`. Desktop breakpoint at `min-width: 1024px` keeps the Podium full-width and applies horizontal guttering via `--podium-inline-padding: var(--space-30)` (matches Design QA desktop frames `582:50` / `583:62`). Calls `validatePost` on submit. Error region with `role="alert"` and `aria-live="polite"`. Textarea `aria-invalid` and `aria-describedby`. Amendment (Gate 5.5 QA fix): SegmentedControl replaced by inline chip `<button>`; `--podium-height` corrected from 187px to 109px; desktop layout changed from centred/max-width to full-width padding.
 
 **Acceptance criteria:**
-- `SegmentedControl`, `textarea`, and Publish button are all in the DOM.
+- Side chip button, `textarea`, and Publish button are all in the DOM.
+- Pressing the side chip button toggles the selected side used for publish.
 - Publish button is `disabled` when `textarea` is empty.
 - Submitting whitespace-only text renders an error message and does **not** call `onPublish`.
 - Submitting valid text (10–300 characters) calls `onPublish(trimmedText, side)`.
@@ -433,13 +444,25 @@ Tasks are ordered by dependency. Tasks with no declared dependency may be worked
 - `isBusy = true` prevents a second call to `onPublish` before the first completes.
 - Error message is associated to textarea via `aria-describedby`.
 - `podium.css` source contains `position: fixed` (assert by reading file text in test; jsdom does not apply external stylesheets, so `getComputedStyle` assertions for CSS-injected layout properties are not used).
-- Desktop `@media (min-width: 1024px)` centering (max-width 600px, `transform: translateX(-50%)`) is verified in Gate 5.5 runtime QA; no jsdom assertion for @media-scoped computed styles.
+- Desktop `@media (min-width: 1024px)` full-width padding (`--podium-inline-padding: var(--space-30)`) is verified in Gate 5.5 runtime QA; no jsdom assertion for @media-scoped computed styles.
 
 **Test file:** `tests/components/Podium.test.tsx`
 
 **AC coverage:** AC-1, AC-2, AC-6, AC-7, AC-8..AC-13.
 
-**Dependency:** T-1, T-2, T-3.
+**Dependency:** T-1, T-2.
+
+**Figma Reference:**
+| Frame | Node ID | URL |
+|---|---|---|
+| Default/Light/Mobile | `304:2` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=304-2 |
+| Default/Dark/Mobile | `414:78` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=414-78 |
+| Default/Light/Tablet | `580:26` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=580-26 |
+| Default/Dark/Tablet | `581:38` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=581-38 |
+| Default/Light/Desktop | `582:50` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=582-50 |
+| Default/Dark/Desktop | `583:62` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=583-62 |
+
+> **Note — interaction-state frames:** Typing, ValidationError, SubmitSuccess, and KeyboardOpen state frames were planned in Gate 3A UX doc but deferred to Pass 5 (pending PO Composer design approval) and were never executed in Figma. These interaction states are validated via BDD tests (`features/post-tark-vitark.feature`) and Gate 5.5 runtime QA. No Figma node IDs exist for these states.
 
 ---
 
@@ -466,7 +489,17 @@ Tasks are ordered by dependency. Tasks with no declared dependency may be worked
 
 **AC coverage:** AC-1, AC-4, AC-5, AC-14, AC-15, AC-18.
 
-**Dependency:** T-2, T-3, T-4.
+**Dependency:** T-2, T-4.
+
+**Figma Reference:**
+| Frame | Node ID | URL |
+|---|---|---|
+| Default/Light/Mobile | `304:2` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=304-2 |
+| Default/Dark/Mobile | `414:78` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=414-78 |
+| Default/Light/Tablet | `580:26` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=580-26 |
+| Default/Dark/Tablet | `581:38` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=581-38 |
+| Default/Light/Desktop | `582:50` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=582-50 |
+| Default/Dark/Desktop | `583:62` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=583-62 |
 
 ---
 
@@ -497,6 +530,8 @@ Tasks are ordered by dependency. Tasks with no declared dependency may be worked
 **AC coverage:** Amendment-1, AC-16.
 
 **Dependency:** None (independent of Podium work).
+
+**Figma Reference:** None — OQ-2 accepted; no Figma frame evidence exists for Amendment-1 (mobile 4-line clamp + Read more). Validate at Gate 5.5 runtime QA.
 
 ---
 
@@ -553,7 +588,7 @@ Parallelizable pairs: {T-1, T-2, T-6}; {T-3} after T-1; {T-4} after T-3; {T-5, T
 |---|---|---|---|
 | OQ-1 | PO constraint item 9 references "FR-6/AC-6 includes mobile 4-line clamp (Amendment 1)." FR-6/AC-6 in `02-prd.md` is the open-posting/no-auth criterion — not the clamp behavior. The AC reference appears to be a labelling error. | **Accepted** — Amendment-1 is treated as an explicit in-scope addition via PO constraint, independent of legacy AC numbering. No PRD revision required. | Proceed. |
 | OQ-2 | Amendment-1 (mobile 4-line clamp + Read more) has no Figma frame evidence. No expanded or collapsed card state was designed in Gate 3B. | **Accepted pending Gate 5.5** — implement per Section 2.5 spec. Gate 5.5 runtime QA is the validation gate. | Proceed. Builder follows architecture spec; no design revision required. |
-| OQ-3 | Desktop Podium centering was not explicitly specified in the architecture agent output. Identified during Orchestrator UX review against Design QA desktop frames (`285:3144`, `285:3180`). | **Resolved (2026-04-16)** — PO selected option 1: add desktop breakpoint to architecture. Applied to Section 2.6 Podium CSS spec and T-4 acceptance criteria. | Closed. |
+| OQ-3 | Desktop Podium centering was not explicitly specified in the architecture agent output. Identified during Orchestrator UX review against Design QA desktop frames (`582:50`, `583:62`). | **Resolved (2026-04-16)** — PO selected option 1: add desktop breakpoint to architecture. Applied to Section 2.6 Podium CSS spec and T-4 acceptance criteria. | Closed. |
 
 ---
 
@@ -561,7 +596,7 @@ Parallelizable pairs: {T-1, T-2, T-6}; {T-3} after T-1; {T-4} after T-3; {T-5, T
 
 **Can proceed to build.**
 
-All 18 acceptance criteria plus Amendment-1 and C-4 are covered by the architecture plan. Module boundaries, interface contracts, data shapes, task ordering, and test locations are fully specified. Known Rule #70 is explicitly accounted for across Divider/Native, SegmentedToggle/Native, and TextField/Native. All open questions are accepted or resolved. Architecture quality checks per `.github/references/architecture-quality-checks.md` pass. Desktop Podium responsive spec added per PO direction (OQ-3 resolved).
+All 18 acceptance criteria plus Amendment-1 and C-4 are covered by the architecture plan. Module boundaries, interface contracts, data shapes, task ordering, and test locations are fully specified. Known Rule #70 is explicitly accounted for across Divider/Native, SegmentedToggle/Native, and TextField/Native. All open questions are accepted or resolved. Architecture quality checks per `.github/references/architecture-quality-checks.md` pass. Desktop Podium responsive spec added per PO direction (OQ-3 resolved). H-4 Figma frame reference requirement satisfied: Figma Reference fields added to all UI-impacting task blocks (T-3, T-4, T-5, T-6).
 
 ---
 
@@ -582,12 +617,12 @@ All 18 acceptance criteria plus Amendment-1 and C-4 are covered by the architect
 |---|---|---|
 | Default/Light/Mobile (authoritative, Pass 4) | `304:2` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=304-2 |
 | Default/Dark/Mobile (authoritative, Pass 4) | `414:78` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=414-78 |
-| Typing/Light/Mobile | `285:2732` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=285-2732 |
-| ValidationError/Light/Mobile | `285:2846` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=285-2846 |
-| SubmitSuccess/Light/Mobile | `285:2964` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=285-2964 |
-| KeyboardOpen/Light/Mobile | `285:3078` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=285-3078 |
-| Default/Light/Desktop | `285:3144` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=285-3144 |
-| Default/Dark/Desktop | `285:3180` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=285-3180 |
+| Default/Light/Tablet | `580:26` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=580-26 |
+| Default/Dark/Tablet | `581:38` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=581-38 |
+| Default/Light/Desktop | `582:50` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=582-50 |
+| Default/Dark/Desktop | `583:62` | https://www.figma.com/design/CsPAyUdLSStdmNpmiBMESQ?node-id=583-62 |
+
+> **Note — interaction-state frames:** Typing, ValidationError, SubmitSuccess, and KeyboardOpen state frames were planned in Gate 3A UX doc (Pass 5, pending Composer design approval) but were never executed in Figma. These states are validated via BDD tests and Gate 5.5 runtime QA. No Figma node IDs exist.
 
 Section 02 container: node `399:78`, file `CsPAyUdLSStdmNpmiBMESQ`.
 
@@ -637,4 +672,4 @@ tests/
 | AD-5 | `SegmentedControl` ARIA pattern | `role="tablist"`, `role="radiogroup"`, custom `role="group"` | `role="radiogroup"` + `role="radio"` | M3 single-select semantics map precisely to radio group; correct screen reader behavior |
 | AD-6 | Horizontal Divider in Podium | DS `<Divider>` component, native `<div>` | Native `<div>` | DS `Divider` is vertical-only in current implementation (Known Rule #70) |
 | AD-7 | `SegmentedControl` scope | DS component (new), feature component | Feature component in `src/components/` (not `src/design-system/`) | PO constraint: no new DS components unless clearly necessary; this is slice-specific |
-| AD-8 | Desktop Podium responsive spec | Span full viewport width, centre with max-width + transform | Centre: `max-width: 600px; left: 50%; transform: translateX(-50%)` at `min-width: 1024px` | Matches Design QA desktop frames `285:3144`/`285:3180`; PO selected option 1 (2026-04-16) |
+| AD-8 | Desktop Podium responsive spec | Span full viewport width, centre with max-width + transform | Span full viewport width; increase horizontal guttering via `--podium-inline-padding: var(--space-30)` at `min-width: 1024px` | Matches Design QA desktop frames `582:50`/`583:62`; PO selected option 1 (2026-04-16); centring approach superseded by PR #108 full-width redesign |

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -93,7 +93,7 @@ Given('the debate screen is loaded', function (this: PostTarkVitarkWorld) {
 Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
   const view = activeRender(this);
 
-  assert.ok(view.getByRole('radiogroup', { name: 'Post side' }));
+  assert.ok(view.getByRole('button', { name: 'Post as Tark' }));
   assert.ok(composerInput(this));
   assert.ok(publishButton(this));
   assert.equal(view.queryByRole('button', { name: /sign in|log in/i }), null);
@@ -103,19 +103,19 @@ Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
 Then('Tark is selected by default', function (this: PostTarkVitarkWorld) {
   const view = activeRender(this);
 
-  assert.equal(view.getByRole('radio', { name: 'Tark' }).getAttribute('aria-checked'), 'true');
-  assert.equal(view.getByRole('radio', { name: 'Vitark' }).getAttribute('aria-checked'), 'false');
+  assert.ok(view.getByRole('button', { name: 'Post as Tark' }));
+  assert.equal(view.queryByRole('button', { name: 'Post as Vitark' }), null);
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  fireEvent.click(activeRender(this).getByRole('radio', { name: 'Vitark' }));
+  fireEvent.click(activeRender(this).getByRole('button', { name: 'Post as Tark' }));
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
   const view = activeRender(this);
 
-  assert.equal(view.getByRole('radio', { name: 'Vitark' }).getAttribute('aria-checked'), 'true');
-  assert.equal(view.getByRole('radio', { name: 'Tark' }).getAttribute('aria-checked'), 'false');
+  assert.ok(view.getByRole('button', { name: 'Post as Vitark' }));
+  assert.equal(view.queryByRole('button', { name: 'Post as Tark' }), null);
 });
 
 When('the visitor enters whitespace-only post text', function (this: PostTarkVitarkWorld) {

--- a/src/components/Podium.tsx
+++ b/src/components/Podium.tsx
@@ -2,7 +2,6 @@ import type { FormEvent } from 'react';
 import { useState } from 'react';
 import type { Side } from '../data/debate';
 import { validatePost } from '../lib/validatePost';
-import { SegmentedControl } from './SegmentedControl';
 import '../styles/components/podium.css';
 
 interface PodiumProps {
@@ -10,8 +9,6 @@ interface PodiumProps {
     onSideChange: (side: Side) => void;
     onPublish: (text: string, side: Side) => void;
 }
-
-const sideOptions: readonly Side[] = ['tark', 'vitark'];
 
 export function Podium({ selectedSide, onSideChange, onPublish }: PodiumProps) {
     const [text, setText] = useState('');
@@ -42,19 +39,23 @@ export function Podium({ selectedSide, onSideChange, onPublish }: PodiumProps) {
         }
     };
 
+    const sideLabel = selectedSide === 'tark' ? 'Tark' : 'Vitark';
+    const nextSide: Side = selectedSide === 'tark' ? 'vitark' : 'tark';
+
     return (
         <form className="podium" onSubmit={handleSubmit} aria-label="Post composer">
             {/* Divider/Native: inline horizontal separator, not DS Divider. */}
             <div className="podium__divider" role="separator" aria-orientation="horizontal" />
 
-            <SegmentedControl
-                options={sideOptions}
-                value={selectedSide}
-                onChange={onSideChange}
-                aria-label="Post side"
-            />
-
             <div className="podium__composer-row">
+                <button
+                    type="button"
+                    className={`podium__chip podium__chip--${selectedSide}`}
+                    aria-label={`Post as ${sideLabel}`}
+                    onClick={() => onSideChange(nextSide)}
+                >
+                    {sideLabel}
+                </button>
                 <textarea
                     className="podium__textarea"
                     value={text}

--- a/src/styles/components/podium.css
+++ b/src/styles/components/podium.css
@@ -1,5 +1,6 @@
 :root {
-    --podium-height: calc(187px + env(safe-area-inset-bottom, 0px));
+    --podium-height: calc(109px + env(safe-area-inset-bottom, 0px));
+    --podium-inline-padding: var(--space-4);
 }
 
 .podium {
@@ -10,7 +11,7 @@
     display: flex;
     flex-direction: column;
     gap: calc(var(--space-4) - var(--radius-sharp));
-    padding: calc(var(--space-4) - var(--radius-sharp)) var(--space-4) 0;
+    padding: calc(var(--space-4) - var(--radius-sharp)) var(--podium-inline-padding) 0;
     padding-bottom: env(safe-area-inset-bottom, 0px);
     background-color: var(--color-surface-default);
     z-index: 20;
@@ -18,9 +19,9 @@
 
 .podium__divider {
     display: block;
-    width: calc(100% + (var(--space-4) * 2));
+    width: calc(100% + (var(--podium-inline-padding) * 2));
     height: var(--divider-thickness);
-    margin-inline: calc(var(--space-4) * -1);
+    margin-inline: calc(var(--podium-inline-padding) * -1);
     background-color: var(--color-spine-line);
 }
 
@@ -72,6 +73,30 @@
     cursor: not-allowed;
 }
 
+.podium__chip {
+    height: var(--space-8);
+    border-radius: 999px;
+    padding: 0 calc(var(--space-4) - var(--radius-sharp));
+    flex-shrink: 0;
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--typescale-label-md-size);
+    font-weight: var(--typescale-label-md-weight);
+    line-height: var(--typescale-label-md-line-height);
+    letter-spacing: var(--typescale-label-md-tracking);
+}
+
+.podium__chip--tark {
+    background-color: var(--color-tark-surface);
+    color: var(--color-tark-on-surface);
+}
+
+.podium__chip--vitark {
+    background-color: var(--color-vitark-surface);
+    color: var(--color-vitark-on-surface);
+}
+
 .podium__error {
     min-height: var(--typescale-label-md-line-height);
     margin: 0;
@@ -84,9 +109,6 @@
 
 @media (min-width: 1024px) {
     .podium {
-        max-width: 600px;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
+        --podium-inline-padding: var(--space-30);
     }
 }

--- a/tests/a11y/podium-a11y.test.tsx
+++ b/tests/a11y/podium-a11y.test.tsx
@@ -95,7 +95,7 @@ describe('Podium ARIA semantics', () => {
         );
     });
 
-    it('SegmentedControl exposes radiogroup and radio roles', () => {
+    it('chip button has accessible name matching selected side', () => {
         render(
             <Podium
                 selectedSide="tark"
@@ -104,14 +104,22 @@ describe('Podium ARIA semantics', () => {
             />
         );
 
-        const segmentedControl = screen.getByRole('radiogroup', {
-            name: 'Post side',
-        });
-        expect(segmentedControl).toBeInTheDocument();
+        const chip = screen.getByRole('button', { name: 'Post as Tark' });
+        expect(chip).toBeInTheDocument();
+        expect(chip).toHaveAccessibleName('Post as Tark');
+    });
 
-        const options = screen.getAllByRole('radio');
-        expect(options).toHaveLength(2);
-        expect(options[0]).toHaveAccessibleName('Tark');
-        expect(options[1]).toHaveAccessibleName('Vitark');
+    it('chip button has accessible name matching vitark selected side', () => {
+        render(
+            <Podium
+                selectedSide="vitark"
+                onSideChange={() => {}}
+                onPublish={() => {}}
+            />
+        );
+
+        const chip = screen.getByRole('button', { name: 'Post as Vitark' });
+        expect(chip).toBeInTheDocument();
+        expect(chip).toHaveAccessibleName('Post as Vitark');
     });
 });

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -53,7 +53,7 @@ describe('DebateScreen', () => {
     it('composes Podium controls', () => {
         render(<DebateScreen />);
 
-        expect(screen.getByRole('radiogroup', { name: 'Post side' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
         expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
     });
@@ -67,29 +67,17 @@ describe('DebateScreen', () => {
     it('defaults selected side to tark on mount', () => {
         render(<DebateScreen />);
 
-        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
-            'aria-checked',
-            'true'
-        );
-        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
-            'aria-checked',
-            'false'
-        );
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Post as Vitark' })).not.toBeInTheDocument();
     });
 
     it('passes side changes to Podium by updating selected side state', () => {
         render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
 
-        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
-            'aria-checked',
-            'true'
-        );
-        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
-            'aria-checked',
-            'false'
-        );
+        expect(screen.getByRole('button', { name: 'Post as Vitark' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Post as Tark' })).not.toBeInTheDocument();
     });
 
     it('appends a valid published post as the last timeline item', async () => {
@@ -131,19 +119,13 @@ describe('DebateScreen', () => {
     it('resets selected side to tark after remount', () => {
         const { unmount } = render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
-        expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute(
-            'aria-checked',
-            'true'
-        );
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        expect(screen.getByRole('button', { name: 'Post as Vitark' })).toBeInTheDocument();
 
         unmount();
         render(<DebateScreen />);
 
-        expect(screen.getByRole('radio', { name: 'Tark' })).toHaveAttribute(
-            'aria-checked',
-            'true'
-        );
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
     });
 
     it('applies debate-screen CSS class to main element', () => {

--- a/tests/components/Podium.test.tsx
+++ b/tests/components/Podium.test.tsx
@@ -10,7 +10,7 @@ const podiumCss = readFileSync(
 );
 
 describe('Podium', () => {
-    it('renders segmented control, textarea, publish button, and native divider', () => {
+    it('renders chip button, textarea, publish button, and native divider', () => {
         render(
             <Podium
                 selectedSide="tark"
@@ -19,7 +19,7 @@ describe('Podium', () => {
             />
         );
 
-        expect(screen.getByRole('radiogroup', { name: 'Post side' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
         expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
         expect(publishButton).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('Podium', () => {
         expect(publishButton).not.toBeDisabled();
     });
 
-    it('delegates side changes through SegmentedControl interaction', () => {
+    it('delegates side changes through chip interaction', () => {
         const onSideChange = vi.fn();
 
         render(
@@ -159,17 +159,16 @@ describe('Podium', () => {
             />
         );
 
-        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
 
         expect(onSideChange).toHaveBeenCalledTimes(1);
         expect(onSideChange).toHaveBeenCalledWith('vitark');
     });
 
-    it('defines fixed and desktop-centered layout rules in podium.css source', () => {
+    it('defines fixed and desktop full-width layout rules in podium.css source', () => {
         expect(podiumCss).toContain('position: fixed;');
-        expect(podiumCss).toContain('--podium-height: calc(187px + env(safe-area-inset-bottom, 0px));');
+        expect(podiumCss).toContain('--podium-height: calc(109px + env(safe-area-inset-bottom, 0px));');
         expect(podiumCss).toContain('@media (min-width: 1024px)');
-        expect(podiumCss).toContain('max-width: 600px;');
-        expect(podiumCss).toContain('transform: translateX(-50%);');
+        expect(podiumCss).toContain('--podium-inline-padding: var(--space-30);');
     });
 });


### PR DESCRIPTION
## Summary

Merges the complete `post-tark-vitark` slice into `master`.

## Slice: post-tark-vitark — What's included

### Features
- **T-1** (#96) — Token additions: `--color-on-surface-variant`, `--color-error`
- **T-2** (#97) — `validatePost` pure utility with full boundary test coverage
- **T-3** (#104) — Native `SegmentedControl` component (ARIA radiogroup + keyboard nav)
- **T-4** (#100) — `Podium` composer component (chip, textarea, publish, validation, ARIA)
- **T-5** (#102) — Wire `Podium` into `DebateScreen` with publish state flow
- **T-6** (#98) — Mobile clamp + Read more / Show less on `ArgumentCard`
- **T-7** (#103) — Cucumber BDD scenarios + step definitions for post-tark-vitark

### Accessibility
- **#101** — Podium a11y test suite (axe, ARIA, keyboard)

### QA Fixes (Gate 5.5)
- **#106** — ThemeToggle repositioned to top on mobile/tablet (no Podium overlap)
- **#108** — Replace SegmentedControl with inline ChipFilter pill; correct `--podium-height` to 109px; desktop full-width padding

## Gate Evidence
- Gate 5.5 Runtime QA: PASS — all functional AC journeys pass at 360px, 768px, 1366px, 1920px × light/dark
- Visual fidelity: PASS — matches Figma frames `304:2`, `414:78`, `582:50`, `583:62`
- All tests pass (260/260)
- No TypeScript errors

## Slice tracker
https://github.com/nishantnaagnihotri/tark-vitark/issues/85

## Rollback note
Revert this PR. All changes are additive feature code; no schema migrations or destructive operations.