### PR TITLE
fix: guard client.stop() teardown and surface challenge tooltip

### DIFF
--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -408,7 +408,9 @@ function startRun(tasks: Task[], clarifications: Record<string, string>): Run {
                 // non-fatal
             }
         } finally {
-            await client.stop();
+            // Teardown is best-effort — a stop() rejection must not propagate to
+            // the outer .catch and clobber already-committed run.results.
+            try { await client.stop(); } catch { /* non-fatal */ }
         }
     })().catch((err) => {
         run.status = "failed";

--- a/tools/agent-status/src/extension.ts
+++ b/tools/agent-status/src/extension.ts
@@ -10,6 +10,7 @@ interface TaskResult {
     role: string;
     status: TaskStatus;
     error?: string;
+    challenge?: string;
 }
 
 interface Run {
@@ -99,7 +100,11 @@ class TaskResultItem extends vscode.TreeItem {
             : result.status === "failed"
             ? new vscode.ThemeIcon("error", new vscode.ThemeColor("charts.red"))
             : new vscode.ThemeIcon("question");
-        if (result.error) this.tooltip = result.error;
+        if (result.status === "needs-clarification" && result.challenge) {
+            this.tooltip = result.challenge;
+        } else if (result.error) {
+            this.tooltip = result.error;
+        }
         this.contextValue = "taskResult";
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #119 addressing two Copilot review comments that arrived after merge (r3099416147, r3099416185).

### Fix 1 — `scripts/mcp-dev-orchestrator.ts` ([r3099416147](https://github.com/nishantnaagnihotri/tark-vitark/pull/119#discussion_r3099416147))

`await client.stop()` was inside a `finally` block that could throw and be caught by the outer `.catch()`, which then overwrote already-committed `run.results` with a spurious failure. Wrapped in a best-effort `try/catch` so teardown errors are swallowed and real results are preserved.

### Fix 2 — `tools/agent-status/src/extension.ts` ([r3099416185](https://github.com/nishantnaagnihotri/tark-vitark/pull/119#discussion_r3099416185))

`TaskResultItem` only showed a tooltip for `error`. Added `challenge?: string` to `TaskResult` and updated `TaskResultItem` to surface `result.challenge` as the tooltip when `status === "needs-clarification"`, so the sidebar displays the clarification question instead of being silent.