### PR TITLE
chore: add pre-completion self-check to pr-review-loop skill

### DIFF
--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -140,8 +140,8 @@ Before declaring the PR review workflow complete or saying the PR is "merge-read
 
 | # | Question | Pass condition |
 |---|---|---|
-| 1 | **Are there any open comments?** Fetch all PR review comments via `gh api repos/<owner>/<repo>/pulls/<n>/comments` and verify every thread has a disposition reply from the author. | Zero `semantic-open` threads |
-| 2 | **Did the latest Copilot review body say "generated 0 comments"?** | Yes, on the current head SHA |
+| 1 | **Are there any open comments?** Fetch both PR review comments via `gh api repos/<owner>/<repo>/pulls/<n>/comments` and top-level PR conversation comments via `gh api repos/<owner>/<repo>/issues/<n>/comments`, then verify there are no unresolved review comments or PR conversation comments that still require a disposition reply from the **PR author**. | Zero unresolved review comments or PR conversation comments awaiting PR-author reply |
+| 2 | **Did the latest Copilot review body indicate zero new comments (for example, "generated 0 comments", "0 new comments", or equivalent wording)?** | Yes — any semantically equivalent zero-comments wording, on the current head SHA |
 | 3 | **Is the branch up-to-date with the base?** | Branch sync check passed (Section 4) |
 | 4 | **Are all challenges resolved with Product Owner?** | No pending `Challenge` items awaiting PO disposition |
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -131,3 +131,18 @@ Status: semantic-closed | semantic-open (reason)
 5. **If rebase fails** (non-trivial conflicts or history divergence): do not attempt to force-resolve. Surface the conflict summary to the Product Owner and await explicit authorization before proceeding.
 
 6. **Ongoing check frequency:** verify sync status at minimum once per review loop completion (after 0-comments clean pass). If the PR has been open for multiple sessions or large changes have landed on the base branch since the PR was opened, also check before each fix-push batch.
+
+---
+
+## 5. Pre-Completion Self-Check (Mandatory Before Declaring Done)
+
+Before declaring the PR review workflow complete or saying the PR is "merge-ready", the agent **must** answer each question below. Answering "no" to any item is a blocking condition.
+
+| # | Question | Pass condition |
+|---|---|---|
+| 1 | **Are there any open comments?** Fetch all PR review comments via `gh api repos/<owner>/<repo>/pulls/<n>/comments` and verify every thread has a disposition reply from the author. | Zero `semantic-open` threads |
+| 2 | **Did the latest Copilot review body say "generated 0 comments"?** | Yes, on the current head SHA |
+| 3 | **Is the branch up-to-date with the base?** | Branch sync check passed (Section 4) |
+| 4 | **Are all challenges resolved with Product Owner?** | No pending `Challenge` items awaiting PO disposition |
+
+**Hardening rule:** the agent must not declare "merge-ready" or call the overall task complete until it has explicitly run this self-check and confirmed all four items pass. Skipping this check is a workflow failure.


### PR DESCRIPTION
## Summary

Adds a mandatory **Section 5: Pre-Completion Self-Check** to `.github/skills/pr-review-loop/SKILL.md`.

The new section requires the agent to answer four questions before declaring any PR done or merge-ready:

1. Are there any open comments? (fetch and verify all threads have disposition replies)
2. Did the latest Copilot review return 0 comments on the current head SHA?
3. Is the branch up-to-date with the base?
4. Are all challenges resolved with Product Owner?

## Motivation

In the `post-tark-vitark` slice review loop, the agent declared PR #150 merge-ready before triaging all open review threads (the `sessionId`/`persistRun` thread was missed on the first pass). This hardening prevents that failure mode by making an explicit open-comment check a blocking gate before completion.

## Files Changed

- `.github/skills/pr-review-loop/SKILL.md` — added Section 5

## Checklist

- [x] session-id: chore/harden-pr-review-loop-precompletion-check
- [x] No feature code changed
- [x] Single-file, single-purpose change