### PR TITLE
chore: add Code Review Specs section to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,6 +31,12 @@ tark-vitark is a personal portfolio/product project. Current implementation is s
 - Skill hardening suggestions should be concrete: specify the skill file, the rule or checklist item to add, and the trigger condition.
 - Apply this principle after gate closures, incident reviews, and any time a protocol deviation is caught.
 
+## Code Review Specs
+
+When reviewing a pull request, Copilot must:
+
+- Always leave a review comment if any existing review thread on the PR has no response from the author. Point out the unanswered thread(s) explicitly so the author knows they need to reply before the review loop can close.
+
 ## Proprietary
 
 This repository is proprietary. All rights reserved. See `LICENSE`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,8 @@ tark-vitark is a personal portfolio/product project. Current implementation is s
 
 When reviewing a pull request, Copilot must:
 
-- Always leave a review comment if any existing review thread on the PR has no response from the author. Point out the unanswered thread(s) explicitly so the author knows they need to reply before the review loop can close.
+- If the provided PR context includes existing review threads and their reply state, leave a review comment when any review thread has no response from the author. Point out the unanswered thread(s) explicitly so the author knows they need to reply before the review loop can close.
+- If the provided review context does not include existing review threads or their reply state, explicitly say that thread status is unavailable and do not guess, infer, or fabricate unanswered threads.
 
 ## Proprietary
 


### PR DESCRIPTION
## Summary

Adds a `## Code Review Specs` section to `.github/copilot-instructions.md` instructing Copilot to always leave a review comment when any existing review thread on the PR has no response from the author.

## Changes

- `.github/copilot-instructions.md`: new `Code Review Specs` section added before `Proprietary`

## Why

Hardens the code review workflow so Copilot proactively surfaces unanswered threads, preventing the review loop from stalling silently.