### PR TITLE
fix: keep Vitark timeline spine cell in row 1

### DIFF
--- a/src/styles/components/timeline.css
+++ b/src/styles/components/timeline.css
@@ -108,6 +108,7 @@
     .timeline__spine-cell {
         display: flex;
         grid-column: 2;
+        grid-row: 1;
         align-items: center;
         justify-content: center;
     }


### PR DESCRIPTION
## Summary
- add `grid-row: 1` to `.timeline__spine-cell` under `@media (min-width: 481px)`
- keep the rule outside `@supports (grid-template-columns: subgrid)` so it applies in subgrid and fallback modes
- preserve existing DOM order and placement logic in `Timeline.tsx`

## Testing
- npm run build
- npm test

Closes #125

## Agent Provenance
```
run-id:     cea1b377-c667-4848-bb53-8a3df44d088b
task-id:    issue/125
title:      Issue: https://github.com/nishantnaagnihotri/tark-vitark/issues/125
role:       dev
model:      gpt-5.3-codex
repo:       tark-vitark
dispatched: 17 Apr 2026, 18:57:03 IST
```
