### PR TITLE
fix: widen mobile argument cards to 85% (debate-screen-polish item 1) closes #124

### DIFF
--- a/src/styles/components/timeline.css
+++ b/src/styles/components/timeline.css
@@ -2,7 +2,7 @@
    Figma reference: CsPAyUdLSStdmNpmiBMESQ
    Desktop: 3-col grid (572 | 32 spine | 572) within 1200px content
    Tablet:  3-col grid (316 | 32 spine | 316) within 688px content
-   Mobile:  single-col flex, chat-bubble stagger ~72% width */
+   Mobile:  single-col flex, chat-bubble stagger ~85% width */
 
 .timeline {
     padding: 0 var(--space-5);

--- a/src/styles/components/timeline.css
+++ b/src/styles/components/timeline.css
@@ -30,7 +30,7 @@
 
 /* ── List items: mobile-first single column ── */
 .timeline__item {
-    width: 72%;
+    width: 85%;
 }
 
 .timeline__item--tark {


### PR DESCRIPTION
## Summary

Closes #124

Widen `.timeline__item` base width from `72%` to `85%` on mobile (single-column flex layout). This is the mobile-first rule with no `@media` wrapper — tablet and desktop layouts are unaffected (they override `width: auto` in the `≥481px` breakpoint).

## Change

**File:** `src/styles/components/timeline.css`

```css
/* before */
.timeline__item {
    width: 72%;
}

/* after */
.timeline__item {
    width: 85%;
}
```

## Acceptance Criteria Verification

| AC | Criterion | Status |
|---|---|---|
| AC-1 | `.timeline__item` renders at 85% on mobile | ✅ — value set |
| AC-2 | No horizontal scroll at 360px | ✅ — 85% of 360px = 306px, well within viewport |
| AC-3 | Tark left / Vitark right (stagger preserved) | ✅ — `align-self` rules untouched |
| AC-4 | 4-line clamp unchanged on mobile | ✅ — argument-card.css not touched |
| AC-5 | Bubble pointer not clipped | ✅ — width increase reduces clipping risk |
| AC-10 | All existing tests pass | ✅ — 265/265 passed |
| AC-11 | Light + dark themes correct | ✅ — width is theme-agnostic |
| AC-12 | WCAG 2.1 AA maintained | ✅ — no visual hierarchy or contrast changes |

## Files Changed

- `src/styles/components/timeline.css` — 1 line changed

## Test Evidence

```
Tests  265 passed (265)
```

## Agent Provenance

```
role: dev
task-id: T-1 (debate-screen-polish)
issue: #124
run-id: direct-invocation
dispatched: 2026-04-17
```