### PR TITLE
chore: add GitHub token maintenance section to agent-dispatch skill

### DIFF
--- a/.github/skills/agent-dispatch/SKILL.md
+++ b/.github/skills/agent-dispatch/SKILL.md
@@ -193,6 +193,48 @@ VS Code's Figma extension stores the OAuth token in VS Code's safeStorage. **Lin
 
 ---
 
+## MCP Auth Maintenance — GitHub Token
+
+### Token facts
+
+| Property | Value |
+|---|---|
+| Token type | Personal access token-style bearer (`gho_…`) |
+| Source | `gh` CLI OAuth login (`gh auth login`) |
+| Refresh model | No built-in auto-refresh; re-authentication mints a new token |
+| Storage | `local.env` as `GITHUB_TOKEN` |
+| Consumer | GitHub MCP `_envHeaders` expansion in `.vscode/mcp.json` |
+
+### When to refresh
+
+- Any GitHub MCP call returns `401 Unauthorized` or `403 Forbidden`
+- `[run-agent] mcp-hdrs` log line shows `first value prefix="Bearer "` (token is empty/unset)
+
+### How to refresh
+
+```bash
+gh auth login      # re-authenticate via browser
+gh auth token      # print new token
+# then update local.env: GITHUB_TOKEN=<new token>
+```
+
+After updating `local.env`, re-source env vars before dispatching agents:
+
+```bash
+set -a && source local.env && set +a
+```
+
+### Verify after refresh
+
+```bash
+set -a && source local.env && set +a
+npx tsx scripts/run-agent.ts dev "Call the GitHub MCP get_me tool and return exactly what it gives you."
+```
+
+Expected output includes your GitHub `login`. Any auth error at this step means `GITHUB_TOKEN` is still invalid or unset.
+
+---
+
 ## Log Reference
 
 | Log prefix | Meaning |

--- a/.github/skills/agent-dispatch/SKILL.md
+++ b/.github/skills/agent-dispatch/SKILL.md
@@ -208,7 +208,7 @@ VS Code's Figma extension stores the OAuth token in VS Code's safeStorage. **Lin
 ### When to refresh
 
 - Any GitHub MCP call returns `401 Unauthorized` or `403 Forbidden`
-- `[run-agent] mcp-hdrs` log line shows `first value prefix="Bearer "` (token is empty/unset)
+- `[run-agent] mcp-hdrs` log line shows `resolved=[none] skipped=[Authorization]` for the GitHub server (the `GITHUB_TOKEN` env var is empty, unset, or invalid)
 
 ### How to refresh
 


### PR DESCRIPTION
## Summary
- add `MCP Auth Maintenance — GitHub Token` to `.github/skills/agent-dispatch/SKILL.md`
- mirror the Figma section structure with token facts, refresh conditions, refresh steps, and verification steps
- place the new section immediately after the Figma token maintenance section

Closes #142

## Agent Provenance
- run-id: direct-invocation
- task-id: direct-invocation
- role: dev
- dispatched: false