### PR TITLE
skill: harden ux-design-execution and pr-review-loop (8 gaps)

### DIFF
--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -55,6 +55,7 @@ Orchestrator-specific rule:
 1. For multi-task dependent PR chains, run `Orchestrator-Managed Stacked Review Mode`: orchestrator owns review requests, polling, disposition triage, and base-to-tip progression.
 2. In `Orchestrator-Managed Stacked Review Mode`, dev handoffs are code-only by default; dev agents do not run independent review loops unless orchestrator explicitly delegates a specific review action.
 3. Record final disposition and rationale in context updates and gate artifacts.
+4. **Standing PR review-loop entry rule:** after any PR is opened — whether as a direct top-level user request or as the final step of a multi-step task, todo list, or gate workflow — immediately load the `pr-review-loop` skill and execute intake triage before declaring the overall task complete. The review loop is not optional and is not scoped only to explicit user review requests. Skipping this step after opening a PR is a workflow failure.
 
 ## Environment Policy
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -55,7 +55,7 @@ Orchestrator-specific rule:
 1. For multi-task dependent PR chains, run `Orchestrator-Managed Stacked Review Mode`: orchestrator owns review requests, polling, disposition triage, and base-to-tip progression.
 2. In `Orchestrator-Managed Stacked Review Mode`, dev handoffs are code-only by default; dev agents do not run independent review loops unless orchestrator explicitly delegates a specific review action.
 3. Record final disposition and rationale in context updates and gate artifacts.
-4. **Standing PR review-loop entry rule:** after any PR is opened — whether as a direct top-level user request or as the final step of a multi-step task, todo list, or gate workflow — immediately load the `pr-review-loop` skill and execute intake triage before declaring the overall task complete. The review loop is not optional and is not scoped only to explicit user review requests. Skipping this step after opening a PR is a workflow failure.
+4. **Standing PR review-loop entry rule:** after any PR is opened — whether as a direct top-level user request or as the final step of a multi-step task, todo list, or gate workflow — immediately load the `pr-review-loop` skill and execute its atomic entry sequence: request Copilot review, then start polling. Once the review is present, perform intake triage per the skill before declaring the overall task complete. The review loop is not optional and is not scoped only to explicit user review requests. Skipping this step after opening a PR is a workflow failure.
 
 ## Environment Policy
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -79,6 +79,7 @@ Status: semantic-closed | semantic-open (reason)
 
 6. **Ongoing check frequency:** verify sync status at minimum once per review loop completion (after 0-comments clean pass). If the PR has been open for multiple sessions or large changes have landed on the base branch since the PR was opened, also check before each fix-push batch.
 
+## 2. PR Review Intake Protocol
 
 1. Before summarizing PR feedback, offering to fix it, or editing code/docs, the agent must first enumerate each actionable review comment and classify it as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
 2. Each classification must include concise reasoning tied to scope, correctness, protocol alignment, or readability.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review-loop
-description: "PR review workflow: Copilot review loop, PR review intake triage, and Accept-vs-Challenge disposition. Use when: creating a PR, addressing PR review comments, running the Copilot review loop, classifying review feedback, resolving review threads, polling for Copilot review results, or handling review dispositions."
+description: "PR review workflow: Copilot review loop, PR review intake triage, and Accept-vs-Challenge disposition. Use when: creating a PR, addressing PR review comments, running the Copilot review loop, classifying review feedback, resolving review threads, polling for Copilot review results, or handling review dispositions. IMPORTANT: this skill also triggers automatically after any PR is opened as the final step of a multi-step workflow or todo list — not only when the user's top-level request is explicitly to create a PR."
 ---
 
 # PR Review Loop
@@ -56,7 +56,7 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 
 ## 3. Copilot Review Loop Protocol
 
-1. Immediately after creating a PR, the review-loop owner must request Copilot review on that PR and begin the bounded polling window. This is automatic and unconditional — the review-loop owner must not pause, ask for confirmation, or wait for PO input before entering the loop. PR creation and review-loop entry are a single atomic sequence.
+1. Immediately after creating a PR — whether the PR was opened in direct response to a user request **or** as the final step of a multi-step todo list or workflow — the review-loop owner must request Copilot review on that PR and begin the bounded polling window. This is automatic and unconditional — the review-loop owner must not pause, ask for confirmation, or wait for PO input before entering the loop. PR creation and review-loop entry are a single atomic sequence. The trigger is the act of opening a PR, not the scope of the originating user request.
 2. After pushing a commit that addresses PR feedback, the review-loop owner must request a fresh Copilot review on that PR before considering the review cycle complete.
 3. Once an active PR review loop has started, the review-loop owner must continue it automatically after each push and review request; it must not pause for another Product Owner prompt unless a blocker, protocol conflict, missing capability, or explicit owner-decision point is reached.
 4. The **only exit condition** from the review loop is when the latest Copilot review body semantically indicates **zero new comments**, including known variants such as **"generated 0 comments"**, **"0 new comments"**, or **"generated no new comments"**. Historical review records may remain on the PR; outdated or resolved threads do not count. The agent must not declare the loop complete based on thread-level analysis alone — the zero-comments result in the newest review is the sole pass criterion.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -21,7 +21,7 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 2. **Review arrives** → enumerate comments → classify each (Intake Protocol)
 3. **Execute dispositions** → fix accepted items, post challenge replies, escalate PO items
 4. **Reply to all threads** → push fixes → **[REVIEW REQUESTED]** → **[POLLING STARTED]** (single atomic sequence)
-5. **Exit Copilot polling loop** when the latest Copilot review body says "generated 0 comments" (or equivalent). **Complete the overall PR review workflow** only when both conditions are met: no `semantic-open` review threads remain from the latest pass, and all challenges are resolved with Product Owner.
+5. **Exit Copilot polling loop** when the latest Copilot review body says "generated 0 comments" (or equivalent). Before declaring merge-ready, verify the branch is up-to-date with the base branch (see Branch Sync Protocol, section 4). If behind, rebase, push, and re-enter the polling loop. **Complete the overall PR review workflow** only when both conditions are met: no `semantic-open` review threads remain from the latest pass, and all challenges are resolved with Product Owner.
 
 ## Review Loop Ownership
 
@@ -65,7 +65,20 @@ Status: semantic-closed | semantic-open (reason)
 
 ---
 
-## 2. PR Review Intake Protocol
+## 4. Branch Sync Protocol
+
+1. **Mandatory sync check before merge-ready declaration.** Before declaring any PR merge-ready, the review-loop owner must verify the PR branch is up-to-date with the base branch. The GitHub UI warning "This branch is out-of-date with the base branch" is the authoritative signal. A merge-ready declaration while the branch is behind the base is a workflow failure.
+
+2. **How to sync:** run `git fetch origin && git rebase origin/<base-branch>` on the PR branch. Resolve any conflicts. Push with `git push --force-with-lease` (never bare `--force`).
+
+3. **After a rebase push:** the PR head SHA changes and prior Copilot review passes are against a superseded SHA. Request a fresh Copilot review and re-enter the polling loop. Do not declare merge-ready until a clean pass (0 new comments) is received on the rebased head SHA.
+
+4. **Policy:** prefer `rebase` over `merge` for branch updates to maintain linear history and preserve rebase-merge compatibility.
+
+5. **If rebase fails** (non-trivial conflicts or history divergence): do not attempt to force-resolve. Surface the conflict summary to the Product Owner and await explicit authorization before proceeding.
+
+6. **Ongoing check frequency:** verify sync status at minimum once per review loop completion (after 0-comments clean pass). If the PR has been open for multiple sessions or large changes have landed on the base branch since the PR was opened, also check before each fix-push batch.
+
 
 1. Before summarizing PR feedback, offering to fix it, or editing code/docs, the agent must first enumerate each actionable review comment and classify it as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
 2. Each classification must include concise reasoning tied to scope, correctness, protocol alignment, or readability.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -20,7 +20,7 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 1. **Create PR** → review-loop owner immediately requests Copilot review → enter polling loop
 2. **Review arrives** → enumerate comments → classify each (Intake Protocol)
 3. **Execute dispositions** → fix accepted items, post challenge replies, escalate PO items
-4. **Push fixes** → request fresh Copilot review → poll again
+4. **Reply to all threads** → push fixes → request fresh Copilot review → poll again
 5. **Exit Copilot polling loop** when the latest Copilot review body says "generated 0 comments" (or equivalent). **Complete the overall PR review workflow** only when both conditions are met: no `semantic-open` review threads remain from the latest pass, and all challenges are resolved with Product Owner.
 
 ## Review Loop Ownership
@@ -39,8 +39,31 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 4. If feedback conflicts with approved protocol, prior owner decisions, or slice scope, the agent must decide whether it is (a) a `Challenge` that can be safely posted while the review loop continues unchanged, or (b) a true blocker / `Needs Product Owner Decision` item that would require changing approved direction, scope, or implementation before the loop can continue. Only case (b) requires pausing and requesting explicit Product Owner approval before changing course.
 5. Internal triage may classify an item as `Challenge`. The agent posts the `Challenge` reply on the PR thread immediately — including rationale, the safer alternative, and a citation of the grounding rule/decision — and continues the review loop without pausing. Once the loop reaches a clean pass (no `semantic-open` review threads remain from the latest pass), the agent presents all open challenges to the Product Owner one by one for final disposition. If the Product Owner overrides any challenge (decides to accept/fix), the agent implements the fix, re-enters the review loop, and repeats until both conditions are met: (1) no `semantic-open` review threads remain from the latest pass, and (2) all challenges resolved with Product Owner.
 6. Final disposition and rationale must be recorded in the relevant output (PR reply, handoff, or context update).
-7. When fixing a review comment, agents must also post a review response that explains their position: what was accepted or challenged, what changed (or why no change), and the rationale/tradeoff.
+7. **Thread reply is a required blocking step — not optional.** Posting a reply on the review thread is part of the disposition, not a follow-up. A disposition is `semantic-open` until the reply is posted, regardless of whether the code fix is already pushed or committed. An agent that pushes a fix without posting the thread reply has not completed the disposition.
 8. After an `Accept` or fully-executed `Challenge` disposition is completed, the agent must resolve the review thread when no Product Owner decision or reviewer follow-up remains.
+
+## 1B. Per-Comment Disposition Execution Checklist (Mandatory — Run for Every Actioned Comment)
+
+For every review comment actioned in a pass, execute these steps **in order**. No step may be skipped. The comment is `semantic-open` until all three are confirmed.
+
+1. **Fix** — implement the code or content change (Accept path) or document the rationale (Challenge path). Push is deferred until all comments in this pass have completed steps 1 and 2.
+2. **Reply** — post a reply on the GitHub PR review thread for this comment stating:
+   - Disposition: `Accept` / `Challenge` / `Needs PO Decision`
+   - What changed (Accept): brief description of the fix, or
+   - Why no change (Challenge): rationale, safer alternative, and citation of grounding rule/decision
+   - **This reply must be posted before the fix commit is pushed.** Pushing first and replying later is not permitted — the reply may be forgotten if the session ends between push and reply.
+3. **Resolve** — mark the thread resolved (or record as `semantically-closed/tooling-unresolved` if MCP lacks the capability).
+
+Log format per comment:
+```
+[DISPOSITION] Thread: <thread ID or comment excerpt>
+Step 1 Fix: ✅ implemented | ⏭ no change (Challenge)
+Step 2 Reply: ✅ posted | 🔴 MISSING — must post before push
+Step 3 Resolve: ✅ resolved | ⚠️ tooling-unresolved
+Status: semantic-closed | semantic-open (reason)
+```
+
+---
 
 ## 2. PR Review Intake Protocol
 
@@ -57,14 +80,16 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 ## 3. Copilot Review Loop Protocol
 
 1. Immediately after creating a PR — whether the PR was opened in direct response to a user request **or** as the final step of a multi-step todo list or workflow — the review-loop owner must request Copilot review on that PR and begin the bounded polling window. This is automatic and unconditional — the review-loop owner must not pause, ask for confirmation, or wait for PO input before entering the loop. PR creation and review-loop entry are a single atomic sequence. The trigger is the act of opening a PR, not the scope of the originating user request.
-2. After pushing a commit that addresses PR feedback, the review-loop owner must request a fresh Copilot review on that PR before considering the review cycle complete.
-3. Once an active PR review loop has started, the review-loop owner must continue it automatically after each push and review request; it must not pause for another Product Owner prompt unless a blocker, protocol conflict, missing capability, or explicit owner-decision point is reached.
-4. The **only exit condition** from the review loop is when the latest Copilot review body semantically indicates **zero new comments**, including known variants such as **"generated 0 comments"**, **"0 new comments"**, or **"generated no new comments"**. Historical review records may remain on the PR; outdated or resolved threads do not count. The agent must not declare the loop complete based on thread-level analysis alone — the zero-comments result in the newest review is the sole pass criterion.
-5. Each new Copilot comment must go through the PR Review Intake Protocol (section 2 above) before any additional changes are proposed or made.
-6. If the loop cannot continue because of a protocol conflict, missing capability, or explicit owner-decision point, the agent must pause, discuss the issue with the Product Owner, and proceed only with the agreed position.
-7. After requesting a fresh Copilot review, the agent must poll the live GitHub PR state for a bounded window before concluding the result is pending. Default polling window: up to 5 minutes at a practical cadence.
-8. Polling must use live GitHub MCP review data as the source of truth rather than relying on cached editor extension payloads.
-9. When a non-MCP polling fallback is used, prefer `node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>`.
-10. Review threads should normally be resolved as part of disposition execution.
-11. If no new Copilot review arrives within the bounded polling window, the agent must report that the loop is blocked on external async review completion.
-12. If a thread still remains outdated and unresolved after disposition execution, the agent must reconcile that thread state before declaring the loop complete, or explicitly record it as `semantically-closed/tooling-unresolved` when MCP lacks the required resolution capability.
+2. **Thread Reply Completeness Check (mandatory before every push):** Before pushing any fix commit, the review-loop owner must verify that a reply has been posted on every comment actioned in this pass. Run through the Per-Comment Disposition Execution Checklist (section 1B) for each comment and confirm Step 2 (Reply) shows ✅ for all. If any reply is missing, post it first — then push. Pushing without all replies posted is a workflow failure.
+
+3. After pushing a commit that addresses PR feedback, the review-loop owner must request a fresh Copilot review on that PR before considering the review cycle complete.
+4. Once an active PR review loop has started, the review-loop owner must continue it automatically after each push and review request; it must not pause for another Product Owner prompt unless a blocker, protocol conflict, missing capability, or explicit owner-decision point is reached.
+5. The **only exit condition** from the review loop is when the latest Copilot review body semantically indicates **zero new comments**, including known variants such as **"generated 0 comments"**, **"0 new comments"**, or **"generated no new comments"**. Historical review records may remain on the PR; outdated or resolved threads do not count. The agent must not declare the loop complete based on thread-level analysis alone — the zero-comments result in the newest review is the sole pass criterion.
+6. Each new Copilot comment must go through the PR Review Intake Protocol (section 2 above) before any additional changes are proposed or made.
+7. If the loop cannot continue because of a protocol conflict, missing capability, or explicit owner-decision point, the agent must pause, discuss the issue with the Product Owner, and proceed only with the agreed position.
+8. After requesting a fresh Copilot review, the agent must poll the live GitHub PR state for a bounded window before concluding the result is pending. Default polling window: up to 5 minutes at a practical cadence.
+9. Polling must use live GitHub MCP review data as the source of truth rather than relying on cached editor extension payloads.
+10. When a non-MCP polling fallback is used, prefer `node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>`.
+11. Review threads should normally be resolved as part of disposition execution.
+12. If no new Copilot review arrives within the bounded polling window, the agent must report that the loop is blocked on external async review completion.
+13. If a thread still remains outdated and unresolved after disposition execution, the agent must reconcile that thread state before declaring the loop complete, or explicitly record it as `semantically-closed/tooling-unresolved` when MCP lacks the required resolution capability.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -17,10 +17,10 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 
 ## Procedure Overview
 
-1. **Create PR** → review-loop owner immediately requests Copilot review → enter polling loop
+1. **Create PR** → **[REVIEW REQUESTED]** → **[POLLING STARTED]** (single atomic sequence — no step between request and poll)
 2. **Review arrives** → enumerate comments → classify each (Intake Protocol)
 3. **Execute dispositions** → fix accepted items, post challenge replies, escalate PO items
-4. **Reply to all threads** → push fixes → request fresh Copilot review → poll again
+4. **Reply to all threads** → push fixes → **[REVIEW REQUESTED]** → **[POLLING STARTED]** (single atomic sequence)
 5. **Exit Copilot polling loop** when the latest Copilot review body says "generated 0 comments" (or equivalent). **Complete the overall PR review workflow** only when both conditions are met: no `semantic-open` review threads remain from the latest pass, and all challenges are resolved with Product Owner.
 
 ## Review Loop Ownership
@@ -82,12 +82,12 @@ Status: semantic-closed | semantic-open (reason)
 1. Immediately after creating a PR — whether the PR was opened in direct response to a user request **or** as the final step of a multi-step todo list or workflow — the review-loop owner must request Copilot review on that PR and begin the bounded polling window. This is automatic and unconditional — the review-loop owner must not pause, ask for confirmation, or wait for PO input before entering the loop. PR creation and review-loop entry are a single atomic sequence. The trigger is the act of opening a PR, not the scope of the originating user request.
 2. **Thread Reply Completeness Check (mandatory before every push):** Before pushing any fix commit, the review-loop owner must verify that a reply has been posted on every comment actioned in this pass. Run through the Per-Comment Disposition Execution Checklist (section 1B) for each comment and confirm Step 2 (Reply) shows ✅ for all. If any reply is missing, post it first — then push. Pushing without all replies posted is a workflow failure.
 
-3. After pushing a commit that addresses PR feedback, the review-loop owner must request a fresh Copilot review on that PR before considering the review cycle complete.
+3. After pushing a commit that addresses PR feedback, the review-loop owner must request a fresh Copilot review and immediately begin polling. Review request and polling are a single atomic sequence — see rule 8 below.
 4. Once an active PR review loop has started, the review-loop owner must continue it automatically after each push and review request; it must not pause for another Product Owner prompt unless a blocker, protocol conflict, missing capability, or explicit owner-decision point is reached.
 5. The **only exit condition** from the review loop is when the latest Copilot review body semantically indicates **zero new comments**, including known variants such as **"generated 0 comments"**, **"0 new comments"**, or **"generated no new comments"**. Historical review records may remain on the PR; outdated or resolved threads do not count. The agent must not declare the loop complete based on thread-level analysis alone — the zero-comments result in the newest review is the sole pass criterion.
 6. Each new Copilot comment must go through the PR Review Intake Protocol (section 2 above) before any additional changes are proposed or made.
 7. If the loop cannot continue because of a protocol conflict, missing capability, or explicit owner-decision point, the agent must pause, discuss the issue with the Product Owner, and proceed only with the agreed position.
-8. After requesting a fresh Copilot review, the agent must poll the live GitHub PR state for a bounded window before concluding the result is pending. Default polling window: up to 5 minutes at a practical cadence.
+8. **Review request and polling are a single atomic sequence (no gap permitted).** The tool call return value from the review request — including `(empty)` — is a trigger to begin polling immediately. It is not a completion signal, not a status, and not a reason to summarize or report. Any return value from the review request tool must be followed by polling without pause. Immediately after calling the review request tool, emit the log entry `[REVIEW REQUESTED] → [POLLING STARTED]` and begin the polling window. If this log entry is absent, the atomic sequence was broken — that is a workflow failure.
 9. Polling must use live GitHub MCP review data as the source of truth rather than relying on cached editor extension payloads.
 10. When a non-MCP polling fallback is used, prefer `node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>`.
 11. Review threads should normally be resolved as part of disposition execution.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -65,20 +65,6 @@ Status: semantic-closed | semantic-open (reason)
 
 ---
 
-## 4. Branch Sync Protocol
-
-1. **Mandatory sync check before merge-ready declaration.** Before declaring any PR merge-ready, the review-loop owner must verify the PR branch is up-to-date with the base branch. The GitHub UI warning "This branch is out-of-date with the base branch" is the authoritative signal. A merge-ready declaration while the branch is behind the base is a workflow failure.
-
-2. **How to sync:** run `git fetch origin && git rebase origin/<base-branch>` on the PR branch. Resolve any conflicts. Push with `git push --force-with-lease` (never bare `--force`).
-
-3. **After a rebase push:** the PR head SHA changes and prior Copilot review passes are against a superseded SHA. Request a fresh Copilot review and re-enter the polling loop. Do not declare merge-ready until a clean pass (0 new comments) is received on the rebased head SHA.
-
-4. **Policy:** prefer `rebase` over `merge` for branch updates to maintain linear history and preserve rebase-merge compatibility.
-
-5. **If rebase fails** (non-trivial conflicts or history divergence): do not attempt to force-resolve. Surface the conflict summary to the Product Owner and await explicit authorization before proceeding.
-
-6. **Ongoing check frequency:** verify sync status at minimum once per review loop completion (after 0-comments clean pass). If the PR has been open for multiple sessions or large changes have landed on the base branch since the PR was opened, also check before each fix-push batch.
-
 ## 2. PR Review Intake Protocol
 
 1. Before summarizing PR feedback, offering to fix it, or editing code/docs, the agent must first enumerate each actionable review comment and classify it as `Accept`, `Challenge`, or `Needs Product Owner Decision`.
@@ -107,3 +93,17 @@ Status: semantic-closed | semantic-open (reason)
 11. Review threads should normally be resolved as part of disposition execution.
 12. If no new Copilot review arrives within the bounded polling window, the agent must report that the loop is blocked on external async review completion.
 13. If a thread still remains outdated and unresolved after disposition execution, the agent must reconcile that thread state before declaring the loop complete, or explicitly record it as `semantically-closed/tooling-unresolved` when MCP lacks the required resolution capability.
+
+## 4. Branch Sync Protocol
+
+1. **Mandatory sync check before merge-ready declaration.** Before declaring any PR merge-ready, the review-loop owner must verify the PR branch is up-to-date with the base branch. The GitHub UI warning "This branch is out-of-date with the base branch" is the authoritative signal. A merge-ready declaration while the branch is behind the base is a workflow failure.
+
+2. **How to sync:** run `git fetch origin && git rebase origin/<base-branch>` on the PR branch. Resolve any conflicts. Push with `git push --force-with-lease` (never bare `--force`).
+
+3. **After a rebase push:** the PR head SHA changes and prior Copilot review passes are against a superseded SHA. Request a fresh Copilot review and re-enter the polling loop. Do not declare merge-ready until a clean pass (0 new comments) is received on the rebased head SHA.
+
+4. **Policy:** prefer `rebase` over `merge` for branch updates to maintain linear history and preserve rebase-merge compatibility.
+
+5. **If rebase fails** (non-trivial conflicts or history divergence): do not attempt to force-resolve. Surface the conflict summary to the Product Owner and await explicit authorization before proceeding.
+
+6. **Ongoing check frequency:** verify sync status at minimum once per review loop completion (after 0-comments clean pass). If the PR has been open for multiple sessions or large changes have landed on the base branch since the PR was opened, also check before each fix-push batch.

--- a/.github/skills/ux-design-execution/SKILL.md
+++ b/.github/skills/ux-design-execution/SKILL.md
@@ -232,9 +232,9 @@ Before creating any frame, run this scan in full. The purpose is to surface all 
 1. **Component inventory check:** For every component in the Frame Blueprint, verify whether it exists in the TV Library (`design_system_library_file_key`) and is published. Record: component name, layer (L1/L2/L3), exists: YES/NO, published: YES/NO.
 
 2. **Token namespace check:** Call `figma.variables.getLocalVariables()` in the DS library (fresh). This is the single `[TOKEN LIST FETCH]` for the gate run — log it now in the format below and reuse this list for all token-exists checks through to Step 4. For every token referenced in the Frame Blueprint, confirm it exists by semantic name. Record: token name, exists: YES/NO.
-```
-[TOKEN LIST FETCH] DS library key: <key> | timestamp: <ISO timestamp> | variable count: <n>
-```
+   ```
+   [TOKEN LIST FETCH] DS library key: <key> | timestamp: <ISO timestamp> | variable count: <n>
+   ```
 
 3. **Library publish state check:** Verify no pending unpublished changes exist in the DS library from prior sessions. If any exist, surface them now.
 

--- a/.github/skills/ux-design-execution/SKILL.md
+++ b/.github/skills/ux-design-execution/SKILL.md
@@ -238,11 +238,14 @@ Before creating any frame, run this scan in full. The purpose is to surface all 
 
 3. **Library publish state check:** Verify no pending unpublished changes exist in the DS library from prior sessions. If any exist, surface them now.
 
-4. **Baseline state check (continuation slices):** Confirm the `[IN PROGRESS]` section does not already exist on the target page (which would indicate a prior blocked session). If it does, check `docs/slices/<slice-name>/context-log.md` for a `gate-status: BLOCKED_AWAITING_PO` marker before proceeding.
+4. **Baseline state check (continuation slices):** Inspect the target page and `docs/slices/<slice-name>/context-log.md` together and classify the state explicitly:
+   - **No `[IN PROGRESS]` section present:** pass the baseline check and continue normally.
+   - **`[IN PROGRESS]` section present + `gate-status: BLOCKED_AWAITING_PO` marker present in the context log:** treat this as a valid resume path from a previously blocked session. Resume from the blocked point only. Do **not** re-run completed pre-flight checks or recreate frames/components already completed in the prior attempt unless the PO explicitly authorizes rework.
+   - **`[IN PROGRESS]` section present + no `gate-status: BLOCKED_AWAITING_PO` marker in the context log:** treat this as a baseline ambiguity/corruption gap. Do **not** proceed with frame execution. Raise it to the PO for confirmation on whether to resume, reset, or discard the prior partial state.
 
-**If any check returns a gap:** consolidate all gaps into a single PO message listing every missing component, unpublished change, token gap, and baseline ambiguity — with the specific authorization or action required for each. Do NOT begin frame execution until the PO message has been sent and all authorizations received.
+**If any check returns a gap:** consolidate all gaps into a single PO message listing every missing component, unpublished change, token gap, and baseline ambiguity (including any `[IN PROGRESS]` section without a matching `gate-status: BLOCKED_AWAITING_PO` marker) — with the specific authorization or action required for each. Do NOT begin frame execution until the PO message has been sent and all authorizations received.
 
-**If all checks pass:** record `[PRE-FLIGHT] All checks passed — proceeding to Step 4` and continue.
+**If all checks pass:** record the applicable pre-flight status and continue — either `[PRE-FLIGHT] All checks passed — proceeding to Step 4` for a clean start, or `[PRE-FLIGHT] Resume path confirmed via BLOCKED_AWAITING_PO marker — resuming from blocked point` for a continuation that must not re-run completed steps.
 
 ---
 
@@ -434,14 +437,14 @@ If a loop-back condition requires PO input and the session ends before a respons
 
 1. Write the following marker to the slice context log (`docs/slices/<slice-name>/context-log.md`) before the session closes:
 
-```
-gate-status: BLOCKED_AWAITING_PO
-gate: 3A
-blocked-at: <Step N — description>
-blocker: <exact loop-back condition description>
-frames-in-progress: <list of frame names and node IDs created so far>
-timestamp: <ISO timestamp>
-```
+   ```
+   gate-status: BLOCKED_AWAITING_PO
+   gate: 3A
+   blocked-at: <Step N — description>
+   blocker: <exact loop-back condition description>
+   frames-in-progress: <list of frame names and node IDs created so far>
+   timestamp: <ISO timestamp>
+   ```
 
 2. On **any resume of Gate 3A**, before executing any frame step, check the context log for this marker. If found:
    - Read the blocker description.

--- a/.github/skills/ux-design-execution/SKILL.md
+++ b/.github/skills/ux-design-execution/SKILL.md
@@ -188,7 +188,22 @@ Produce before ANY frame creation:
 
 ### Cross-Screen Reuse Scan (Mandatory Before Classifying Any Element as Screen-Local)
 
-Before finalising the Frame Blueprint, review every **structural element** in the layout with this question:
+**First: enumerate the full Figma file context (mandatory before any reuse judgment).**
+
+1. Call MCP to list all pages in the Figma file.
+2. For each page, list all top-level sections and their names.
+3. Filter sections to those ending with `[APPROVED]` — these represent all previously shipped screens.
+4. Record the page name, section name, and node ID for each `[APPROVED]` section.
+5. This inventory is the complete screen universe against which reuse is evaluated. Without it, the reuse question cannot be answered correctly.
+
+Log the result as:
+```
+[REUSE SCAN — FILE INVENTORY]
+Pages found: <list>
+APPROVED sections found: <list with page, section name, node ID>
+```
+
+Only after the inventory is recorded, review every **structural element** in the layout with this question:
 
 > *Could this element plausibly appear on any other screen in the product, now or in the future?*
 
@@ -208,6 +223,26 @@ If **any signal applies**, stop and resolve it as a DS component gap (see Step 4
 
 Elements that are genuinely screen-local (e.g., a one-off decorative illustration, a screen-specific hero layout) must be explicitly flagged as such in the blueprint output with a one-line justification.
 
+## Step 3B — Pre-Flight Gap Scan (Run Before Step 4 — Consolidates All Blockers Into One PO Question)
+
+Before creating any frame, run this scan in full. The purpose is to surface all likely blocking conditions in a single pass and ask the Product Owner one consolidated question — rather than hitting gaps sequentially mid-execution.
+
+**Required checks (all must be run before frame creation begins):**
+
+1. **Component inventory check:** For every component in the Frame Blueprint, verify whether it exists in the TV Library (`design_system_library_file_key`) and is published. Record: component name, layer (L1/L2/L3), exists: YES/NO, published: YES/NO.
+
+2. **Token namespace check:** Call `figma.variables.getLocalVariables()` in the DS library (fresh — record the timestamp). For every token referenced in the Frame Blueprint, confirm it exists by semantic name. Record: token name, exists: YES/NO.
+
+3. **Library publish state check:** Verify no pending unpublished changes exist in the DS library from prior sessions. If any exist, surface them now.
+
+4. **Baseline state check (continuation slices):** Confirm the `[IN PROGRESS]` section does not already exist on the target page (which would indicate a prior blocked session). If it does, check `.github/docs/slices/<slice-name>/context-log.md` for a `gate-status: BLOCKED_AWAITING_PO` marker before proceeding.
+
+**If any check returns a gap:** consolidate all gaps into a single PO message listing every missing component, unpublished change, token gap, and baseline ambiguity — with the specific authorization or action required for each. Do NOT begin frame execution until the PO message has been sent and all authorizations received.
+
+**If all checks pass:** record `[PRE-FLIGHT] All checks passed — proceeding to Step 4` and continue.
+
+---
+
 ## Step 4 — Component Coverage Check (Self-Blocking)
 
 Before creating any frame, verify every declared component:
@@ -219,7 +254,14 @@ No frame creation until all declared components pass their layer check. Document
 
 ### Token-Exists Check (Mandatory Before Creating Any Variable)
 
-Before creating any new Figma variable or token, call `figma.variables.getLocalVariables()` in the DS library and search for existing variables that cover the same semantic role.
+**Fresh-fetch requirement:** At the start of gate execution (or on session resume), call `figma.variables.getLocalVariables()` in the DS library and record the fetch timestamp. This list must be fetched fresh — do NOT use a variable list from a prior session or earlier in the same session without re-fetching. All token-exists checks in this gate run must reference the timestamped list.
+
+Log format:
+```
+[TOKEN LIST FETCH] DS library key: <key> | timestamp: <ISO timestamp> | variable count: <n>
+```
+
+Before creating any new Figma variable or token, search the timestamped list for existing variables that cover the same semantic role.
 
 **A new variable must NOT be created if:**
 
@@ -388,6 +430,29 @@ Any unexpected finding during frame execution (missing component, variable bindi
 
 Do NOT patch inline. Await instruction.
 
+### Blocked-State Persistence (Mandatory on Session Close While Awaiting PO)
+
+If a loop-back condition requires PO input and the session ends before a response is received:
+
+1. Write the following marker to the slice context log (`docs/slices/<slice-name>/context-log.md`) before the session closes:
+
+```
+gate-status: BLOCKED_AWAITING_PO
+gate: 3A
+blocked-at: <Step N — description>
+blocker: <exact loop-back condition description>
+frames-in-progress: <list of frame names and node IDs created so far>
+timestamp: <ISO timestamp>
+```
+
+2. On **any resume of Gate 3A**, before executing any frame step, check the context log for this marker. If found:
+   - Read the blocker description.
+   - Surface the unresolved blocker to PO and wait for authorization before continuing.
+   - Do NOT re-execute any step that was already completed before the block. Use the `frames-in-progress` list to identify what exists.
+   - Only remove the `gate-status: BLOCKED_AWAITING_PO` marker after PO has explicitly authorized continuation.
+
+Skipping this check on resume and re-executing Phase 1 will create duplicate `[IN PROGRESS]` sections. This is a protocol violation.
+
 ## Step 10 — End-of-Pass Full Verification Sweep
 
 Before declaring any frame pass complete (Phase 1 or Phase 2), run a final systematic read-back sweep across every node modified in this pass:
@@ -496,7 +561,35 @@ Before presenting any frame to Product Owner, answer every question. Any NO is a
 | 9 | Would this frame look at home alongside Threads, Reddit, or Discord in the App Store? | YES |
 | 10 | Is the visual rhythm (font scale, spacing, colour saturation, border radius) consistent with other `[APPROVED]` frames in this file? | YES |
 
-Q10 requires: take a screenshot of the nearest `[APPROVED]` section baseline frame and compare side by side. Font scales, spacing rhythm, colour saturation, and border radius patterns must feel like the same product. If anything feels out of family, fix it before presenting.
+Q10 requires both a visual check AND objective MCP read-back consistency checks:
+
+**Visual check:** take a screenshot of the nearest `[APPROVED]` section baseline frame and compare side by side. Font scales, spacing rhythm, colour saturation, and border radius patterns must feel like the same product.
+
+**MCP consistency checks (mandatory — must accompany the visual check):** select the nearest `[APPROVED]` baseline frame and read the following properties via MCP, then read the same properties from the new frame and compare value-for-value:
+
+| Property | How to read | Pass condition |
+|---|---|---|
+| Primary text token | `fills[0].boundVariables.color.id` on the primary text node | Same variable ID |
+| Card corner radii | `topLeftRadius`, `topRightRadius`, `bottomLeftRadius`, `bottomRightRadius` on a Card instance | All 4 values identical |
+| Container padding | `paddingTop`, `paddingBottom`, `paddingLeft`, `paddingRight` on the outermost content frame | All values identical |
+| Section gap | `itemSpacing` on the primary vertical auto-layout frame | Same value |
+| Surface fill token | `fills[0].boundVariables.color.id` on the screen background frame | Same variable ID |
+
+Log the result as:
+```
+[Q10 CONSISTENCY CHECK]
+Baseline frame: <node ID>
+New frame: <node ID>
+Primary text token: baseline=<id> / new=<id> | match: YES/NO
+Card radii (TL/TR/BL/BR): baseline=<values> / new=<values> | match: YES/NO
+Container padding: baseline=<values> / new=<values> | match: YES/NO
+Section gap: baseline=<value> / new=<value> | match: YES/NO
+Surface fill token: baseline=<id> / new=<id> | match: YES/NO
+Visual check: same product family: YES/NO
+Q10 result: PASS / FAIL
+```
+
+Any NO in the MCP checks is a blocker — fix the mismatched property before presenting, even if the visual check passed. The visual check alone is not sufficient.
 
 **Log format for this step:**
 

--- a/.github/skills/ux-design-execution/SKILL.md
+++ b/.github/skills/ux-design-execution/SKILL.md
@@ -231,11 +231,14 @@ Before creating any frame, run this scan in full. The purpose is to surface all 
 
 1. **Component inventory check:** For every component in the Frame Blueprint, verify whether it exists in the TV Library (`design_system_library_file_key`) and is published. Record: component name, layer (L1/L2/L3), exists: YES/NO, published: YES/NO.
 
-2. **Token namespace check:** Call `figma.variables.getLocalVariables()` in the DS library (fresh — record the timestamp). For every token referenced in the Frame Blueprint, confirm it exists by semantic name. Record: token name, exists: YES/NO.
+2. **Token namespace check:** Call `figma.variables.getLocalVariables()` in the DS library (fresh). This is the single `[TOKEN LIST FETCH]` for the gate run — log it now in the format below and reuse this list for all token-exists checks through to Step 4. For every token referenced in the Frame Blueprint, confirm it exists by semantic name. Record: token name, exists: YES/NO.
+```
+[TOKEN LIST FETCH] DS library key: <key> | timestamp: <ISO timestamp> | variable count: <n>
+```
 
 3. **Library publish state check:** Verify no pending unpublished changes exist in the DS library from prior sessions. If any exist, surface them now.
 
-4. **Baseline state check (continuation slices):** Confirm the `[IN PROGRESS]` section does not already exist on the target page (which would indicate a prior blocked session). If it does, check `.github/docs/slices/<slice-name>/context-log.md` for a `gate-status: BLOCKED_AWAITING_PO` marker before proceeding.
+4. **Baseline state check (continuation slices):** Confirm the `[IN PROGRESS]` section does not already exist on the target page (which would indicate a prior blocked session). If it does, check `docs/slices/<slice-name>/context-log.md` for a `gate-status: BLOCKED_AWAITING_PO` marker before proceeding.
 
 **If any check returns a gap:** consolidate all gaps into a single PO message listing every missing component, unpublished change, token gap, and baseline ambiguity — with the specific authorization or action required for each. Do NOT begin frame execution until the PO message has been sent and all authorizations received.
 
@@ -254,12 +257,7 @@ No frame creation until all declared components pass their layer check. Document
 
 ### Token-Exists Check (Mandatory Before Creating Any Variable)
 
-**Fresh-fetch requirement:** At the start of gate execution (or on session resume), call `figma.variables.getLocalVariables()` in the DS library and record the fetch timestamp. This list must be fetched fresh — do NOT use a variable list from a prior session or earlier in the same session without re-fetching. All token-exists checks in this gate run must reference the timestamped list.
-
-Log format:
-```
-[TOKEN LIST FETCH] DS library key: <key> | timestamp: <ISO timestamp> | variable count: <n>
-```
+**Fetch protocol:** Reuse the timestamped `[TOKEN LIST FETCH]` logged in Step 3B pre-flight for all token-exists checks in this gate run. Do NOT fetch again unless the DS library was published or known to have changed since Step 3B completed. On session resume (no Step 3B in scope), call `figma.variables.getLocalVariables()` fresh and log a new `[TOKEN LIST FETCH]` entry before proceeding.
 
 Before creating any new Figma variable or token, search the timestamped list for existing variables that cover the same semantic role.
 


### PR DESCRIPTION
Closes #114

## Summary

Hardens three skill/agent files with 8 identified protocol gaps across two concerns: `ux-design-execution` execution correctness, and `pr-review-loop` review discipline (auto-entry, mandatory thread replies, atomic polling).

---

## Changes — `ux-design-execution` (5 gaps)

### Gap 1 — Pre-Flight Gap Scan (new Step 3B)
Consolidated pre-flight step before frame execution.

### Gap 2 — Blocked-State Persistence (Step 9)
`gate-status: BLOCKED_AWAITING_PO` marker on session close.

### Gap 3 — QG-6 Q10 MCP Consistency Checks
MCP read-back table replaces visual-only Q10.

### Gap 4 — Cross-Screen Reuse Scan File Enumeration (Step 3)
Figma page+section enumeration required before reuse judgment.

### Gap 5 — Token-Exists Check Fresh-Fetch (Step 4)
Fresh-fetch + ISO timestamp required at gate execution start.

---

## Changes — `pr-review-loop` (3 gaps)

### Gap 6 — Review Loop Not Entered After Multi-Step Workflow PR Creation
- `pr-review-loop/SKILL.md` description and rule 1 updated with multi-step trigger.
- `architect-orchestrator.agent.md` standing rule #4 added.

### Gap 7 — Thread Reply Skipped After Fix Push
- Section 1B: Per-Comment Disposition Execution Checklist (Fix → Reply → Resolve; reply before push).
- Rule 1.7 upgraded to blocking-step language.
- Rule 3.2: Thread Reply Completeness Check pre-push gate.

### Gap 8 — Polling Skipped After Review Request
**Root cause:** `(empty)` return from review request tool was treated as a completion signal. Rule 3.8's "before concluding" framing left room to skip polling if the agent didn't perceive itself as concluding anything.

**Fix:**
- Rule 3.8 rewritten: review request and polling are a single atomic sequence. Any return value (including `(empty)`) is a trigger to begin polling immediately — not a completion signal.
- Mandatory `[REVIEW REQUESTED] → [POLLING STARTED]` log entry added; absence = workflow failure.
- Rule 3.3 and Procedure Overview steps 1 and 4 updated to show the atomic sequence label explicitly.

---

## Files Changed

| File | Change |
|---|---|
| `.github/skills/ux-design-execution/SKILL.md` | +96 / -3 (Gaps 1–5) |
| `.github/skills/pr-review-loop/SKILL.md` | +42 / -17 (Gaps 6–8) |
| `.github/agents/architect-orchestrator.agent.md` | standing rule #4 added (Gap 6) |