### PR TITLE
test(bdd): add debate screen polish structural scenarios

### DIFF
--- a/features/debate-screen-polish.feature
+++ b/features/debate-screen-polish.feature
@@ -1,0 +1,33 @@
+Feature: Debate Screen Polish
+  As a public visitor
+  I want to read debate arguments comfortably on mobile
+  And see correctly aligned spine dots on tablet and desktop
+  So that the timeline is legible and visually coherent
+
+  Scenario: Argument cards carry the timeline item CSS class
+    Given the debate screen is loaded
+    Then each timeline item has the timeline__item CSS class
+
+  Scenario: Tark argument cards have the tark side class
+    Given the debate screen is loaded
+    Then each Tark timeline item has the timeline__item--tark class
+
+  Scenario: Vitark argument cards have the vitark side class
+    Given the debate screen is loaded
+    Then each Vitark timeline item has the timeline__item--vitark class
+
+  Scenario: Each Vitark timeline item contains exactly two grid children
+    Given the debate screen is loaded
+    Then each Vitark timeline item has exactly 2 direct children
+
+  Scenario: Each Vitark timeline item has a spine cell as its second child
+    Given the debate screen is loaded
+    Then each Vitark timeline item has a spine cell as its second child
+
+  Scenario: Each Tark timeline item has a spine cell as its second child
+    Given the debate screen is loaded
+    Then each Tark timeline item has a spine cell as its second child
+
+  Scenario: Spine dots are rendered for all argument cards
+    Given the debate screen is loaded
+    Then the number of spine dots equals the number of argument cards

--- a/features/step-definitions/debate-screen-polish.steps.ts
+++ b/features/step-definitions/debate-screen-polish.steps.ts
@@ -1,0 +1,90 @@
+import { Then, World } from '@cucumber/cucumber';
+import type { RenderResult } from '@testing-library/react';
+import * as assert from 'assert';
+
+interface DebateScreenPolishWorld extends World {
+  renderResult: RenderResult | null;
+}
+
+function activeRender(world: DebateScreenPolishWorld): RenderResult {
+  assert.ok(world.renderResult, 'Expected the debate screen to be rendered.');
+  return world.renderResult;
+}
+
+function timelineItems(world: DebateScreenPolishWorld): HTMLElement[] {
+  return Array.from(
+    activeRender(world).container.querySelectorAll<HTMLElement>('.timeline__list > .timeline__item')
+  );
+}
+
+function sideItems(world: DebateScreenPolishWorld, side: 'tark' | 'vitark'): HTMLElement[] {
+  return timelineItems(world).filter((item) => item.classList.contains(`timeline__item--${side}`));
+}
+
+function assertSpineCellAsSecondChild(items: HTMLElement[], side: 'tark' | 'vitark'): void {
+  assert.ok(items.length > 0, `Expected at least one ${side} timeline item.`);
+
+  for (const item of items) {
+    assert.equal(item.children.length >= 2, true, `Expected ${side} item to have at least 2 children.`);
+    const secondChild = item.children.item(1);
+    assert.ok(secondChild, `Expected ${side} item to have a second child.`);
+    assert.equal(
+      secondChild.classList.contains('timeline__spine-cell'),
+      true,
+      `Expected ${side} item second child to be .timeline__spine-cell.`
+    );
+  }
+}
+
+// AC-1/2/3/5 include pixel/layout/overflow behavior that jsdom cannot verify and are deferred to Gate 5.5 runtime QA.
+
+Then('each timeline item has the timeline__item CSS class', function (this: DebateScreenPolishWorld) {
+  const items = timelineItems(this);
+  assert.ok(items.length > 0, 'Expected timeline items to exist.');
+
+  for (const item of items) {
+    assert.equal(item.classList.contains('timeline__item'), true);
+  }
+});
+
+Then('each Tark timeline item has the timeline__item--tark class', function (this: DebateScreenPolishWorld) {
+  const tarkItems = sideItems(this, 'tark');
+  assert.ok(tarkItems.length > 0, 'Expected at least one Tark timeline item.');
+
+  for (const item of tarkItems) {
+    assert.equal(item.classList.contains('timeline__item--tark'), true);
+  }
+});
+
+Then('each Vitark timeline item has the timeline__item--vitark class', function (this: DebateScreenPolishWorld) {
+  const vitarkItems = sideItems(this, 'vitark');
+  assert.ok(vitarkItems.length > 0, 'Expected at least one Vitark timeline item.');
+
+  for (const item of vitarkItems) {
+    assert.equal(item.classList.contains('timeline__item--vitark'), true);
+  }
+});
+
+Then('each Vitark timeline item has exactly 2 direct children', function (this: DebateScreenPolishWorld) {
+  const vitarkItems = sideItems(this, 'vitark');
+  assert.ok(vitarkItems.length > 0, 'Expected at least one Vitark timeline item.');
+
+  for (const item of vitarkItems) {
+    assert.equal(item.children.length, 2);
+  }
+});
+
+Then('each Vitark timeline item has a spine cell as its second child', function (this: DebateScreenPolishWorld) {
+  assertSpineCellAsSecondChild(sideItems(this, 'vitark'), 'vitark');
+});
+
+Then('each Tark timeline item has a spine cell as its second child', function (this: DebateScreenPolishWorld) {
+  assertSpineCellAsSecondChild(sideItems(this, 'tark'), 'tark');
+});
+
+Then('the number of spine dots equals the number of argument cards', function (this: DebateScreenPolishWorld) {
+  const view = activeRender(this);
+  const spineDots = view.container.querySelectorAll('.timeline__dot');
+  const argumentCards = view.container.querySelectorAll('.argument-card');
+  assert.equal(spineDots.length, argumentCards.length);
+});

--- a/features/step-definitions/debate-screen-polish.steps.ts
+++ b/features/step-definitions/debate-screen-polish.steps.ts
@@ -7,6 +7,7 @@ interface DebateScreenPolishWorld extends World {
 }
 
 function activeRender(world: DebateScreenPolishWorld): RenderResult {
+  // Shared World + Given setup lives in post-tark-vitark.steps.ts; this file reads the rendered view from that setup.
   assert.ok(world.renderResult, 'Expected the debate screen to be rendered.');
   return world.renderResult;
 }
@@ -51,7 +52,10 @@ Then('each timeline item has the timeline__item CSS class', function (this: Deba
   assert.ok(items.length > 0, 'Expected timeline items to exist.');
 
   for (const item of items) {
-    assert.equal(item.classList.contains('timeline__item'), true);
+    assert.ok(
+      item.classList.contains('timeline__item'),
+      'Expected each timeline item to include the timeline__item CSS class.'
+    );
   }
 });
 
@@ -60,7 +64,10 @@ Then('each Tark timeline item has the timeline__item--tark class', function (thi
   assert.ok(tarkItems.length > 0, 'Expected at least one Tark timeline item.');
 
   for (const item of tarkItems) {
-    assert.equal(item.classList.contains('timeline__item--tark'), true);
+    assert.ok(
+      item.classList.contains('timeline__item--tark'),
+      'Expected each Tark timeline item to have the timeline__item--tark class.'
+    );
   }
 });
 
@@ -69,7 +76,10 @@ Then('each Vitark timeline item has the timeline__item--vitark class', function 
   assert.ok(vitarkItems.length > 0, 'Expected at least one Vitark timeline item.');
 
   for (const item of vitarkItems) {
-    assert.equal(item.classList.contains('timeline__item--vitark'), true);
+    assert.ok(
+      item.classList.contains('timeline__item--vitark'),
+      'Expected each Vitark timeline item to have the timeline__item--vitark class.'
+    );
   }
 });
 

--- a/features/step-definitions/debate-screen-polish.steps.ts
+++ b/features/step-definitions/debate-screen-polish.steps.ts
@@ -13,24 +13,32 @@ function activeRender(world: DebateScreenPolishWorld): RenderResult {
 
 function timelineItems(world: DebateScreenPolishWorld): HTMLElement[] {
   return Array.from(
-    activeRender(world).container.querySelectorAll<HTMLElement>('.timeline__list > .timeline__item')
+    activeRender(world).container.querySelectorAll<HTMLElement>('.timeline__list > li')
   );
 }
 
 function sideItems(world: DebateScreenPolishWorld, side: 'tark' | 'vitark'): HTMLElement[] {
-  return timelineItems(world).filter((item) => item.classList.contains(`timeline__item--${side}`));
+  const cards = Array.from(
+    activeRender(world).container.querySelectorAll<HTMLElement>(`.argument-card--${side}`)
+  );
+  assert.ok(cards.length > 0, `Expected at least one ${side} argument card.`);
+
+  return cards.map((card) => {
+    const timelineItem = card.closest('.timeline__item');
+    assert.ok(timelineItem instanceof HTMLElement, `Expected ${side} argument card to be inside a timeline item.`);
+    return timelineItem;
+  });
 }
 
 function assertSpineCellAsSecondChild(items: HTMLElement[], side: 'tark' | 'vitark'): void {
   assert.ok(items.length > 0, `Expected at least one ${side} timeline item.`);
 
   for (const item of items) {
-    assert.equal(item.children.length >= 2, true, `Expected ${side} item to have at least 2 children.`);
+    assert.ok(item.children.length >= 2, `Expected ${side} item to have at least 2 children.`);
     const secondChild = item.children.item(1);
     assert.ok(secondChild, `Expected ${side} item to have a second child.`);
-    assert.equal(
+    assert.ok(
       secondChild.classList.contains('timeline__spine-cell'),
-      true,
       `Expected ${side} item second child to be .timeline__spine-cell.`
     );
   }

--- a/features/support/jsdom-setup.mjs
+++ b/features/support/jsdom-setup.mjs
@@ -18,6 +18,7 @@ defineGlobalValue('document', win.document);
 defineGlobalValue('navigator', win.navigator);
 defineGlobalValue('self', win);
 defineGlobalValue('HTMLElement', win.HTMLElement);
+defineGlobalValue('HTMLParagraphElement', win.HTMLParagraphElement);
 defineGlobalValue('Node', win.Node);
 defineGlobalValue('Text', win.Text);
 defineGlobalValue('Event', win.Event);


### PR DESCRIPTION
## Summary
- add `features/debate-screen-polish.feature` with 7 DOM-structural scenarios from issue #126
- add `features/step-definitions/debate-screen-polish.steps.ts` for timeline item class, side class, child count, spine-cell order, and dot/card parity assertions
- fix jsdom cucumber setup by exposing `HTMLParagraphElement` globally so debate screen rendering works in BDD runs

## Verification
- `npm test`
- `npm run test:bdd`
- `npm run build`

Closes #126

## Agent Provenance
```
run-id:     cea1b377-c667-4848-bb53-8a3df44d088b
task-id:    issue/126
title:      Issue: https://github.com/nishantnaagnihotri/tark-vitark/issues/126
role:       dev
model:      gpt-5.3-codex
repo:       tark-vitark
dispatched: 17 Apr 2026, 18:57:03 IST
```