### PR TITLE
fix(orchestrator): re-read runs.json on every get_run_status call

### DIFF
--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -174,8 +174,9 @@ interface Run {
 }
 
 // persistRuns writes a lossy schema: _tasks is omitted and results[].output is
-// stripped to keep runs.json small. Use PersistedRun when reading from disk so
-// TypeScript surfaces missing fields instead of silently assuming they exist.
+// stripped to keep runs.json small. Use PersistedRun when reading from disk
+// (loadPersistedRuns and get_run_status disk-refresh) so TypeScript surfaces
+// missing fields instead of silently assuming they exist.
 type PersistedTaskResult = Omit<TaskResult, "output"> & { output?: never };
 type PersistedRun = Omit<Run, "_tasks" | "results"> & {
     _tasks?: never;
@@ -219,8 +220,14 @@ function loadPersistedRuns(): void {
     try {
         if (!existsSync(RUNS_FILE)) return;
         let mutated = false;
-        const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, Run>;
-        for (const [id, run] of Object.entries(raw)) {
+        const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, PersistedRun>;
+        for (const [id, persisted] of Object.entries(raw)) {
+            // Hydrate the lossy persisted shape back to a full Run before mutating.
+            const run: Run = {
+                ...persisted,
+                _tasks: [],
+                results: persisted.results as TaskResult[],
+            };
             // Mark any run that was "running" at crash time as failed
             if (run.status === "running") {
                 run.status = "failed";
@@ -239,7 +246,6 @@ function loadPersistedRuns(): void {
                 );
                 mutated = true;
             }
-            run._tasks = run._tasks ?? [];
             runs.set(id, run);
         }
         if (mutated) persistRuns();

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -515,6 +515,9 @@ server.tool(
             // Always prefer disk when memory was crash-marked "failed" at startup
             // and disk now has a real terminal state.
             if (mem.status === "failed" && isTerminalStatus(disk.status)) return true;
+            // Prefer disk when disk is terminal and memory is not — disk caught a
+            // completion that the in-memory run hasn't observed yet.
+            if (isTerminalStatus(disk.status) && !isTerminalStatus(mem.status)) return true;
             // Prefer disk when disk has a finishedAt that memory lacks or is older.
             // finishedAt is produced by nowIST() which returns a locale-formatted string
             // ("17 Apr 2026, 22:00:00 IST") — not ISO 8601. Date.parse may return NaN,

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -173,6 +173,15 @@ interface Run {
     _tasks: Task[];  // kept for submit_clarifications replay
 }
 
+// persistRuns writes a lossy schema: _tasks is omitted and results[].output is
+// stripped to keep runs.json small. Use PersistedRun when reading from disk so
+// TypeScript surfaces missing fields instead of silently assuming they exist.
+type PersistedTaskResult = Omit<TaskResult, "output"> & { output?: never };
+type PersistedRun = Omit<Run, "_tasks" | "results"> & {
+    _tasks?: never;
+    results: PersistedTaskResult[];
+};
+
 // ── Run registry (in-memory + disk) ──────────────────────────────────────────
 
 const RUNS_FILE = join(LOG_DIR, "runs.json");
@@ -507,9 +516,15 @@ server.tool(
             // and disk now has a real terminal state.
             if (mem.status === "failed" && isTerminalStatus(disk.status)) return true;
             // Prefer disk when disk has a finishedAt that memory lacks or is older.
+            // finishedAt is produced by nowIST() which returns a locale-formatted string
+            // ("17 Apr 2026, 22:00:00 IST") — not ISO 8601. Date.parse may return NaN,
+            // so guard explicitly and treat NaN as "indeterminate" (keep memory).
             if (disk.finishedAt) {
                 if (!mem.finishedAt) return true;
-                return new Date(disk.finishedAt).getTime() >= new Date(mem.finishedAt).getTime();
+                const diskMs = new Date(disk.finishedAt).getTime();
+                const memMs = new Date(mem.finishedAt).getTime();
+                if (!Number.isFinite(diskMs) || !Number.isFinite(memMs)) return false;
+                return diskMs >= memMs;
             }
             return false;
         };
@@ -552,10 +567,17 @@ server.tool(
 
         try {
             if (existsSync(RUNS_FILE)) {
-                const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, Run>;
+                const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, PersistedRun>;
                 const diskRun = raw[runId];
                 if (diskRun) {
-                    runs.set(runId, mergeRunState(runs.get(runId), diskRun));
+                    // Hydrate the lossy persisted shape back to Run: restore _tasks from
+                    // memory (disk never has it) and keep results typed correctly.
+                    const hydratedDisk: Run = {
+                        ...diskRun,
+                        _tasks: runs.get(runId)?._tasks ?? [],
+                        results: diskRun.results as TaskResult[],
+                    };
+                    runs.set(runId, mergeRunState(runs.get(runId), hydratedDisk));
                 }
             }
         } catch { /* non-fatal — fall through to in-memory state */ }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -495,6 +495,21 @@ server.tool(
         runId: z.string().uuid().describe("runId returned by run_async_subagents"),
     },
     async ({ runId }) => {
+        // Always re-read from disk before serving status — the in-memory Map can
+        // be stale when VS Code restarts the MCP server process after a run
+        // completes (old process writes "done" to disk; new process already
+        // loaded an intermediate "running"→"failed" snapshot at startup).
+        try {
+            if (existsSync(RUNS_FILE)) {
+                const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, Run>;
+                const diskRun = raw[runId];
+                if (diskRun) {
+                    diskRun._tasks = runs.get(runId)?._tasks ?? diskRun._tasks ?? [];
+                    runs.set(runId, diskRun);
+                }
+            }
+        } catch { /* non-fatal — fall through to in-memory state */ }
+
         const run = runs.get(runId);
         if (!run) {
             return {

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -495,17 +495,67 @@ server.tool(
         runId: z.string().uuid().describe("runId returned by run_async_subagents"),
     },
     async ({ runId }) => {
-        // Always re-read from disk before serving status — the in-memory Map can
-        // be stale when VS Code restarts the MCP server process after a run
-        // completes (old process writes "done" to disk; new process already
-        // loaded an intermediate "running"→"failed" snapshot at startup).
+        // Re-read from disk before serving status so a restarted MCP process can
+        // observe a newer persisted terminal state, but do NOT blindly replace
+        // richer in-memory data with the lossy on-disk snapshot (persistRuns strips
+        // TaskResult.output, so an unconditional overwrite drops outputPreview).
+        const isTerminalStatus = (s: Run["status"]) =>
+            s === "done" || s === "failed" || s === "pending-clarification";
+
+        const shouldPreferDisk = (mem: Run, disk: Run): boolean => {
+            // Always prefer disk when memory was crash-marked "failed" at startup
+            // and disk now has a real terminal state.
+            if (mem.status === "failed" && isTerminalStatus(disk.status)) return true;
+            // Prefer disk when disk has a finishedAt that memory lacks or is older.
+            if (disk.finishedAt) {
+                if (!mem.finishedAt) return true;
+                return new Date(disk.finishedAt).getTime() >= new Date(mem.finishedAt).getTime();
+            }
+            return false;
+        };
+
+        const mergeRunState = (mem: Run | undefined, disk: Run): Run => {
+            if (!mem) return { ...disk, _tasks: disk._tasks ?? [] };
+
+            const memById = new Map(mem.results.map((r) => [r.taskId, r]));
+            const diskById = new Map(disk.results.map((r) => [r.taskId, r]));
+            const allIds = new Set([...memById.keys(), ...diskById.keys()]);
+            const preferDisk = shouldPreferDisk(mem, disk);
+
+            const mergedResults = Array.from(allIds).map((id) => {
+                const mr = memById.get(id);
+                const dr = diskById.get(id);
+                if (!mr) return dr!;
+                if (!dr) return mr;
+                // Whichever source wins, always preserve richer in-memory output.
+                return {
+                    ...(preferDisk ? mr : dr),
+                    ...(preferDisk ? dr : mr),
+                    output: mr.output ?? dr.output,
+                };
+            });
+
+            return {
+                ...(preferDisk ? mem : disk),
+                ...(preferDisk ? disk : mem),
+                results: mergedResults,
+                _tasks: mem._tasks ?? disk._tasks ?? [],
+                taskIds: mem.taskIds.length > 0 ? mem.taskIds : disk.taskIds,
+                pendingClarification: preferDisk
+                    ? (disk.pendingClarification ?? mem.pendingClarification)
+                    : (mem.pendingClarification ?? disk.pendingClarification),
+                finishedAt: preferDisk
+                    ? (disk.finishedAt ?? mem.finishedAt)
+                    : (mem.finishedAt ?? disk.finishedAt),
+            };
+        };
+
         try {
             if (existsSync(RUNS_FILE)) {
                 const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, Run>;
                 const diskRun = raw[runId];
                 if (diskRun) {
-                    diskRun._tasks = runs.get(runId)?._tasks ?? diskRun._tasks ?? [];
-                    runs.set(runId, diskRun);
+                    runs.set(runId, mergeRunState(runs.get(runId), diskRun));
                 }
             }
         } catch { /* non-fatal — fall through to in-memory state */ }


### PR DESCRIPTION
## Problem

`get_run_status` returned `running` with empty results even after both agents had finished and opened PRs. Root cause: the tool reads only from the in-memory `runs` Map, which goes stale across MCP server restarts.

Sequence that triggers the bug:
1. Run dispatched → `runs.json` written with `status: "running"`
2. VS Code restarts the MCP server process mid-run (e.g. on file save)
3. `loadPersistedRuns()` runs at startup, sees `"running"` → marks it `"failed"` in memory
4. Old process completes, writes `"done"` to disk
5. New process is now live — `get_run_status` serves the stale `"failed"` Map entry, never seeing the `"done"` on disk

## Fix

At the top of the `get_run_status` handler, re-read the specific run entry from `runs.json` and refresh the in-memory Map before serving the response. Falls back to existing in-memory state if disk read fails (non-fatal). Preserves `_tasks` from memory (needed for `submit_clarifications` reruns).

## Agent Provenance
- role: architect-orchestrator
- task-id: fix/orchestrator-run-status-disk-refresh
- run-id: direct-invocation
- dispatched: 2026-04-17