### PR TITLE
fix(theme-toggle): reposition to top-right on mobile/tablet to avoid Podium overlap

### DIFF
--- a/src/styles/components/legend-bar.css
+++ b/src/styles/components/legend-bar.css
@@ -54,7 +54,7 @@
 @media (min-width: 481px) {
     .legend-bar {
         display: grid;
-        grid-template-columns: 1fr 32px 1fr;
+        grid-template-columns: 1fr var(--space-8) 1fr;
         gap: 12px;
         padding-inline: 40px;
     }

--- a/src/styles/components/legend-bar.css
+++ b/src/styles/components/legend-bar.css
@@ -9,7 +9,7 @@
     justify-content: center;
     align-items: center;
     gap: 8px;
-    height: 32px;
+    height: var(--space-8);
     background-color: var(--color-legend-surface);
     color: var(--color-legend-on-surface);
 }

--- a/src/styles/components/theme-toggle.css
+++ b/src/styles/components/theme-toggle.css
@@ -22,7 +22,7 @@
 
 @media (max-width: 1023px) {
     .theme-toggle {
-        bottom: unset;
+        bottom: auto;
         top: calc(var(--space-4) + var(--space-8));
     }
 }

--- a/src/styles/components/theme-toggle.css
+++ b/src/styles/components/theme-toggle.css
@@ -19,3 +19,10 @@
     padding: 0;
     line-height: 1;
 }
+
+@media (max-width: 1023px) {
+    .theme-toggle {
+        bottom: unset;
+        top: var(--space-4);
+    }
+}

--- a/src/styles/components/theme-toggle.css
+++ b/src/styles/components/theme-toggle.css
@@ -23,6 +23,6 @@
 @media (max-width: 1023px) {
     .theme-toggle {
         bottom: unset;
-        top: var(--space-4);
+        top: calc(var(--space-4) + var(--space-8));
     }
 }


### PR DESCRIPTION
## Problem

On viewports ≤ 1023px, the fixed `bottom-right` ThemeToggle overlapped the Podium Publish button, making the publish action inaccessible.

Closes #105

## Changes

| File | Change |
|---|---|
| `src/styles/components/theme-toggle.css` | `@media (max-width: 1023px)`: unset `bottom`, set `top: calc(var(--space-4) + var(--space-8))` |
| `src/styles/components/legend-bar.css` | Tokenize `height: 32px` → `var(--space-8)` so the calc offset matches the actual bar height |

## Behaviour

- **Mobile/tablet (≤ 1023px):** ThemeToggle moves to top-right, offset `calc(--space-4 + --space-8)` from top to clear the LegendBar.
- **Desktop (≥ 1024px):** unchanged — remains `bottom: var(--space-4)`, `right: var(--space-4)`.

## Verification

- 263/263 tests pass (`npx vitest run`)
- No TypeScript errors
- CSS-only change — no component logic touched