### PR TITLE
chore: increase default Copilot review polling timeout to 10 min

### DIFF
--- a/scripts/wait_for_copilot_review.js
+++ b/scripts/wait_for_copilot_review.js
@@ -108,7 +108,7 @@ function parseCliArgs() {
         repo: { type: "string" },
         pr: { type: "string" },
         "head-sha": { type: "string" },
-        "timeout-seconds": { type: "string", default: "300" },
+        "timeout-seconds": { type: "string", default: "600" },
         "interval-seconds": { type: "string", default: "15" },
       },
       strict: true,


### PR DESCRIPTION
Changes default `--timeout-seconds` from `300` (5 min) to `600` (10 min) to give Copilot review enough time to post before the polling script gives up.