### PR TITLE
chore: protocol hardening — async run tracking, agent provenance, constraint cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,4 +69,11 @@ How can this be safely undone if needed?
 
 ---
 
-Execution-Agent: dev
+## Agent Provenance
+
+```
+run-id: direct-invocation
+task-id: direct-invocation
+role: dev
+dispatched: direct-invocation
+```

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -35,7 +35,7 @@ You are the technical lead and workflow conductor for exactly one active slice a
 11. When performing Gate 3A UX work, follow the `ux-design-execution` skill exactly. Do NOT originate design proposals outside Gate 3A execution context.
 12. DO NOT make content edits to gate artifacts (`01-requirement.md`, `02-prd.md`, `03-ux.md`, etc.). Route artifact updates to the owning agent: PRD changes → PRD Agent. Verbatim mechanical persistence or commit of the Orchestrator's own Gate 3A output into `docs/slices/<slice-name>/03-ux.md` is allowed.
 13. Follow the `domain-ownership-governance` skill (`.github/skills/domain-ownership-governance/SKILL.md`) for ownership boundaries and cross-domain routing.
-14. After every `run_async_subagents` call, immediately write the returned `runId` and task context to `/memories/session/active-state.md` under `## Pending Async Runs` before any other action. At session resume, poll all `running` entries before returning the resume snapshot. Skipping either step is a protocol violation.
+14. After every `run_async_subagents` call, immediately write the returned `runId` value as `run-id`, along with task context, to `/memories/session/active-state.md` under `## Pending Async Runs` before any other action. At session resume, poll all `running` entries before returning the resume snapshot. Skipping either step is a protocol violation.
 
 ## Domain Language Policy
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -3,7 +3,7 @@ name: architect-orchestrator
 description: "Use when: planning a new slice, sequencing agent work, enforcing gates, architecture signoff, and preparing merge-readiness decisions."
 argument-hint: "Provide requirement statement and current checkpoint (done/next/blockers)."
 user-invocable: true
-tools: [vscode, execute, read, agent, edit, search, web, browser, 'com.figma.mcp/mcp/*', 'io.github.chromedevtools/chrome-devtools-mcp/*', 'github/*', github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, todo]
+tools: [vscode, execute, read, agent, edit, search, web, browser, 'com.figma.mcp/mcp/*', 'io.github.chromedevtools/chrome-devtools-mcp/*', 'github/*', github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, 'agent-orchestrator/*', todo]
 agents: [requirement-challenger, prd-agent, design-qa-agent, architecture-agent, dev, runtime-qa]
 ---
 
@@ -35,6 +35,7 @@ You are the technical lead and workflow conductor for exactly one active slice a
 11. When performing Gate 3A UX work, follow the `ux-design-execution` skill exactly. Do NOT originate design proposals outside Gate 3A execution context.
 12. DO NOT make content edits to gate artifacts (`01-requirement.md`, `02-prd.md`, `03-ux.md`, etc.). Route artifact updates to the owning agent: PRD changes → PRD Agent. Verbatim mechanical persistence or commit of the Orchestrator's own Gate 3A output into `docs/slices/<slice-name>/03-ux.md` is allowed.
 13. Follow the `domain-ownership-governance` skill (`.github/skills/domain-ownership-governance/SKILL.md`) for ownership boundaries and cross-domain routing.
+14. After every `run_async_subagents` call, immediately write the returned `runId` and task context to `/memories/session/active-state.md` under `## Pending Async Runs` before any other action. At session resume, poll all `running` entries before returning the resume snapshot. Skipping either step is a protocol violation.
 
 ## Domain Language Policy
 

--- a/.github/agents/dev.agent.md
+++ b/.github/agents/dev.agent.md
@@ -35,7 +35,7 @@ You are the implementation specialist for one approved coding task at a time.
 4. DO NOT implement behavior before defining corresponding scenario tests.
 5. ONLY claim completion when PR is ready and linked to the issue.
 6. Keep changes reversible and scoped to one atomic task.
-7. Every PR body MUST include an `## Agent Provenance` section. If the orchestrator injected a provenance block into your prompt, copy it verbatim. If not (e.g., user-invoked directly), write the block with `role: dev` and leave `run-id` and `task-id` as `(direct-invocation)`.
+7. Every PR body MUST include an `## Agent Provenance` section. If the orchestrator injected a provenance block into your prompt, copy it verbatim. If not (e.g., user-invoked directly), write the block with `role: dev` and leave `run-id` and `task-id` as `direct-invocation`.
 8. For any Figma-alignment task, DO NOT rely on visual approximation alone; use extracted frame-level values as the source of truth.
 9. DO NOT use raw color values, hardcoded spacing, or ad-hoc tokens in code. Reference only CSS custom properties from the project's token file (see Design System Foundation Policy in `.github/AGENTS.md`).
 10. DO NOT ship code that only supports one theme. All styling must work in both Light and Dark themes via the token system.
@@ -120,7 +120,7 @@ A build output is "Ready" only when all are true:
 3. Tests for changed behavior are added or updated and pass.
 4. No architecture contract violations are introduced.
 5. PR is created and includes issue-closing reference.
-6. PR body includes provenance marker: `Execution-Agent: dev`.
+6. PR body includes an `## Agent Provenance` block with `run-id`, `task-id`, `role`, and `dispatched` fields.
 7. Residual risks and rollback note are documented.
 8. Open questions are resolved or explicitly accepted by Product Owner.
 9. For Figma-parity tasks, PR evidence includes frame-to-code value mapping (desktop/mobile or all required frames) and confirmation of any intentional deviations.
@@ -153,7 +153,7 @@ For Figma-parity tasks, include an additional subsection under `Verification Evi
 3. Verification evidence summary.
 4. BDD evidence: scenario catalog and scenario-to-test mapping.
 5. PR link and issue-closing statement.
-6. PR provenance marker confirmation (`Execution-Agent: dev`).
+6. PR provenance block confirmation (`## Agent Provenance` section with required fields).
 7. Residual risk and rollback note.
 8. Open questions with owner status.
 9. Traceability snapshot to issue acceptance criteria and architecture sections.

--- a/.github/agents/dev.agent.md
+++ b/.github/agents/dev.agent.md
@@ -27,7 +27,6 @@ You are the implementation specialist for one approved coding task at a time.
 4. Produce implementation code plus required verification evidence.
 5. Prepare a PR that closes the assigned issue.
 6. Report residual risks and rollback notes for merge readiness.
-
 ## Constraints
 
 1. DO NOT implement work outside the assigned Issue scope.
@@ -36,12 +35,13 @@ You are the implementation specialist for one approved coding task at a time.
 4. DO NOT implement behavior before defining corresponding scenario tests.
 5. ONLY claim completion when PR is ready and linked to the issue.
 6. Keep changes reversible and scoped to one atomic task.
-7. For any Figma-alignment task, DO NOT rely on visual approximation alone; use extracted frame-level values as the source of truth.
-8. DO NOT use raw color values, hardcoded spacing, or ad-hoc tokens in code. Reference only CSS custom properties from the project's token file (see Design System Foundation Policy in `.github/AGENTS.md`).
-9. DO NOT ship code that only supports one theme. All styling must work in both Light and Dark themes via the token system.
-10. For GitHub issue, pull request, review, comment, label, and status interactions, use GitHub MCP tools as the required interface. Only use a non-MCP fallback if the GitHub MCP server lacks the capability and Product Owner approves the exception.
-11. In `Orchestrator-Managed Stacked Review Mode`, DO NOT independently start or continue the PR review loop unless orchestrator explicitly delegates that action.
-12. For UI-impacting issues, provide the full Runtime QA handoff package evidence (journey map, route list, expected states, setup notes, setup/test data, and known-risk notes); this complements coded tests and does not replace them.
+7. Every PR body MUST include an `## Agent Provenance` section. If the orchestrator injected a provenance block into your prompt, copy it verbatim. If not (e.g., user-invoked directly), write the block with `role: dev` and leave `run-id` and `task-id` as `(direct-invocation)`.
+8. For any Figma-alignment task, DO NOT rely on visual approximation alone; use extracted frame-level values as the source of truth.
+9. DO NOT use raw color values, hardcoded spacing, or ad-hoc tokens in code. Reference only CSS custom properties from the project's token file (see Design System Foundation Policy in `.github/AGENTS.md`).
+10. DO NOT ship code that only supports one theme. All styling must work in both Light and Dark themes via the token system.
+11. For GitHub issue, pull request, review, comment, label, and status interactions, use GitHub MCP tools as the required interface. Only use a non-MCP fallback if the GitHub MCP server lacks the capability and Product Owner approves the exception.
+12. In `Orchestrator-Managed Stacked Review Mode`, DO NOT independently start or continue the PR review loop unless orchestrator explicitly delegates that action.
+13. For UI-impacting issues, provide the full Runtime QA handoff package evidence (journey map, route list, expected states, setup notes, setup/test data, and known-risk notes); this complements coded tests and does not replace them.
 
 ## Domain Language Policy
 

--- a/.github/orchestrator-context.md
+++ b/.github/orchestrator-context.md
@@ -88,7 +88,7 @@ Project-specific Figma identifiers live in `.figma-config.local` (gitignored). U
 15. Gate 5 default execution is local. Product Owner may opt a specific issue into cloud execution. Final build evidence is verified in local context before merge recommendation.
 16. Gate 5 implementation uses BDD discipline: behavior scenarios, test-first workflow, and scenario-to-test evidence are required before merge progression.
 17. Issue-centric handoff is supported for Gate 5: issue link/number is sufficient only when issue metadata includes acceptance criteria, slice path, and architecture reference.
-18. Gate 5 PR provenance is mandatory: PR body must include issue-closing keyword and `Execution-Agent: dev` marker for attribution and orchestration traceability.
+18. Gate 5 PR provenance is mandatory: PR body must include issue-closing keyword and an `## Agent Provenance` block with `run-id`, `task-id`, `role`, and `dispatched` fields. The legacy `Execution-Agent: dev` marker alone is not provenance-complete.
 19. Gate 6 is orchestrator-owned and Local-only. It recommends merge or loop-back based on evidence, but Product Owner alone performs the actual merge.
 20. Design artifact is mandatory for every UX task: Gate 3A must include a valid Figma file URL before progression. Raw file keys must not appear in git-tracked artifacts — store them only in `.figma-config.local`.
 21. Orchestrator terminal policy is diagnostics-first, but explicit Product Owner requests may authorize scoped git mutating commands (including add/commit/push/branch/PR operations); destructive commands still require command-level approval.

--- a/.github/skills/build-evidence-and-merge-readiness/SKILL.md
+++ b/.github/skills/build-evidence-and-merge-readiness/SKILL.md
@@ -26,22 +26,24 @@ Use this skill to validate implementation evidence and merge readiness for Gate 
 
 ## PR Provenance Convention
 
-Every Gate 5 PR must include an `## Agent Provenance` section in its body with this exact format:
+Every Gate 5 PR must include an `## Agent Provenance` section in its body. The block must contain at least these required fields:
 
 ```
 ## Agent Provenance
-```
-run-id: <uuid or "direct-invocation">
+
+run-id: <uuid or direct-invocation>
 task-id: <task id or issue ref>
 role: dev
-dispatched: <ISO timestamp or "direct-invocation">
-```
+dispatched: <ISO timestamp or direct-invocation>
 ```
 
+A superset block injected by the orchestrator (with additional fields such as `title`, `model`, `repo`) also satisfies this requirement; dev must copy it verbatim. This `## Agent Provenance` block replaces the legacy `Execution-Agent: dev` marker everywhere provenance completeness is evaluated; `Execution-Agent: dev` alone is not provenance-complete.
+
 1. Every Gate 5 PR must include an issue-closing keyword (for example, `Closes #123`).
-2. Every Gate 5 PR must include the full `## Agent Provenance` block above (not just `Execution-Agent: dev`).
-3. The `run-id` traces back to the `run_async_subagents` call recorded in `/memories/session/active-state.md`.
-4. Orchestrator verifies linkage and provenance before merge recommendation.
+2. Every Gate 5 PR must include an `## Agent Provenance` block containing at minimum `run-id`, `task-id`, `role`, and `dispatched` fields; a superset block (e.g., orchestrator-injected) also satisfies this requirement.
+3. This `## Agent Provenance` block replaces the legacy `Execution-Agent: dev` marker everywhere provenance completeness is evaluated; `Execution-Agent: dev` alone is not provenance-complete.
+4. The `run-id` traces back to the `run_async_subagents` call recorded in `/memories/session/active-state.md`.
+5. Orchestrator verifies linkage and provenance against the `## Agent Provenance` block before merge recommendation.
 
 ## Merge Gate Policy
 

--- a/.github/skills/build-evidence-and-merge-readiness/SKILL.md
+++ b/.github/skills/build-evidence-and-merge-readiness/SKILL.md
@@ -26,9 +26,22 @@ Use this skill to validate implementation evidence and merge readiness for Gate 
 
 ## PR Provenance Convention
 
+Every Gate 5 PR must include an `## Agent Provenance` section in its body with this exact format:
+
+```
+## Agent Provenance
+```
+run-id: <uuid or "direct-invocation">
+task-id: <task id or issue ref>
+role: dev
+dispatched: <ISO timestamp or "direct-invocation">
+```
+```
+
 1. Every Gate 5 PR must include an issue-closing keyword (for example, `Closes #123`).
-2. Every Gate 5 PR must include `Execution-Agent: dev` in the PR body.
-3. Orchestrator verifies linkage and provenance before merge recommendation.
+2. Every Gate 5 PR must include the full `## Agent Provenance` block above (not just `Execution-Agent: dev`).
+3. The `run-id` traces back to the `run_async_subagents` call recorded in `/memories/session/active-state.md`.
+4. Orchestrator verifies linkage and provenance before merge recommendation.
 
 ## Merge Gate Policy
 
@@ -46,7 +59,7 @@ Use this skill to validate implementation evidence and merge readiness for Gate 
 5. Domain language lock: verify code uses domain terminology and concepts (e.g., `displayBrandMessage()` not `renderDOMElement()`). Variable names, function names, and class names reflect the problem domain.
 6. Verification lock: verify required test commands passed and evidence is explicit. All tests passing is mandatory.
 7. PR lock: verify PR exists and includes explicit issue-closing reference and scenario-to-test mapping evidence.
-8. Provenance lock: verify PR body includes `Execution-Agent: dev` marker.
+8. Provenance lock: verify PR body includes a full `## Agent Provenance` block with `run-id`, `task-id`, `role`, and `dispatched` fields.
 9. Risk lock: verify residual risks and rollback note are documented.
 10. Approval lock: verify unresolved open questions are resolved or explicitly accepted by Product Owner.
 11. Runtime QA scope lock: verify issue is classified as `UI-impacting` or `Runtime QA: Not Required` with explicit rationale.
@@ -56,7 +69,7 @@ Use this skill to validate implementation evidence and merge readiness for Gate 
 
 1. Scope lock: verify PR still maps cleanly to the intended Issue and approved slice boundaries.
 2. Verification lock: verify required tests passed and Build evidence remains sufficient.
-3. Provenance lock: verify PR includes issue-closing keyword and `Execution-Agent: dev` marker.
+3. Provenance lock: verify PR includes issue-closing keyword and a full `## Agent Provenance` block with `run-id` tracing back to session memory.
 4. Review lock: verify review comments are resolved or explicitly accepted by Product Owner.
 5. Copilot review loop lock: verify the latest Copilot review on the latest commit reports zero comments in its review body, including known phrasings such as **"generated 0 comments"**, **"0 new comments"**, or **"generated no new comments"**. This is the only exit condition. Historical outdated threads do not count. If the latest review still reports >0 comments, the loop must continue. `semantically-closed/tooling-unresolved` items must be reported explicitly and do not block merge unless Product Owner decides otherwise.
 6. Runtime QA lock: for `UI-impacting` issues, verify latest Runtime QA verdict is `Pass`, or explicit Product Owner risk acceptance is documented.

--- a/.github/skills/build-evidence-and-merge-readiness/SKILL.md
+++ b/.github/skills/build-evidence-and-merge-readiness/SKILL.md
@@ -42,8 +42,8 @@ A superset block injected by the orchestrator (with additional fields such as `t
 1. Every Gate 5 PR must include an issue-closing keyword (for example, `Closes #123`).
 2. Every Gate 5 PR must include an `## Agent Provenance` block containing at minimum `run-id`, `task-id`, `role`, and `dispatched` fields; a superset block (e.g., orchestrator-injected) also satisfies this requirement.
 3. This `## Agent Provenance` block replaces the legacy `Execution-Agent: dev` marker everywhere provenance completeness is evaluated; `Execution-Agent: dev` alone is not provenance-complete.
-4. The `run-id` traces back to the `run_async_subagents` call recorded in `/memories/session/active-state.md`.
-5. Orchestrator verifies linkage and provenance against the `## Agent Provenance` block before merge recommendation.
+4. If `run-id` is an orchestrator-generated identifier, it must trace back to the `run_async_subagents` call recorded in `/memories/session/active-state.md`; if `run-id: direct-invocation`, this session-memory linkage requirement is explicitly N/A.
+5. Orchestrator verifies provenance completeness for every Gate 5 PR and verifies `/memories/session/active-state.md` linkage when the `run-id` is an orchestrator-generated identifier.
 
 ## Merge Gate Policy
 

--- a/.github/skills/gate-handoff-packet/SKILL.md
+++ b/.github/skills/gate-handoff-packet/SKILL.md
@@ -198,7 +198,7 @@ PR:
 Required evidence:
 - Build Output Package
 - issue-closing reference
-- `Execution-Agent: dev` marker
+- `## Agent Provenance` block
 - test results
 - review status
 - docs/release note status

--- a/.github/skills/orchestrator-session-context-lifecycle/SKILL.md
+++ b/.github/skills/orchestrator-session-context-lifecycle/SKILL.md
@@ -22,7 +22,7 @@ On first response in any new activity:
 2. Read `.github/orchestrator-context.md`.
 3. Identify current gate from context.
 4. Read only gate-relevant agent files under `.github/agents/`.
-5. Write `/memories/session/active-state.md` with current slice, gate, blockers, and next micro-goal.
+5. Write or update `/memories/session/active-state.md` with current slice, gate, blockers, and next micro-goal. When updating an existing file, preserve and merge the `## Pending Async Runs` section and all prior rows — do not replace the whole file.
 6. Return a short resume snapshot:
    - current gate
    - known artifacts present or missing

--- a/.github/skills/orchestrator-session-context-lifecycle/SKILL.md
+++ b/.github/skills/orchestrator-session-context-lifecycle/SKILL.md
@@ -56,15 +56,15 @@ After any gate transition or major owner decision:
 
 ## Async Run Tracking Protocol
 
-Any `run_async_subagents` call creates a fire-and-forget session. Without active tracking these runIds get lost in chat history.
+Any `run_async_subagents` call creates a fire-and-forget session. Without active tracking these `run-id` values get lost in chat history.
 
-**On dispatch** — immediately after `run_async_subagents` returns a `runId`, write or update `/memories/session/active-state.md` with an `## Pending Async Runs` section:
+**On dispatch** — immediately after `run_async_subagents` returns a `runId`, write or update `/memories/session/active-state.md` with an `## Pending Async Runs` section, recording the value as `run-id`:
 
 ```
 ## Pending Async Runs
 
-| runId | dispatched | tasks | purpose | status |
-|-------|------------|-------|---------|--------|
+| run-id | dispatched | tasks | purpose | status |
+|--------|------------|-------|---------|--------|
 | <uuid> | <ISO timestamp> | <task ids> | <one-line context> | running |
 ```
 
@@ -74,7 +74,7 @@ Do this before any other response content. If `/memories/session/active-state.md
 
 **On completion** — when `get_run_status` returns `done` or `pending-clarification` for a run, update its row status in session memory and record the outcome (output preview or challenge text). Do not delete the row — keep it as an audit trail for the session.
 
-**Standing rule** — never leave a turn where `run_async_subagents` was called without updating session memory. This is not optional. Forgetting to write the runId to session memory is a protocol violation.
+**Standing rule** — never leave a turn where `run_async_subagents` was called without updating session memory. This is not optional. Forgetting to write the `run-id` to session memory is a protocol violation.
 
 ## Log Archiving Protocol
 

--- a/.github/skills/orchestrator-session-context-lifecycle/SKILL.md
+++ b/.github/skills/orchestrator-session-context-lifecycle/SKILL.md
@@ -54,6 +54,28 @@ After any gate transition or major owner decision:
 4. Ask Product Owner to append the log block into `.github/orchestrator-context.md`.
 5. Use the updated context file as next-session baseline.
 
+## Async Run Tracking Protocol
+
+Any `run_async_subagents` call creates a fire-and-forget session. Without active tracking these runIds get lost in chat history.
+
+**On dispatch** — immediately after `run_async_subagents` returns a `runId`, write or update `/memories/session/active-state.md` with an `## Pending Async Runs` section:
+
+```
+## Pending Async Runs
+
+| runId | dispatched | tasks | purpose | status |
+|-------|------------|-------|---------|--------|
+| <uuid> | <ISO timestamp> | <task ids> | <one-line context> | running |
+```
+
+Do this before any other response content. If `/memories/session/active-state.md` does not exist yet, create it.
+
+**On resume** — as the very first action of the Resume Protocol (before returning the resume snapshot), scan `## Pending Async Runs` in session memory. For each row with status `running`, call `get_run_status` immediately and update the row to reflect the current state (`running` / `done` / `pending-clarification` / `failed`). Surface any completed or blocked runs in the resume snapshot.
+
+**On completion** — when `get_run_status` returns `done` or `pending-clarification` for a run, update its row status in session memory and record the outcome (output preview or challenge text). Do not delete the row — keep it as an audit trail for the session.
+
+**Standing rule** — never leave a turn where `run_async_subagents` was called without updating session memory. This is not optional. Forgetting to write the runId to session memory is a protocol violation.
+
 ## Log Archiving Protocol
 
 When a slice reaches Gate 6 ✅ Complete:

--- a/.github/workflows/protocol-checks.yml
+++ b/.github/workflows/protocol-checks.yml
@@ -25,8 +25,24 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! printf '%s' "$PR_BODY" | grep -q "Agent Provenance"; then
-            echo "::warning::PR body missing ## Agent Provenance block"
+          missing_provenance=false
+
+          if [ -z "$PR_BODY" ]; then
+            missing_provenance=true
+          fi
+
+          if ! printf '%s\n' "$PR_BODY" | grep -qE '^[[:space:]]*##[[:space:]]+Agent Provenance[[:space:]]*$'; then
+            missing_provenance=true
+          fi
+
+          for key in 'run-id:' 'task-id:' 'role:' 'dispatched:'; do
+            if ! printf '%s\n' "$PR_BODY" | grep -qE "^[[:space:]]*${key}[[:space:]]*"; then
+              missing_provenance=true
+            fi
+          done
+
+          if [ "$missing_provenance" = true ]; then
+            echo "::warning::PR body missing ## Agent Provenance block or required provenance fields (run-id:, task-id:, role:, dispatched:)"
           fi
 
       - name: Check PR body for issue-closing keyword

--- a/.github/workflows/protocol-checks.yml
+++ b/.github/workflows/protocol-checks.yml
@@ -31,7 +31,7 @@ jobs:
             missing_provenance=true
           fi
 
-          if ! printf '%s\n' "$PR_BODY" | grep -qE '^[[:space:]]*##[[:space:]]+Agent Provenance[[:space:]]*$'; then
+          if ! printf '%s\n' "$PR_BODY" | grep -qE '^[[:space:]]*##[[:space:]]+Agent Provenance([[:space:]].*)?$'; then
             missing_provenance=true
           fi
 

--- a/.github/workflows/protocol-checks.yml
+++ b/.github/workflows/protocol-checks.yml
@@ -25,8 +25,8 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! printf '%s' "$PR_BODY" | grep -q "Execution-Agent:"; then
-            echo "::warning::PR body missing Execution-Agent provenance marker"
+          if ! printf '%s' "$PR_BODY" | grep -q "Agent Provenance"; then
+            echo "::warning::PR body missing ## Agent Provenance block"
           fi
 
       - name: Check PR body for issue-closing keyword

--- a/docs/slices/post-tark-vitark/06-tasks.md
+++ b/docs/slices/post-tark-vitark/06-tasks.md
@@ -36,7 +36,8 @@ https://github.com/nishantnaagnihotri/tark-vitark/issues/85
 | Chip replace | Replace Podium `SegmentedControl` with inline `ChipFilter` pill | [#107](https://github.com/nishantnaagnihotri/tark-vitark/issues/107) / PR #108 | ✅ merged 2026-04-16 |
 | Slice merge | Stacked PR merge of post-tark-vitark feature into master | PR #109 | ✅ merged 2026-04-17 |
 | Theme-toggle reposition | Reposition to top-right to avoid Podium (second pass) | PR #111 | ✅ merged 2026-04-17 |
-| a11y: Podium chip | `role="switch"` + static `aria-label="Post as Tark"` + `aria-checked` | [#110](https://github.com/nishantnaagnihotri/tark-vitark/issues/110) / PR #112 | ✅ merged 2026-04-17; ⚠️ follow-up: WCAG 2.5.3 Label in Name — chip shows "Vitark" visually but aria-label stays "Post as Tark" |
+| a11y: Podium chip | `role="switch"` + static `aria-label="Post as Tark"` + `aria-checked` | [#110](https://github.com/nishantnaagnihotri/tark-vitark/issues/110) / PR #112 | ✅ merged 2026-04-17 |
+| WCAG 2.5.3 bugfix | Dynamic aria-label for Podium chip to match visible label (Tark/Vitark) | [#116](https://github.com/nishantnaagnihotri/tark-vitark/issues/116) / PR #118 | ✅ merged 2026-04-17 |
 
 ---
 

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -183,7 +183,7 @@ Given('a publish is already in progress in the composer', async function (this: 
   this.renderResult = render(
     createElement(Podium, {
       selectedSide: 'tark',
-      onSideChange: () => {},
+      onSideChange: () => { },
       onPublish: () =>
         new Promise<void>((resolve) => {
           this.publishCalls += 1;

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -183,7 +183,7 @@ Given('a publish is already in progress in the composer', async function (this: 
   this.renderResult = render(
     createElement(Podium, {
       selectedSide: 'tark',
-      onSideChange: () => { },
+      onSideChange: () => {},
       onPublish: () =>
         new Promise<void>((resolve) => {
           this.publishCalls += 1;


### PR DESCRIPTION
## Summary

Protocol hardening accumulated from the MCP orchestrator / agent-status work. Four behaviour changes and two housekeeping fixes.

### Agent protocol changes

**`architect-orchestrator.agent.md`**
- Added `'agent-orchestrator/*'` to the tools list so the MCP orchestrator tool is explicitly declared
- Added constraint #14: after every `run_async_subagents` call, immediately write the `runId` and task context to `/memories/session/active-state.md` under `## Pending Async Runs`; poll all `running` entries on resume

**`dev.agent.md`**
- Added constraint #7: every PR body MUST include an `## Agent Provenance` section (verbatim if orchestrator-injected, or `role: dev` / `(direct-invocation)` if user-invoked directly)
- Renumbered subsequent constraints (7→8 … 12→13)

### Skill changes

**`build-evidence-and-merge-readiness/SKILL.md`**
- Upgraded PR Provenance Convention from bare `Execution-Agent: dev` marker to a full `## Agent Provenance` block with `run-id`, `task-id`, `role`, and `dispatched` fields
- Updated Gate 5 and Gate 6 provenance locks to match

**`orchestrator-session-context-lifecycle/SKILL.md`**
- Added **Async Run Tracking Protocol**: on-dispatch, on-resume, and on-completion rules for persisting `runId` to session memory

### Housekeeping

- `docs/slices/post-tark-vitark/06-tasks.md`: extracted WCAG 2.5.3 bugfix into its own completed task row
- `features/step-definitions/post-tark-vitark.steps.ts`: formatter whitespace fix `() => {}` → `() => { }`
- `legend-bar.css`, `theme-toggle.css`: restore trailing newlines