### PR TITLE
feat: MCP orchestrator disk persistence + VS Code agent-status extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ __pycache__/
 *.pyc
 
 # Editor / IDE
-.vscode/
+.vscode/*
+!.vscode/mcp.json
 
 # OS artifacts
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules/
 # Build output
 dist/
 
+# Runtime agent logs (generated at runtime, not source)
+logs/parallel-agents/
+
 # Python cache artifacts
 __pycache__/
 *.pyc

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,47 @@
+{
+    "servers": {
+        "agent-orchestrator": {
+            "type": "stdio",
+            "command": "npx",
+            "args": [
+                "--yes",
+                "--package",
+                "@github/copilot-sdk@^0.2.2",
+                "--package",
+                "@modelcontextprotocol/sdk@^1.10.2",
+                "--package",
+                "tsx",
+                "tsx",
+                "${workspaceFolder}/scripts/mcp-dev-orchestrator.ts"
+            ]
+        },
+        "com.figma.mcp/mcp": {
+            "type": "http",
+            "url": "https://mcp.figma.com/mcp",
+            "_toolPrefixes": [
+                "com.figma.mcp"
+            ]
+        },
+        "io.github.github/github-mcp-server": {
+            "type": "http",
+            "url": "https://api.githubcopilot.com/mcp/",
+            "_toolPrefixes": [
+                "github",
+                "io.github.github"
+            ]
+        },
+        "io.github.ChromeDevTools/chrome-devtools-mcp": {
+            "type": "stdio",
+            "command": "npx",
+            "args": [
+                "--registry",
+                "https://registry.npmjs.org",
+                "chrome-devtools-mcp@0.21.0"
+            ],
+            "_toolPrefixes": [
+                "io.github.chromedevtools",
+                "io.github.ChromeDevTools"
+            ]
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@cucumber/cucumber": "^11.3.0",
+        "@github/copilot-sdk": "^0.2.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -27,7 +29,8 @@
         "typescript": "^5.8.3",
         "vite": "^6.3.1",
         "vite-plugin-pwa": "^0.21.1",
-        "vitest": "^3.1.1"
+        "vitest": "^3.1.1",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2532,6 +2535,154 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@github/copilot": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.31.tgz",
+      "integrity": "sha512-AfoVW9pHsKQGtLCpPcvQ8TOwBVF8meo5srle/8cqRSsx882CpIQx5C4uNs6zwrCtqMTo8M8D6zlDIbXkLudrXw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.31",
+        "@github/copilot-darwin-x64": "1.0.31",
+        "@github/copilot-linux-arm64": "1.0.31",
+        "@github/copilot-linux-x64": "1.0.31",
+        "@github/copilot-win32-arm64": "1.0.31",
+        "@github/copilot-win32-x64": "1.0.31"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.31.tgz",
+      "integrity": "sha512-DnAbe87U55/egBu/SFdMniQfhnYjfP3ZXXhrba3DZMXQI+91iRAGfPFKAsSlekl0zfNFw8toOkiafr9Hu2lHvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.31.tgz",
+      "integrity": "sha512-mFmuYT3N1JE3zRIwCAPaXGDstL8Npa62Jey3vT4Lo003NfzQrBzvZ4ObAVMTmFQ6pRZzj39rTTKp1vLYGg+K0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.31.tgz",
+      "integrity": "sha512-R5V7EIqn92f9YMe3zbQkW++Mw8WErDy6hA8Rr95bSJGiTVyWdj5kqPWSAPH6MLjFbC1T5cJQm/1we+QP3XO3Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.31.tgz",
+      "integrity": "sha512-LmcCGmYP9QLim/YMu5e1UlVeqCt/cuMI0fIqkdHs68h+0FGreSnHpn7nA9RbjAbQuPq9HFWeFjG5UpbAHM71Xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.21",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.31.tgz",
+      "integrity": "sha512-OlMPsQYFbl1hzrE0t703BwB9k8lQauQ4ETiiKpXSV4FxUb3DAU9PqWcy1pZoBjmLCni9h1ASQQKmPQ9ERJPm3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.31.tgz",
+      "integrity": "sha512-nK8uRdlKH6TNk1cjBqEPTvzWQxwnDPgNN3M5bB7TBXL6EsaFdUJePz4tqutUPoPbSKQqo+DtmJGT3/+A30ZcXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2634,6 +2785,47 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3516,6 +3708,47 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3554,6 +3787,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -3792,6 +4043,48 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
@@ -3842,6 +4135,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4069,12 +4372,56 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -4088,6 +4435,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -4309,6 +4674,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4359,6 +4734,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -4388,6 +4770,16 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -4607,6 +4999,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -4637,6 +5036,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4645,6 +5077,96 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4735,6 +5257,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up-simple": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
@@ -4796,6 +5340,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -5149,6 +5713,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -5180,6 +5754,27 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5253,6 +5848,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
@@ -5276,6 +5878,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5553,6 +6175,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5769,6 +6398,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5836,6 +6475,13 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5996,6 +6642,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -6122,6 +6791,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -6216,6 +6895,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -6285,6 +6987,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6326,6 +7038,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -6361,6 +7084,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6473,6 +7206,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6483,6 +7230,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6491,6 +7254,49 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react": {
@@ -6809,6 +7615,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
@@ -6938,6 +7761,60 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -6946,6 +7823,26 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -6996,6 +7893,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7214,6 +8118,16 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -7735,6 +8649,16 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/toposort": {
       "version": "2.0.2",
@@ -8293,6 +9217,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -8491,6 +9457,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -8573,6 +9549,16 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -8775,6 +9761,16 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -9547,6 +10543,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -9643,6 +10646,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^11.3.0",
+    "@github/copilot-sdk": "^0.2.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -31,6 +33,7 @@
     "typescript": "^5.8.3",
     "vite": "^6.3.1",
     "vite-plugin-pwa": "^0.21.1",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "zod": "^4.3.6"
   }
 }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -1,0 +1,553 @@
+#!/usr/bin/env tsx
+/**
+ * MCP server — Parallel Agent Orchestrator
+ *
+ * Generic async dispatcher: fires one Copilot SDK session per task, any agent role.
+ *
+ * Tools:
+ *
+ *   run_async_subagents(tasks, clarifications?)
+ *     → { runId, startedAt, taskIds }
+ *     Each task carries its own id, role, and full prompt — the orchestrator
+ *     decides what to ask; this server just fires the sessions in parallel.
+ *     Returns a runId immediately (non-blocking).
+ *
+ *   get_run_status(runId)
+ *     → { status, results, pendingClarification }
+ *     Poll until "done" or "pending-clarification".
+ *
+ *   submit_clarifications(runId, clarifications)
+ *     → { runId, startedAt, taskIds }
+ *     Re-queues only the blocked tasks from a previous run, injecting
+ *     clarification text into each prompt. Returns a new runId.
+ *
+ * Registration: .vscode/mcp.json
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CopilotClient, approveAll, type MCPServerConfig } from "@github/copilot-sdk";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const WORKSPACE_ROOT = resolve(import.meta.dirname, "..");
+const AGENTS_DIR = join(WORKSPACE_ROOT, ".github", "agents");
+const MCP_CONFIG_PATH = join(WORKSPACE_ROOT, ".vscode", "mcp.json");
+const MODEL = "gpt-5.3-codex";
+const LOG_DIR = resolve(import.meta.dirname, "../logs/parallel-agents");
+const AGENT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour per agent
+
+// ── Runtime MCP resolution ────────────────────────────────────────────────────
+// Reads the agent file and mcp.json fresh on every dispatch — no startup index,
+// no hardcoded prefix map. Zero code changes needed when adding a new MCP.
+//
+// Convention: each server entry in .vscode/mcp.json may carry a `_toolPrefixes`
+// array declaring which tool-namespace prefixes it serves (the same prefixes
+// that appear in agent frontmatter tools: lists). If omitted, the server key
+// itself is used as the prefix (works when key == namespace, e.g. "my-server").
+//
+// Example .vscode/mcp.json entry:
+//   "figma": { "type": "sse", "url": "...", "_toolPrefixes": ["com.figma.mcp"] }
+//   "chrome-devtools": { "type": "stdio", "command": "...", "_toolPrefixes": ["io.github.chromedevtools"] }
+
+function readAgentTools(role: string): string[] {
+    try {
+        const files = readdirSync(AGENTS_DIR).filter((f) => f.endsWith(".agent.md"));
+        for (const file of files) {
+            const content = readFileSync(join(AGENTS_DIR, file), "utf-8");
+            const nameMatch = content.match(/^name:\s*(.+)$/m);
+            if (!nameMatch || nameMatch[1].trim() !== role) continue;
+            // Parse tools: [...] from YAML frontmatter
+            const fmMatch = content.match(/^---[\s\S]*?^---/m);
+            if (!fmMatch) return [];
+            const toolsLine = fmMatch[0].match(/^tools:\s*\[(.*)\]/m);
+            if (!toolsLine) return [];
+            return toolsLine[1]
+                .split(",")
+                .map((t) => t.trim().replace(/^['"]/, "").replace(/['"]$/, ""))
+                .filter(Boolean);
+        }
+    } catch (err) {
+        console.error(`[agent-orchestrator] Warning: could not read agent file for role '${role}':`, err);
+    }
+    return [];
+}
+
+function resolveAgentMcpServers(role: string): Record<string, MCPServerConfig> {
+    const agentTools = readAgentTools(role);
+    if (agentTools.length === 0) return {};
+
+    let rawRegistry: Record<string, any> = {};
+    try {
+        rawRegistry = JSON.parse(readFileSync(MCP_CONFIG_PATH, "utf-8")).servers ?? {};
+    } catch {
+        return {};
+    }
+
+    const result: Record<string, MCPServerConfig> = {};
+    for (const [serverKey, rawConfig] of Object.entries(rawRegistry)) {
+        // Strip our private annotation before passing to the SDK
+        const { _toolPrefixes, ...config } = rawConfig as { _toolPrefixes?: string[];[k: string]: unknown };
+        const prefixes: string[] = _toolPrefixes ?? [serverKey];
+        const matched = agentTools.some((tool) =>
+            prefixes.some((p) => tool === p || tool.startsWith(p + "/"))
+        );
+        if (matched) result[serverKey] = config as MCPServerConfig;
+    }
+    return result;
+}
+
+// ── Default system messages per known role ────────────────────────────────────
+
+const DEFAULT_SYSTEM_MESSAGES: Record<string, string> = {
+    dev: `\
+You are a dev agent. Implement exactly one approved Gate 4 task per session.
+Follow .github/agents/dev.agent.md as the authoritative protocol.
+Never commit directly to master. Always use a git worktree for your branch.
+When blocked, surface the issue clearly under "Open Questions" and set
+Build Readiness: Needs Clarification.`,
+
+    "runtime-qa": `\
+You are a runtime-qa agent. Execute acceptance-criterion browser journeys for the
+assigned issue across the required viewport and theme matrix.
+Follow .github/agents/runtime-qa.agent.md as the authoritative protocol.
+Return a Runtime QA Verdict Package.`,
+
+    "prd-agent": `\
+You are a PRD agent. Convert the provided Requirement Context Package into a
+PRD v0 draft and validate completeness.
+Follow .github/agents/prd-agent.agent.md as the authoritative protocol.`,
+
+    "requirement-challenger": `\
+You are a requirement challenger. Grill the provided requirements, expose ambiguity,
+challenge assumptions, identify missing information, and score readiness.
+Follow .github/agents/requirement-challenger.agent.md as the authoritative protocol.`,
+
+    "design-qa-agent": `\
+You are a design QA agent. Review the provided Design Draft Package against PRD
+and UX artifacts and produce a Design QA Verdict Package.
+Follow .github/agents/design-qa-agent.agent.md as the authoritative protocol.`,
+};
+
+function systemMessageForRole(role: string, override?: string): string {
+    return override ?? DEFAULT_SYSTEM_MESSAGES[role] ?? `You are a ${role} agent. Follow the relevant agent protocol in .github/agents/.`;
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TaskStatus = "done" | "needs-clarification" | "failed";
+type RunStatus = "running" | "done" | "pending-clarification" | "failed";
+
+interface Task {
+    id: string;              // stable label: "issue/116", "prd-run-1", "qa-mobile", anything
+    role: string;            // agent role: "dev", "runtime-qa", "prd-agent", etc.
+    prompt: string;          // full prompt to send — orchestrator builds this
+    systemMessage?: string;  // override default system message for this role
+    // mcpServers is NOT exposed in the public API — derived automatically from
+    // the agent's tools: frontmatter + .vscode/mcp.json. No manual injection needed.
+}
+
+interface TaskResult {
+    taskId: string;
+    role: string;
+    sessionId: string;
+    status: TaskStatus;
+    output?: string;
+    challenge?: string;
+    error?: string;
+}
+
+interface Run {
+    runId: string;
+    startedAt: string;
+    taskIds: string[];
+    status: RunStatus;
+    results: TaskResult[];
+    pendingClarification: string[]; // taskIds
+    finishedAt?: string;
+    _tasks: Task[];  // kept for submit_clarifications replay
+}
+
+// ── Run registry (in-memory + disk) ──────────────────────────────────────────
+
+const RUNS_FILE = join(LOG_DIR, "runs.json");
+
+const runs = new Map<string, Run>();
+
+function persistRuns(): void {
+    try {
+        mkdirSync(LOG_DIR, { recursive: true });
+        const snapshot: Record<string, Omit<Run, "_tasks"> & { _tasks?: unknown }> = {};
+        for (const [id, run] of runs) {
+            const { _tasks, ...rest } = run;
+            snapshot[id] = rest;
+        }
+        writeFileSync(RUNS_FILE, JSON.stringify(snapshot, null, 2), "utf-8");
+    } catch {
+        // non-fatal — in-memory state is authoritative
+    }
+}
+
+function loadPersistedRuns(): void {
+    try {
+        if (!existsSync(RUNS_FILE)) return;
+        const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, Run>;
+        for (const [id, run] of Object.entries(raw)) {
+            // Mark any run that was "running" at crash time as failed
+            if (run.status === "running") {
+                run.status = "failed";
+                run.finishedAt = nowIST();
+                run.results = (run.results ?? []).concat(
+                    (run.taskIds ?? [])
+                        .filter((tid) => !run.results.some((r) => r.taskId === tid))
+                        .map((tid) => ({
+                            taskId: tid,
+                            role: "unknown",
+                            sessionId: "unknown",
+                            status: "failed" as TaskStatus,
+                            error: "Orchestrator crashed or restarted before task completed",
+                        }))
+                );
+            }
+            run._tasks = run._tasks ?? [];
+            runs.set(id, run);
+        }
+    } catch {
+        // corrupted file — start fresh
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function detectNeedsClarification(output: string): boolean {
+    return /build readiness\s*:\s*needs clarification/i.test(output);
+}
+
+function extractChallenge(output: string): string {
+    const m = output.match(
+        /(?:open questions|needs clarification|blockers?)[^\n]*\n([\s\S]{1,800}?)(?:\n#{1,3} |\n---|\n\*\*\*|$)/i
+    );
+    return m ? m[1].trim() : output.slice(0, 600).trim();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function nowIST(): string {
+    return new Date().toLocaleString("en-IN", {
+        timeZone: "Asia/Kolkata",
+        year: "numeric",
+        month: "short",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+    }) + " IST";
+}
+
+// ── Core: run one agent session ───────────────────────────────────────────────
+
+async function runAgentTask(
+    client: CopilotClient,
+    task: Task,
+    clarification?: string,
+    runId?: string,
+    dispatchedAt?: string,
+): Promise<TaskResult> {
+    const title = task.prompt.split("\n").find((l) => l.trim())?.trim().slice(0, 80) ?? task.id;
+    const repo = basename(WORKSPACE_ROOT);
+    const provenance = runId
+        ? [
+            "",
+            "## Agent Provenance (include verbatim in every PR body you open)",
+            "```",
+            `run-id:     ${runId}`,
+            `task-id:    ${task.id}`,
+            `title:      ${title}`,
+            `role:       ${task.role}`,
+            `model:      ${MODEL}`,
+            `repo:       ${repo}`,
+            `dispatched: ${dispatchedAt}`,
+            "```",
+            "",
+          ].join("\n")
+        : "";
+    const finalPrompt = clarification
+        ? `${task.prompt}${provenance}\n\n## Orchestrator clarification\n\n${clarification}`
+        : `${task.prompt}${provenance}`;
+
+    const mcpServers = resolveAgentMcpServers(task.role);
+    const session = await client.createSession({
+        model: MODEL,
+        onPermissionRequest: approveAll,
+        systemMessage: { content: systemMessageForRole(task.role, task.systemMessage) },
+        ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+    });
+
+    try {
+        const result = await session.sendAndWait(
+            { prompt: finalPrompt },
+            AGENT_TIMEOUT_MS
+        );
+
+        const output = result?.data?.content ?? "(no output)";
+
+        mkdirSync(LOG_DIR, { recursive: true });
+        const safeId = task.id.replace(/[^a-zA-Z0-9_-]/g, "_");
+        writeFileSync(join(LOG_DIR, `${safeId}.log`), output, "utf-8");
+
+        if (detectNeedsClarification(output)) {
+            return {
+                taskId: task.id,
+                role: task.role,
+                sessionId: session.sessionId,
+                status: "needs-clarification",
+                output,
+                challenge: extractChallenge(output),
+            };
+        }
+
+        return { taskId: task.id, role: task.role, sessionId: session.sessionId, status: "done", output };
+    } catch (err) {
+        return {
+            taskId: task.id,
+            role: task.role,
+            sessionId: session.sessionId,
+            status: "failed",
+            error: err instanceof Error ? err.message : String(err),
+        };
+    } finally {
+        await session.disconnect();
+    }
+}
+
+// ── Core: start a run (non-blocking) ─────────────────────────────────────────
+
+function startRun(tasks: Task[], clarifications: Record<string, string>): Run {
+    const runId = randomUUID();
+    const startedAt = nowIST();
+
+    const run: Run = {
+        runId,
+        startedAt,
+        taskIds: tasks.map((t) => t.id),
+        status: "running",
+        results: [],
+        pendingClarification: [],
+        _tasks: tasks,
+    };
+    runs.set(runId, run);
+    persistRuns();
+
+    (async () => {
+        const client = new CopilotClient();
+        await client.start();
+
+        try {
+            const results = await Promise.all(
+                tasks.map((t) => runAgentTask(client, t, clarifications[t.id], runId, startedAt))
+            );
+
+            run.results = results;
+            run.pendingClarification = results
+                .filter((r) => r.status === "needs-clarification")
+                .map((r) => r.taskId);
+            run.finishedAt = nowIST();
+            run.status = run.pendingClarification.length > 0 ? "pending-clarification" : "done";
+            persistRuns();
+
+            mkdirSync(LOG_DIR, { recursive: true });
+            writeFileSync(
+                join(LOG_DIR, "run-summary.json"),
+                JSON.stringify({ ...run, _tasks: undefined }, null, 2),
+                "utf-8"
+            );
+        } finally {
+            await client.stop();
+        }
+    })().catch((err) => {
+        run.status = "failed";
+        run.finishedAt = nowIST();
+        run.results = tasks.map((t) => ({
+            taskId: t.id,
+            role: t.role,
+            sessionId: "unknown",
+            status: "failed" as TaskStatus,
+            error: String(err),
+        }));
+        persistRuns();
+    });
+
+    return run;
+}
+
+// ── MCP Server ────────────────────────────────────────────────────────────────
+
+const server = new McpServer({
+    name: "agent-orchestrator",
+    version: "2.0.0",
+});
+
+// Tool 1: run_async_subagents
+server.tool(
+    "run_async_subagents",
+    "Start parallel Copilot agent sessions — one per task, any agent role. " +
+    "Each task carries its own id, role, and full prompt. The orchestrator " +
+    "builds the prompts; this tool fires and tracks the sessions. " +
+    "Returns a runId immediately; poll with get_run_status.",
+    {
+        tasks: z
+            .array(
+                z.object({
+                    id: z.string().min(1).describe(
+                        "Stable label for this task: 'issue/116', 'prd-run-1', 'qa-mobile', anything"
+                    ),
+                    role: z.string().min(1).describe(
+                        "Agent role: 'dev', 'runtime-qa', 'prd-agent', 'requirement-challenger', 'design-qa-agent', or any custom role"
+                    ),
+                    prompt: z.string().min(1).describe(
+                        "Full prompt to send to the agent — orchestrator builds this"
+                    ),
+                    systemMessage: z.string().optional().describe(
+                        "Override the default system message for this role"
+                    ),
+                })
+            )
+            .min(1)
+            .describe("Tasks to run in parallel"),
+        clarifications: z
+            .record(z.string(), z.string())
+            .optional()
+            .describe("Optional map of taskId → clarification text for re-runs after a challenge loop"),
+    },
+    async ({ tasks, clarifications = {} }) => {
+        const run = startRun(tasks, clarifications);
+
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify(
+                        { runId: run.runId, startedAt: run.startedAt, taskIds: run.taskIds, status: run.status },
+                        null,
+                        2
+                    ),
+                },
+            ],
+        };
+    }
+);
+
+// Tool 2: get_run_status
+server.tool(
+    "get_run_status",
+    "Poll the status of a parallel agent run. When status is 'pending-clarification', " +
+    "read pendingClarification and challenge fields, resolve with PO, then call " +
+    "submit_clarifications to re-queue the blocked tasks.",
+    {
+        runId: z.string().uuid().describe("runId returned by run_async_subagents"),
+    },
+    async ({ runId }) => {
+        const run = runs.get(runId);
+        if (!run) {
+            return {
+                content: [{ type: "text", text: JSON.stringify({ error: `Run ${runId} not found` }) }],
+                isError: true,
+            };
+        }
+
+        const summary = {
+            runId: run.runId,
+            status: run.status,
+            startedAt: run.startedAt,
+            finishedAt: run.finishedAt,
+            taskIds: run.taskIds,
+            pendingClarification: run.pendingClarification,
+            results: run.results.map((r) => ({
+                taskId: r.taskId,
+                role: r.role,
+                status: r.status,
+                sessionId: r.sessionId,
+                ...(r.challenge ? { challenge: r.challenge } : {}),
+                ...(r.error ? { error: r.error } : {}),
+                ...(r.status === "done"
+                    ? { outputPreview: r.output?.split("\n").slice(0, 30).join("\n") }
+                    : {}),
+            })),
+        };
+
+        return {
+            content: [{ type: "text", text: JSON.stringify(summary, null, 2) }],
+        };
+    }
+);
+
+// Tool 3: submit_clarifications
+server.tool(
+    "submit_clarifications",
+    "Re-queue only the blocked tasks from a previous run, injecting PO-approved " +
+    "clarifications into each prompt. Returns a new runId.",
+    {
+        runId: z
+            .string()
+            .uuid()
+            .describe("runId of the run that produced pending-clarification results"),
+        clarifications: z
+            .record(z.string(), z.string())
+            .describe("Map of taskId → clarification text approved by PO"),
+    },
+    async ({ runId, clarifications }) => {
+        const previousRun = runs.get(runId);
+        if (!previousRun) {
+            return {
+                content: [{ type: "text", text: JSON.stringify({ error: `Run ${runId} not found` }) }],
+                isError: true,
+            };
+        }
+
+        const blockedIds = new Set(previousRun.pendingClarification);
+        const tasksToRetry = previousRun._tasks.filter(
+            (t) => blockedIds.has(t.id) && Object.prototype.hasOwnProperty.call(clarifications, t.id)
+        );
+
+        if (tasksToRetry.length === 0) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({
+                            error: "No matching blocked tasks found for the provided clarifications",
+                            pendingClarification: previousRun.pendingClarification,
+                        }),
+                    },
+                ],
+                isError: true,
+            };
+        }
+
+        const run = startRun(tasksToRetry, clarifications);
+
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify(
+                        { runId: run.runId, startedAt: run.startedAt, taskIds: run.taskIds, status: run.status, retryOf: runId },
+                        null,
+                        2
+                    ),
+                },
+            ],
+        };
+    }
+);
+
+// ── Boot ──────────────────────────────────────────────────────────────────────
+
+loadPersistedRuns();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -28,17 +28,18 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CopilotClient, approveAll, type MCPServerConfig } from "@github/copilot-sdk";
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { basename, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
-const WORKSPACE_ROOT = resolve(import.meta.dirname, "..");
+const WORKSPACE_ROOT = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const AGENTS_DIR = join(WORKSPACE_ROOT, ".github", "agents");
 const MCP_CONFIG_PATH = join(WORKSPACE_ROOT, ".vscode", "mcp.json");
 const MODEL = "gpt-5.3-codex";
-const LOG_DIR = resolve(import.meta.dirname, "../logs/parallel-agents");
+const LOG_DIR = resolve(fileURLToPath(new URL(".", import.meta.url)), "../logs/parallel-agents");
 const AGENT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour per agent
 
 // ── Runtime MCP resolution ────────────────────────────────────────────────────
@@ -120,7 +121,7 @@ Return a Runtime QA Verdict Package.`,
     "prd-agent": `\
 You are a PRD agent. Convert the provided Requirement Context Package into a
 PRD v0 draft and validate completeness.
-Follow .github/agents/prd-agent.agent.md as the authoritative protocol.`,
+Follow .github/agents/prd.agent.md as the authoritative protocol.`,
 
     "requirement-challenger": `\
 You are a requirement challenger. Grill the provided requirements, expose ambiguity,
@@ -130,7 +131,7 @@ Follow .github/agents/requirement-challenger.agent.md as the authoritative proto
     "design-qa-agent": `\
 You are a design QA agent. Review the provided Design Draft Package against PRD
 and UX artifacts and produce a Design QA Verdict Package.
-Follow .github/agents/design-qa-agent.agent.md as the authoritative protocol.`,
+Follow .github/agents/design-qa.agent.md as the authoritative protocol.`,
 };
 
 function systemMessageForRole(role: string, override?: string): string {

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -185,7 +185,12 @@ function persistRuns(): void {
         const snapshot: Record<string, Omit<Run, "_tasks"> & { _tasks?: unknown }> = {};
         for (const [id, run] of runs) {
             const { _tasks, ...rest } = run;
-            snapshot[id] = rest;
+            // Strip full output from disk — already saved to per-task .log files.
+            // Keeps runs.json small so the VS Code watcher stays fast as history grows.
+            snapshot[id] = {
+                ...rest,
+                results: rest.results.map(({ output, ...r }) => r),
+            };
         }
         const tmp = RUNS_FILE + ".tmp";
         writeFileSync(tmp, JSON.stringify(snapshot, null, 2), "utf-8");
@@ -309,9 +314,15 @@ async function runAgentTask(
 
         const output = result?.data?.content ?? "(no output)";
 
-        mkdirSync(LOG_DIR, { recursive: true });
-        const safeId = task.id.replace(/[^a-zA-Z0-9_-]/g, "_");
-        writeFileSync(join(LOG_DIR, `${runId}-${safeId}.log`), output, "utf-8");
+        // Log write is best-effort — a disk/permission error must not flip a
+        // successful agent session to "failed".
+        try {
+            mkdirSync(LOG_DIR, { recursive: true });
+            const safeId = task.id.replace(/[^a-zA-Z0-9_-]/g, "_");
+            writeFileSync(join(LOG_DIR, `${runId}-${safeId}.log`), output, "utf-8");
+        } catch {
+            // non-fatal — session result is still returned correctly
+        }
 
         if (detectNeedsClarification(output)) {
             return {
@@ -376,12 +387,18 @@ function startRun(tasks: Task[], clarifications: Record<string, string>): Run {
                 : hasFailed ? "failed" : "done";
             persistRuns();
 
-            mkdirSync(LOG_DIR, { recursive: true });
-            writeFileSync(
-                join(LOG_DIR, "run-summary.json"),
-                JSON.stringify({ ...run, _tasks: undefined }, null, 2),
-                "utf-8"
-            );
+            // Summary write is best-effort — a filesystem error here must not
+            // overwrite the already-committed run.results via the outer .catch.
+            try {
+                mkdirSync(LOG_DIR, { recursive: true });
+                writeFileSync(
+                    join(LOG_DIR, "run-summary.json"),
+                    JSON.stringify({ ...run, _tasks: undefined }, null, 2),
+                    "utf-8"
+                );
+            } catch {
+                // non-fatal
+            }
         } finally {
             await client.stop();
         }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -201,9 +201,10 @@ function loadPersistedRuns(): void {
             if (run.status === "running") {
                 run.status = "failed";
                 run.finishedAt = nowIST();
-                run.results = (run.results ?? []).concat(
+                const existingResults = run.results ?? [];
+                run.results = existingResults.concat(
                     (run.taskIds ?? [])
-                        .filter((tid) => !run.results.some((r) => r.taskId === tid))
+                        .filter((tid) => !existingResults.some((r) => r.taskId === tid))
                         .map((tid) => ({
                             taskId: tid,
                             role: "unknown",
@@ -298,7 +299,7 @@ async function runAgentTask(
 
         mkdirSync(LOG_DIR, { recursive: true });
         const safeId = task.id.replace(/[^a-zA-Z0-9_-]/g, "_");
-        writeFileSync(join(LOG_DIR, `${safeId}.log`), output, "utf-8");
+        writeFileSync(join(LOG_DIR, `${runId}-${safeId}.log`), output, "utf-8");
 
         if (detectNeedsClarification(output)) {
             return {
@@ -357,7 +358,10 @@ function startRun(tasks: Task[], clarifications: Record<string, string>): Run {
                 .filter((r) => r.status === "needs-clarification")
                 .map((r) => r.taskId);
             run.finishedAt = nowIST();
-            run.status = run.pendingClarification.length > 0 ? "pending-clarification" : "done";
+            const hasFailed = run.results.some((r) => r.status === "failed");
+            run.status = run.pendingClarification.length > 0
+                ? "pending-clarification"
+                : hasFailed ? "failed" : "done";
             persistRuns();
 
             mkdirSync(LOG_DIR, { recursive: true });
@@ -505,6 +509,18 @@ server.tool(
         if (!previousRun) {
             return {
                 content: [{ type: "text", text: JSON.stringify({ error: `Run ${runId} not found` }) }],
+                isError: true,
+            };
+        }
+
+        // _tasks is not persisted across restarts — guard before attempting replay
+        if (previousRun._tasks.length === 0 && previousRun.pendingClarification.length > 0) {
+            return {
+                content: [{ type: "text", text: JSON.stringify({
+                    error: "Cannot re-queue: task details were not persisted across an orchestrator restart. " +
+                           "Submit a new run_async_subagents call to replace this run.",
+                    pendingClarification: previousRun.pendingClarification,
+                }) }],
                 isError: true,
             };
         }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -299,14 +299,20 @@ async function runAgentTask(
         : `${task.prompt}${provenance}`;
 
     const mcpServers = resolveAgentMcpServers(task.role);
-    const session = await client.createSession({
-        model: MODEL,
-        onPermissionRequest: approveAll,
-        systemMessage: { content: systemMessageForRole(task.role, task.systemMessage) },
-        ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
-    });
+    // Declare outside try so finally can reference it for disconnect; starts
+    // undefined so a session-creation failure also gets a task-scoped result.
+    let session: Awaited<ReturnType<typeof client.createSession>> | undefined;
 
     try {
+        // createSession is inside try so a failure returns a task-scoped
+        // "failed" result rather than throwing into Promise.all.
+        session = await client.createSession({
+            model: MODEL,
+            onPermissionRequest: approveAll,
+            systemMessage: { content: systemMessageForRole(task.role, task.systemMessage) },
+            ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+        });
+
         const result = await session.sendAndWait(
             { prompt: finalPrompt },
             AGENT_TIMEOUT_MS
@@ -340,12 +346,14 @@ async function runAgentTask(
         return {
             taskId: task.id,
             role: task.role,
-            sessionId: session.sessionId,
+            sessionId: session?.sessionId ?? "unknown",
             status: "failed",
             error: err instanceof Error ? err.message : String(err),
         };
     } finally {
-        await session.disconnect();
+        // Best-effort teardown — a disconnect() rejection must not mask the
+        // already-returned task result (or throw into Promise.all).
+        try { await session?.disconnect(); } catch { /* non-fatal */ }
     }
 }
 

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -27,7 +27,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CopilotClient, approveAll, type MCPServerConfig } from "@github/copilot-sdk";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
@@ -186,7 +186,9 @@ function persistRuns(): void {
             const { _tasks, ...rest } = run;
             snapshot[id] = rest;
         }
-        writeFileSync(RUNS_FILE, JSON.stringify(snapshot, null, 2), "utf-8");
+        const tmp = RUNS_FILE + ".tmp";
+        writeFileSync(tmp, JSON.stringify(snapshot, null, 2), "utf-8");
+        renameSync(tmp, RUNS_FILE);
     } catch {
         // non-fatal — in-memory state is authoritative
     }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -27,7 +27,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CopilotClient, approveAll, type MCPServerConfig } from "@github/copilot-sdk";
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
@@ -188,7 +188,13 @@ function persistRuns(): void {
         }
         const tmp = RUNS_FILE + ".tmp";
         writeFileSync(tmp, JSON.stringify(snapshot, null, 2), "utf-8");
-        renameSync(tmp, RUNS_FILE);
+        try {
+            renameSync(tmp, RUNS_FILE);
+        } catch {
+            // Windows: fs.rename cannot overwrite an existing file (EPERM); unlink first
+            try { unlinkSync(RUNS_FILE); } catch { /* file may not exist on first write */ }
+            renameSync(tmp, RUNS_FILE);
+        }
     } catch {
         // non-fatal — in-memory state is authoritative
     }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -204,6 +204,7 @@ function persistRuns(): void {
 function loadPersistedRuns(): void {
     try {
         if (!existsSync(RUNS_FILE)) return;
+        let mutated = false;
         const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, Run>;
         for (const [id, run] of Object.entries(raw)) {
             // Mark any run that was "running" at crash time as failed
@@ -222,10 +223,12 @@ function loadPersistedRuns(): void {
                             error: "Orchestrator crashed or restarted before task completed",
                         }))
                 );
+                mutated = true;
             }
             run._tasks = run._tasks ?? [];
             runs.set(id, run);
         }
+        if (mutated) persistRuns();
     } catch {
         // corrupted file — start fresh
     }

--- a/tools/agent-status/.gitignore
+++ b/tools/agent-status/.gitignore
@@ -1,0 +1,3 @@
+out/
+*.vsix
+node_modules/

--- a/tools/agent-status/package.json
+++ b/tools/agent-status/package.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-status",
+  "publisher": "nishantnaagnihotri",
   "displayName": "Agent Status",
   "description": "Shows async agent run status in the status bar and Activity Bar sidebar",
   "version": "0.1.0",
@@ -21,7 +22,7 @@
         "agentStatus.runsFilePath": {
           "type": "string",
           "default": "",
-          "description": "Absolute path to runs.json, or leave empty to auto-detect from workspace root (logs/parallel-agents/runs.json)."
+          "description": "Absolute or workspace-relative path to runs.json (e.g. /home/user/runs.json or logs/parallel-agents/runs.json). Leave empty to auto-detect from workspace root."
         }
       }
     },

--- a/tools/agent-status/package.json
+++ b/tools/agent-status/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "agent-status",
+  "displayName": "Agent Status",
+  "description": "Shows async agent run status in the status bar and Activity Bar sidebar",
+  "version": "0.1.0",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onView:agentStatus.runsView",
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Agent Status",
+      "properties": {
+        "agentStatus.runsFilePath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to runs.json, or leave empty to auto-detect from workspace root (logs/parallel-agents/runs.json)."
+        }
+      }
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "agentStatus",
+          "title": "Agent Runs",
+          "icon": "resources/agent.svg"
+        }
+      ]
+    },
+    "views": {
+      "agentStatus": [
+        {
+          "id": "agentStatus.runsView",
+          "name": "Runs"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "agentStatus.showDetails",
+        "title": "Agent Status: Show Run Details"
+      },
+      {
+        "command": "agentStatus.openRun",
+        "title": "Agent Status: Open Run JSON"
+      },
+      {
+        "command": "agentStatus.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "agentStatus.refresh",
+          "when": "view == agentStatus.runsView",
+          "group": "navigation"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p tsconfig.json",
+    "watch": "tsc -watch -p tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@vscode/vsce": "^3.9.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/tools/agent-status/resources/agent.svg
+++ b/tools/agent-status/resources/agent.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="5" r="2"/>
+  <circle cx="5" cy="19" r="2"/>
+  <circle cx="19" cy="19" r="2"/>
+  <line x1="12" y1="7" x2="5" y2="17"/>
+  <line x1="12" y1="7" x2="19" y2="17"/>
+</svg>

--- a/tools/agent-status/src/extension.ts
+++ b/tools/agent-status/src/extension.ts
@@ -299,7 +299,7 @@ export function activate(context: vscode.ExtensionContext): void {
             watcher = fs.watch(runsFile, { persistent: false }, () => refresh());
         } catch {
             watcher = fs.watch(dir, { persistent: false }, (_, filename) => {
-                if (filename === "runs.json") {
+                if (String(filename) === path.basename(runsFile)) {
                     refresh();
                     watcher?.close();
                     startWatcher();

--- a/tools/agent-status/src/extension.ts
+++ b/tools/agent-status/src/extension.ts
@@ -286,13 +286,16 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // Watch for file changes
     let watcher: fs.FSWatcher | undefined;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+    context.subscriptions.push({ dispose: () => { clearTimeout(retryTimer); watcher?.close(); } });
 
     function startWatcher(): void {
         const runsFile = getRunsFile();
-        if (!runsFile) { setTimeout(startWatcher, 5000); return; }
+        if (!runsFile) { retryTimer = setTimeout(startWatcher, 5000); return; }
         const dir = path.dirname(runsFile);
         if (!fs.existsSync(dir)) {
-            setTimeout(startWatcher, 5000);
+            retryTimer = setTimeout(startWatcher, 5000);
             return;
         }
         try {
@@ -306,7 +309,6 @@ export function activate(context: vscode.ExtensionContext): void {
                 }
             });
         }
-        context.subscriptions.push({ dispose: () => watcher?.close() });
     }
 
     startWatcher();

--- a/tools/agent-status/src/extension.ts
+++ b/tools/agent-status/src/extension.ts
@@ -1,0 +1,330 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+
+type TaskStatus = "done" | "failed" | "needs-clarification";
+type RunStatus = "running" | "done" | "failed" | "pending-clarification";
+
+interface TaskResult {
+    taskId: string;
+    role: string;
+    status: TaskStatus;
+    error?: string;
+}
+
+interface Run {
+    runId: string;
+    startedAt: string;
+    finishedAt?: string;
+    status: RunStatus;
+    taskIds: string[];
+    results: TaskResult[];
+    pendingClarification: string[];
+}
+
+type RunsSnapshot = Record<string, Run>;
+
+const RUNS_FILE_REL = path.join("logs", "parallel-agents", "runs.json");
+
+function readRuns(runsFile: string): RunsSnapshot {
+    try {
+        return JSON.parse(fs.readFileSync(runsFile, "utf-8")) as RunsSnapshot;
+    } catch {
+        return {};
+    }
+}
+
+/** Returns runs newest-first (JSON object preserves insertion order = chronological). */
+function sorted(runs: RunsSnapshot): Run[] {
+    return Object.values(runs).reverse();
+}
+
+function statusIcon(status: RunStatus): string {
+    switch (status) {
+        case "running": return "$(sync~spin)";
+        case "done": return "$(check)";
+        case "failed": return "$(error)";
+        case "pending-clarification": return "$(question)";
+    }
+}
+
+function statusThemeIcon(status: RunStatus): vscode.ThemeIcon {
+    switch (status) {
+        case "running": return new vscode.ThemeIcon("sync~spin", new vscode.ThemeColor("charts.yellow"));
+        case "done": return new vscode.ThemeIcon("check", new vscode.ThemeColor("charts.green"));
+        case "failed": return new vscode.ThemeIcon("error", new vscode.ThemeColor("charts.red"));
+        case "pending-clarification": return new vscode.ThemeIcon("question", new vscode.ThemeColor("charts.orange"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tree items
+// ---------------------------------------------------------------------------
+
+class RunTreeItem extends vscode.TreeItem {
+    constructor(readonly run: Run) {
+        const taskCount = run.taskIds.length;
+        const taskSummary = taskCount === 1
+            ? run.taskIds[0]
+            : `${taskCount} tasks`;
+        const state = run.results.length > 0
+            ? vscode.TreeItemCollapsibleState.Collapsed
+            : vscode.TreeItemCollapsibleState.None;
+        super(run.runId, state);
+        this.description = `${taskSummary}  ·  ${run.status}  ·  ${run.finishedAt ?? run.startedAt}`;
+        this.iconPath = statusThemeIcon(run.status);
+        this.tooltip = [
+            `Run: ${run.runId}`,
+            `Tasks: ${run.taskIds.join(", ") || "(none)"}`,
+            `Status: ${run.status}`,
+            `Started: ${run.startedAt}`,
+            run.finishedAt ? `Finished: ${run.finishedAt}` : "(still running)",
+            run.pendingClarification.length > 0 ? `Clarification: ${run.pendingClarification.join(", ")}` : "",
+        ].filter(Boolean).join("\n");
+        this.command = {
+            command: "agentStatus.openRun",
+            title: "Open Run JSON",
+            arguments: [run],
+        };
+        this.contextValue = "run";
+    }
+}
+
+class TaskResultItem extends vscode.TreeItem {
+    constructor(result: TaskResult) {
+        super(result.taskId, vscode.TreeItemCollapsibleState.None);
+        this.description = result.status;
+        this.iconPath = result.status === "done"
+            ? new vscode.ThemeIcon("check", new vscode.ThemeColor("charts.green"))
+            : result.status === "failed"
+            ? new vscode.ThemeIcon("error", new vscode.ThemeColor("charts.red"))
+            : new vscode.ThemeIcon("question");
+        if (result.error) this.tooltip = result.error;
+        this.contextValue = "taskResult";
+    }
+}
+
+type AnyItem = RunTreeItem | TaskResultItem;
+
+// ---------------------------------------------------------------------------
+// Tree data provider
+// ---------------------------------------------------------------------------
+
+class RunsTreeProvider implements vscode.TreeDataProvider<AnyItem> {
+    private readonly _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    private snapshot: RunsSnapshot = {};
+
+    refresh(snapshot: RunsSnapshot): void {
+        this.snapshot = snapshot;
+        this._onDidChangeTreeData.fire(undefined);
+    }
+
+    getTreeItem(element: AnyItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: AnyItem): AnyItem[] {
+        if (!element) {
+            return sorted(this.snapshot).slice(0, 100).map((r) => new RunTreeItem(r));
+        }
+        if (element instanceof RunTreeItem) {
+            return element.run.results.map((r) => new TaskResultItem(r));
+        }
+        return [];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Status bar summary
+// ---------------------------------------------------------------------------
+
+function summarise(runs: RunsSnapshot): { label: string; tooltip: string; color?: vscode.ThemeColor } {
+    const all = Object.values(runs);
+    if (all.length === 0) {
+        return { label: "$(circle-slash) No agent runs", tooltip: "No agent runs recorded yet." };
+    }
+
+    const running = all.filter((r) => r.status === "running").length;
+    const clarification = all.filter((r) => r.status === "pending-clarification").length;
+    const failed = all.filter((r) => r.status === "failed").length;
+    const done = all.filter((r) => r.status === "done").length;
+
+    const parts: string[] = [];
+    if (running > 0) parts.push(`$(sync~spin) ${running} running`);
+    if (clarification > 0) parts.push(`$(question) ${clarification} waiting`);
+    if (failed > 0) parts.push(`$(error) ${failed} failed`);
+    if (running === 0 && clarification === 0 && failed === 0) parts.push(`$(check) ${done} done`);
+
+    const label = "Agents: " + parts.join("  ");
+
+    const tooltipLines = sorted(runs).slice(0, 5).map((r) => {
+        const icon = r.status === "running" ? "⟳" : r.status === "done" ? "✓" : r.status === "failed" ? "✗" : "?";
+        const tasks = r.taskIds.join(", ");
+        const time = r.finishedAt ?? r.startedAt;
+        return `${icon} ${tasks} — ${r.status} (${time})`;
+    });
+
+    const tooltip = tooltipLines.join("\n") + (all.length > 5 ? `\n…and ${all.length - 5} older runs` : "");
+
+    const color =
+        running > 0 ? new vscode.ThemeColor("statusBarItem.warningBackground") :
+        clarification > 0 ? new vscode.ThemeColor("statusBarItem.warningBackground") :
+        failed > 0 ? new vscode.ThemeColor("statusBarItem.errorBackground") :
+        undefined;
+
+    return { label, tooltip, color };
+}
+
+// ---------------------------------------------------------------------------
+// QuickPick details
+// ---------------------------------------------------------------------------
+
+function showDetails(runs: RunsSnapshot): void {
+    const all = sorted(runs);
+    if (all.length === 0) {
+        vscode.window.showInformationMessage("No agent runs recorded.");
+        return;
+    }
+
+    const items = all.slice(0, 20).map((r) => {
+        const taskSummary = r.taskIds.length === 1 ? r.taskIds[0] : `${r.taskIds.length} tasks`;
+        return {
+            label: `${statusIcon(r.status)} ${r.runId}`,
+            description: taskSummary,
+            detail: `${r.startedAt}${r.finishedAt ? " → " + r.finishedAt : " (running)"}`,
+            run: r,
+        };
+    });
+
+    vscode.window.showQuickPick(items, {
+        title: "Agent Runs (latest first)",
+        matchOnDescription: true,
+        matchOnDetail: true,
+    }).then((picked) => {
+        if (!picked) return;
+        openRunJson(picked.run);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Virtual document provider — stable URI per run so tabs are reused
+// ---------------------------------------------------------------------------
+
+const RUN_SCHEME = "agent-run";
+
+class RunDocumentProvider implements vscode.TextDocumentContentProvider {
+    private readonly _docs = new Map<string, string>();
+    private readonly _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+    readonly onDidChangeEmitter = this._onDidChange;
+    readonly onDidChange = this._onDidChange.event;
+
+    set(runId: string, content: string): void {
+        this._docs.set(runId, content);
+        this._onDidChange.fire(vscode.Uri.parse(`${RUN_SCHEME}:/${runId}.json`));
+    }
+
+    provideTextDocumentContent(uri: vscode.Uri): string {
+        const runId = path.basename(uri.path, ".json");
+        return this._docs.get(runId) ?? "{}";
+    }
+}
+
+const runDocProvider = new RunDocumentProvider();
+
+function openRunJson(run: Run): void {
+    const content = JSON.stringify(run, null, 2);
+    runDocProvider.set(run.runId, content);
+    const uri = vscode.Uri.parse(`${RUN_SCHEME}:/${run.runId}.json`);
+    vscode.window.showTextDocument(uri, { preview: false, preserveFocus: false });
+}
+
+// ---------------------------------------------------------------------------
+// Activation
+// ---------------------------------------------------------------------------
+
+export function activate(context: vscode.ExtensionContext): void {
+    // Virtual document provider for stable run URIs
+    context.subscriptions.push(
+        vscode.workspace.registerTextDocumentContentProvider(RUN_SCHEME, runDocProvider),
+        { dispose: () => runDocProvider.onDidChangeEmitter.dispose() }
+    );
+    // Sidebar tree view — registered unconditionally so VS Code always has a provider
+    const treeProvider = new RunsTreeProvider();
+    const treeView = vscode.window.createTreeView("agentStatus.runsView", {
+        treeDataProvider: treeProvider,
+        showCollapseAll: true,
+    });
+    context.subscriptions.push(treeView);
+
+    // Status bar
+    const bar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+    bar.command = "agentStatus.showDetails";
+    bar.show();
+    context.subscriptions.push(bar);
+
+    function getRunsFile(): string | undefined {
+        const configured = vscode.workspace.getConfiguration("agentStatus").get<string>("runsFilePath", "").trim();
+        if (configured && path.isAbsolute(configured)) return configured;
+        const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        if (root) return path.join(root, configured || RUNS_FILE_REL);
+        return undefined;
+    }
+
+    function refresh(): void {
+        const runsFile = getRunsFile();
+        const runs = runsFile ? readRuns(runsFile) : {};
+        const { label, tooltip, color } = summarise(runs);
+        bar.text = label;
+        bar.tooltip = tooltip;
+        bar.backgroundColor = color;
+        treeProvider.refresh(runs);
+    }
+
+    refresh();
+
+    // Watch for file changes
+    let watcher: fs.FSWatcher | undefined;
+
+    function startWatcher(): void {
+        const runsFile = getRunsFile();
+        if (!runsFile) { setTimeout(startWatcher, 5000); return; }
+        const dir = path.dirname(runsFile);
+        if (!fs.existsSync(dir)) {
+            setTimeout(startWatcher, 5000);
+            return;
+        }
+        try {
+            watcher = fs.watch(runsFile, { persistent: false }, () => refresh());
+        } catch {
+            watcher = fs.watch(dir, { persistent: false }, (_, filename) => {
+                if (filename === "runs.json") {
+                    refresh();
+                    watcher?.close();
+                    startWatcher();
+                }
+            });
+        }
+        context.subscriptions.push({ dispose: () => watcher?.close() });
+    }
+
+    startWatcher();
+
+    // Polling fallback every 10s in case fs.watch misses events (known unreliable on Linux)
+    const poller = setInterval(() => refresh(), 10_000);
+    context.subscriptions.push({ dispose: () => clearInterval(poller) });
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("agentStatus.showDetails", () => {
+            const runsFile = getRunsFile();
+            showDetails(runsFile ? readRuns(runsFile) : {});
+        }),
+        vscode.commands.registerCommand("agentStatus.openRun", (run: Run) =>
+            openRunJson(run)
+        ),
+        vscode.commands.registerCommand("agentStatus.refresh", () => refresh())
+    );
+}
+
+export function deactivate(): void {}

--- a/tools/agent-status/src/extension.ts
+++ b/tools/agent-status/src/extension.ts
@@ -299,15 +299,16 @@ export function activate(context: vscode.ExtensionContext): void {
             return;
         }
         try {
-            watcher = fs.watch(runsFile, { persistent: false }, () => refresh());
-        } catch {
+            // Watch the directory, not the file, so inode replacement from atomic
+            // rename (write-to-tmp + rename-into-place in the orchestrator) keeps
+            // triggering updates reliably on Linux/inotify and macOS/kqueue.
             watcher = fs.watch(dir, { persistent: false }, (_, filename) => {
                 if (String(filename) === path.basename(runsFile)) {
                     refresh();
-                    watcher?.close();
-                    startWatcher();
                 }
             });
+        } catch {
+            retryTimer = setTimeout(startWatcher, 5000);
         }
     }
 

--- a/tools/agent-status/tsconfig.json
+++ b/tools/agent-status/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": ["ES2020"],
+    "strict": true,
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Two additions that enable real-time monitoring of async agent runs from inside VS Code.

### 1. `scripts/mcp-dev-orchestrator.ts` — MCP orchestrator with disk persistence

- Dispatches parallel subagent tasks via the MCP `run_async_subagents` protocol
- **IST timestamps** via `nowIST()` on all run events
- **Enriched provenance block** per run: `run-id`, `task-id`, `title` (first 80 chars of prompt), `model`, `repo`, `dispatched`
- Model: `gpt-5.3-codex`
- **Disk persistence**: every state change (running → done / failed / pending-clarification) writes a snapshot to `logs/parallel-agents/runs.json`
- **Crash recovery**: `loadPersistedRuns()` on boot marks any orphaned `"running"` entries as `"failed"`

### 2. `tools/agent-status/` — VS Code extension

A lightweight extension that watches `runs.json` and surfaces live agent status without leaving VS Code.

**Features:**
- **Activity Bar sidebar** (`agentStatus.runsView`) — tree view with expandable run nodes; each run shows task count/name as description, full task list on hover
- **Newest-first ordering** everywhere (sidebar, QuickPick, status bar tooltip)
- **Expandable task results** — per-task child nodes with colored status icons and error tooltips
- **Status bar badge** — compact `✓ N done · ⚡ N running` summary
- **Auto-refresh** via `fs.watch` + 10-second polling fallback (robust on Linux)
- **Manual Refresh button** (↺) in the panel header via `view/title` menu
- **Stable per-run editor tabs** — `TextDocumentContentProvider` with `agent-run://` scheme; re-clicking the same run reuses the existing tab
- **Configurable runs path** via `agentStatus.runsFilePath` setting (fallback: workspace root)

### 3. `.gitignore` updates

- `logs/parallel-agents/` — runtime state, not source
- `tools/agent-status/.gitignore` — excludes `out/`, `*.vsix`, `node_modules/`