### PR TITLE
fix: Podium chip WCAG 2.5.3 Label in Name — dynamic aria-label for Tark/Vitark sides

### DIFF
--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -115,7 +115,7 @@ When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld)
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
   const view = activeRender(this);
 
-  const chip = view.getByRole('switch', { name: 'Post as Tark' });
+  const chip = view.getByRole('switch', { name: 'Post as Vitark' });
   assert.ok(chip);
   assert.equal(chip.getAttribute('aria-checked'), 'false');
 });

--- a/src/components/Podium.tsx
+++ b/src/components/Podium.tsx
@@ -52,7 +52,7 @@ export function Podium({ selectedSide, onSideChange, onPublish }: PodiumProps) {
                     type="button"
                     role="switch"
                     className={`podium__chip podium__chip--${selectedSide}`}
-                    aria-label="Post as Tark"
+                    aria-label={`Post as ${sideLabel}`}
                     aria-checked={selectedSide === 'tark'}
                     onClick={() => onSideChange(nextSide)}
                 >

--- a/tests/a11y/podium-a11y.test.tsx
+++ b/tests/a11y/podium-a11y.test.tsx
@@ -120,10 +120,10 @@ describe('Podium ARIA semantics', () => {
             />
         );
 
-        const chip = screen.getByRole('switch', { name: 'Post as Tark' });
+        const chip = screen.getByRole('switch', { name: 'Post as Vitark' });
         expect(chip).toBeInTheDocument();
         expect(chip).toHaveAttribute('role', 'switch');
         expect(chip).toHaveAttribute('aria-checked', 'false');
-        expect(chip).toHaveAccessibleName('Post as Tark');
+        expect(chip).toHaveAccessibleName('Post as Vitark');
     });
 });

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -77,7 +77,7 @@ describe('DebateScreen', () => {
 
         fireEvent.click(screen.getByRole('switch', { name: 'Post as Tark' }));
 
-        const chip = screen.getByRole('switch', { name: 'Post as Tark' });
+        const chip = screen.getByRole('switch', { name: 'Post as Vitark' });
         expect(chip).toBeInTheDocument();
         expect(chip).toHaveAttribute('aria-checked', 'false');
     });
@@ -122,7 +122,7 @@ describe('DebateScreen', () => {
         const { unmount } = render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('switch', { name: 'Post as Tark' }));
-        expect(screen.getByRole('switch', { name: 'Post as Tark' })).toHaveAttribute('aria-checked', 'false');
+        expect(screen.getByRole('switch', { name: 'Post as Vitark' })).toHaveAttribute('aria-checked', 'false');
 
         unmount();
         render(<DebateScreen />);

--- a/tests/components/Podium.test.tsx
+++ b/tests/components/Podium.test.tsx
@@ -168,6 +168,36 @@ describe('Podium', () => {
         expect(onSideChange).toHaveBeenCalledWith('vitark');
     });
 
+    it('chip aria-label matches visible text — Tark side', () => {
+        render(
+            <Podium
+                selectedSide="tark"
+                onSideChange={() => {}}
+                onPublish={() => {}}
+            />
+        );
+
+        const chip = screen.getByRole('switch', { name: 'Post as Tark' });
+        expect(chip).toBeInTheDocument();
+        expect(chip).toHaveTextContent('Tark');
+        expect(chip).toHaveAttribute('aria-label', 'Post as Tark');
+    });
+
+    it('chip aria-label matches visible text — Vitark side', () => {
+        render(
+            <Podium
+                selectedSide="vitark"
+                onSideChange={() => {}}
+                onPublish={() => {}}
+            />
+        );
+
+        const chip = screen.getByRole('switch', { name: 'Post as Vitark' });
+        expect(chip).toBeInTheDocument();
+        expect(chip).toHaveTextContent('Vitark');
+        expect(chip).toHaveAttribute('aria-label', 'Post as Vitark');
+    });
+
     it('defines fixed and desktop full-width layout rules in podium.css source', () => {
         expect(podiumCss).toContain('position: fixed;');
         expect(podiumCss).toContain('--podium-height: calc(109px + env(safe-area-inset-bottom, 0px));');


### PR DESCRIPTION
## Problem

The Podium chip uses `role="switch"` + `aria-checked` + static `aria-label="Post as Tark"` (merged in PR #112, closes #110).

The chip's **visible text toggles** between `"Tark"` and `"Vitark"` depending on the selected side. When the selected side is **Vitark**, the accessible name (`"Post as Tark"`) does not contain the visible label text (`"Vitark"`), violating **WCAG 2.5.3 Label in Name** (Level A).

## Solution

The chip's `aria-label` is now computed dynamically to match the currently visible label:
- Side = `tark` → `aria-label="Post as Tark"` (no change from current)
- Side = `vitark` → `aria-label="Post as Vitark"`

`role="switch"` and `aria-checked` remain unchanged.

## Implementation Details

**Files Changed:**
- `src/components/Podium.tsx` — aria-label now uses template literal with `sideLabel` variable
- `tests/components/Podium.test.tsx` — added dedicated tests for both sides
- `tests/a11y/podium-a11y.test.tsx` — updated vitark test to expect correct label
- `tests/components/DebateScreen.test.tsx` — updated integration tests to expect correct dynamic labels

## BDD Evidence

### Scenario-to-Test Mapping

| Acceptance Criterion | Test File | Test Name |
|---------------------|-----------|-----------|
| AC-1: Tark side aria-label | `tests/components/Podium.test.tsx` | "chip aria-label matches visible text — Tark side" |
| AC-1: Vitark side aria-label | `tests/components/Podium.test.tsx` | "chip aria-label matches visible text — Vitark side" |
| AC-2: Role preserved | `tests/a11y/podium-a11y.test.tsx` | "chip button uses role=\"switch\" and aria-checked for tark side" |
| AC-2: State preserved | `tests/a11y/podium-a11y.test.tsx` | "chip button uses role=\"switch\" and aria-checked for vitark side" |
| AC-3 & AC-4: All tests pass | Full test suite | 265 tests pass |

### Test-First Approach

1. **Red**: Updated tests to expect dynamic aria-labels → 2 tests failed
2. **Green**: Implemented dynamic aria-label using template literal → all tests passed
3. **Refactor**: N/A (minimal change, no refactoring needed)

## Verification Evidence

### Tests
```
✓ tests/components/Podium.test.tsx (9 tests) 174ms
  ✓ chip aria-label matches visible text — Tark side
  ✓ chip aria-label matches visible text — Vitark side
✓ tests/a11y/podium-a11y.test.tsx (6 tests) 166ms
  ✓ chip button uses role="switch" and aria-checked for tark side
  ✓ chip button uses role="switch" and aria-checked for vitark side
✓ tests/components/DebateScreen.test.tsx (15 tests) 328ms

Test Files  19 passed (19)
     Tests  265 passed (265)
```

### Build
```
✓ tsc (type check)
✓ vite build
```

## Execution-Agent

`dev`

## Closes

Closes #116

## References

- WCAG 2.5.3: https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html
- Slice: `docs/slices/post-tark-vitark/`
- Parent issue: #110 (closed)
- Original fix: PR #112

## Residual Risk

None. This is a straightforward accessibility fix with complete test coverage.

## Rollback Note

If rollback is needed, revert commit `03f6a5d` to restore static aria-label.

## Runtime QA Handoff Package

Not applicable — this is a non-visual accessibility fix that does not impact UI rendering or user journeys. The accessible name change is only detectable via assistive technology or testing library queries.

---

**Quality Gates Status:**
- ✅ All acceptance criteria satisfied
- ✅ BDD scenario-to-test mapping complete
- ✅ 265 tests pass (includes 2 new dedicated tests)
- ✅ No architecture contract violations
- ✅ TypeScript build passes
- ✅ Issue-closing reference included
- ✅ Execution-Agent provenance marker included