### PR TITLE
fix(poller): short-SHA prefix match and --after timestamp filter for wait_for_copilot_review.js

### DIFF
--- a/scripts/wait_for_copilot_review.js
+++ b/scripts/wait_for_copilot_review.js
@@ -108,6 +108,7 @@ function parseCliArgs() {
         repo: { type: "string" },
         pr: { type: "string" },
         "head-sha": { type: "string" },
+        "after": { type: "string" },
         "timeout-seconds": { type: "string", default: "600" },
         "interval-seconds": { type: "string", default: "15" },
       },
@@ -121,6 +122,7 @@ function parseCliArgs() {
   const repo = values.repo;
   const pr = parseInt(values.pr, 10);
   const headSha = values["head-sha"] || null;
+  const after = values["after"] || null;
   const timeoutSeconds = parseInt(values["timeout-seconds"], 10);
   const intervalSeconds = parseInt(values["interval-seconds"], 10);
 
@@ -129,6 +131,9 @@ function parseCliArgs() {
   }
   if (!Number.isInteger(pr) || pr <= 0) {
     exitError("--pr must be a positive integer");
+  }
+  if (after !== null && isNaN(Date.parse(after))) {
+    exitError("--after must be a valid ISO 8601 timestamp (e.g. 2026-04-19T12:00:00Z)");
   }
 
   if (Number.isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
@@ -141,7 +146,7 @@ function parseCliArgs() {
     exitError("--interval-seconds must not exceed --timeout-seconds");
   }
 
-  return { owner, repo, pr, headSha, timeoutSeconds, intervalSeconds };
+  return { owner, repo, pr, headSha, after, timeoutSeconds, intervalSeconds };
 }
 
 function formatCheckRuns(commitNodes) {
@@ -160,14 +165,32 @@ function formatCheckRuns(commitNodes) {
 }
 
 async function main() {
-  const { owner, repo, pr, headSha, timeoutSeconds, intervalSeconds } =
+  const { owner, repo, pr, headSha, after, timeoutSeconds, intervalSeconds } =
     parseCliArgs();
   const start = Date.now();
+  // Records reviews submitted after this timestamp. Defaults to poll start time
+  // so pre-existing reviews are never returned as "new".
+  const afterMs = after ? Date.parse(after) : start;
 
-  // First query to resolve target SHA
+  // First query to resolve full target SHA (supports short-SHA prefix input).
   const initial = ghGraphQL(REVIEW_QUERY, { owner, repo, pr });
-  const targetSha =
-    headSha || initial.data.repository.pullRequest.headRefOid;
+  const liveShaInitial = initial.data.repository.pullRequest.headRefOid;
+  if (headSha && !liveShaInitial.startsWith(headSha)) {
+    console.log(
+      JSON.stringify(
+        {
+          status: "head-changed",
+          elapsed_seconds: 0,
+          expected_head_sha: headSha,
+          live_head_sha: liveShaInitial,
+        },
+        null,
+        2
+      )
+    );
+    process.exit(3);
+  }
+  const targetSha = liveShaInitial;
 
   while (true) {
     const elapsed = Math.round((Date.now() - start) / 1000);
@@ -197,7 +220,8 @@ async function main() {
           r.author?.login === BOT_LOGIN &&
           r.commit?.oid === targetSha &&
           r.state !== "PENDING" &&
-          r.submittedAt
+          r.submittedAt &&
+          Date.parse(r.submittedAt) > afterMs
       )
       .sort((a, b) => a.submittedAt.localeCompare(b.submittedAt));
 

--- a/scripts/wait_for_copilot_review.js
+++ b/scripts/wait_for_copilot_review.js
@@ -132,8 +132,8 @@ function parseCliArgs() {
   if (!Number.isInteger(pr) || pr <= 0) {
     exitError("--pr must be a positive integer");
   }
-  if (after !== null && isNaN(Date.parse(after))) {
-    exitError("--after must be a valid ISO 8601 timestamp (e.g. 2026-04-19T12:00:00Z)");
+  if (after !== null && !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(after)) {
+    exitError("--after must be an ISO 8601 timestamp with explicit timezone (e.g. 2026-04-19T12:00:00Z)");
   }
 
   if (Number.isNaN(timeoutSeconds) || timeoutSeconds <= 0) {


### PR DESCRIPTION
## Problem

Two bugs in `scripts/wait_for_copilot_review.js` caused unreliable polling:

1. **Short SHA comparison (exit 3):** `--head-sha 0cffa20` was compared with strict equality against the full 40-char `liveSha` — always a mismatch → immediate `head-changed` exit.
2. **False-positive exit 0:** When `--head-sha` was omitted, the script resolved `targetSha` from the live PR head and then immediately found a bot review already attached to that SHA, returning it as if a new review had arrived.

## Fix

- Use `startsWith()` for the prefix check after resolving the full SHA from the live PR head on startup.
- Add `--after <ISO 8601>` option; only reviews with `submittedAt > afterMs` are returned. Defaults to poll start time so pre-existing reviews are always filtered out even when `--after` is omitted.

## Usage going forward

```bash
REVIEW_REQUESTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
node scripts/wait_for_copilot_review.js \
  --owner nishantnaagnihotri --repo tark-vitark --pr <N> \
  --head-sha "$HEAD_SHA" \
  --after "$REVIEW_REQUESTED_AT"
```

## Files changed

- `scripts/wait_for_copilot_review.js` (1 file, +30/-6 lines)