### PR TITLE
feat(podium-fab): add PodiumFAB component

### DIFF
--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import type { Side } from '../data/debate';
 import '../styles/components/podium-fab.css';
 
@@ -9,46 +10,71 @@ export interface PodiumFABProps {
 }
 
 export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: PodiumFABProps) {
-    if (!isExpanded) {
-        return (
+    const openComposerButtonRef = useRef<HTMLButtonElement>(null);
+    const tarkComposerButtonRef = useRef<HTMLButtonElement>(null);
+    const wasExpandedRef = useRef(isExpanded);
+
+    useEffect(() => {
+        if (isExpanded && !wasExpandedRef.current) {
+            tarkComposerButtonRef.current?.focus();
+        }
+
+        if (!isExpanded && wasExpandedRef.current) {
+            openComposerButtonRef.current?.focus();
+        }
+
+        wasExpandedRef.current = isExpanded;
+    }, [isExpanded]);
+
+    return (
+        <div className={`podium-fab-shell${isExpanded ? ' podium-fab-shell--expanded' : ''}`}>
             <button
+                ref={openComposerButtonRef}
                 type="button"
-                className="podium-fab"
+                className="podium-fab podium-fab__trigger"
                 aria-label="Open post composer"
-                aria-expanded="false"
+                aria-expanded={isExpanded ? 'true' : 'false'}
+                aria-hidden={isExpanded}
+                tabIndex={isExpanded ? -1 : 0}
                 onClick={onExpand}
             >
                 <span aria-hidden="true">+</span>
             </button>
-        );
-    }
-
-    return (
-        <div className="podium-fab podium-fab--expanded" role="group" aria-label="Post composer options">
-            <button
-                type="button"
-                className="podium-fab__mini-btn podium-fab__mini-btn--tark"
-                aria-label="Post as Tark"
-                onClick={() => onSideSelect('tark')}
+            <div
+                className="podium-fab podium-fab--expanded"
+                role={isExpanded ? 'group' : undefined}
+                aria-label={isExpanded ? 'Post composer options' : undefined}
+                aria-hidden={!isExpanded}
             >
-                T
-            </button>
-            <button
-                type="button"
-                className="podium-fab__mini-btn podium-fab__mini-btn--vitark"
-                aria-label="Post as Vitark"
-                onClick={() => onSideSelect('vitark')}
-            >
-                V
-            </button>
-            <button
-                type="button"
-                className="podium-fab__dismiss"
-                aria-label="Close"
-                onClick={onCollapse}
-            >
-                ×
-            </button>
+                <button
+                    ref={tarkComposerButtonRef}
+                    type="button"
+                    className="podium-fab__mini-btn podium-fab__mini-btn--tark"
+                    aria-label="Post as Tark"
+                    tabIndex={isExpanded ? 0 : -1}
+                    onClick={() => onSideSelect('tark')}
+                >
+                    T
+                </button>
+                <button
+                    type="button"
+                    className="podium-fab__mini-btn podium-fab__mini-btn--vitark"
+                    aria-label="Post as Vitark"
+                    tabIndex={isExpanded ? 0 : -1}
+                    onClick={() => onSideSelect('vitark')}
+                >
+                    V
+                </button>
+                <button
+                    type="button"
+                    className="podium-fab__dismiss"
+                    aria-label="Close"
+                    tabIndex={isExpanded ? 0 : -1}
+                    onClick={onCollapse}
+                >
+                    ×
+                </button>
+            </div>
         </div>
     );
 }

--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -101,9 +101,10 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
             )}
             {shouldRenderComposerGroup && (
                 <div
-                    className={`podium-fab-group${isComposerExpanded ? ' podium-fab-group--expanded' : ''}`}
+                    className={`podium-fab podium-fab--group${isComposerExpanded ? ' podium-fab--expanded' : ''}`}
                     role={isComposerExpanded ? 'group' : undefined}
                     aria-label={isComposerExpanded ? 'Post composer options' : undefined}
+                    aria-hidden={!isComposerExpanded}
                 >
                     <button
                         ref={tarkComposerButtonRef}
@@ -111,6 +112,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         className="podium-fab__mini-btn podium-fab__mini-btn--tark"
                         aria-label="Post as Tark"
                         tabIndex={isComposerExpanded ? 0 : -1}
+                        disabled={!isComposerExpanded}
                         onClick={() => onSideSelect('tark')}
                     >
                         T
@@ -120,6 +122,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         className="podium-fab__mini-btn podium-fab__mini-btn--vitark"
                         aria-label="Post as Vitark"
                         tabIndex={isComposerExpanded ? 0 : -1}
+                        disabled={!isComposerExpanded}
                         onClick={() => onSideSelect('vitark')}
                     >
                         V
@@ -129,6 +132,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         className="podium-fab__dismiss"
                         aria-label="Close"
                         tabIndex={isComposerExpanded ? 0 : -1}
+                        disabled={!isComposerExpanded}
                         onClick={onCollapse}
                     >
                         ×

--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -9,14 +9,12 @@ export interface PodiumFABProps {
     onCollapse: () => void;
 }
 
-const FAB_TRANSITION_MS = 300;
-
 export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: PodiumFABProps) {
     const openComposerButtonRef = useRef<HTMLButtonElement>(null);
     const tarkComposerButtonRef = useRef<HTMLButtonElement>(null);
     const wasExpandedRef = useRef(isExpanded);
     const shouldFocusExpandedControlRef = useRef(false);
-    const collapseTimeoutRef = useRef<number | null>(null);
+    const shouldUnmountComposerGroupRef = useRef(false);
     const expandFrameRef = useRef<number | null>(null);
     const [isComposerVisible, setIsComposerVisible] = useState(isExpanded);
     const [isComposerExpanded, setIsComposerExpanded] = useState(isExpanded);
@@ -25,11 +23,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
         const wasExpanded = wasExpandedRef.current;
 
         if (isExpanded) {
-            if (collapseTimeoutRef.current !== null) {
-                window.clearTimeout(collapseTimeoutRef.current);
-                collapseTimeoutRef.current = null;
-            }
-
+            shouldUnmountComposerGroupRef.current = false;
             setIsComposerVisible(true);
 
             if (!wasExpanded) {
@@ -62,10 +56,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
             setIsComposerExpanded(false);
 
             if (isComposerVisible) {
-                collapseTimeoutRef.current = window.setTimeout(() => {
-                    setIsComposerVisible(false);
-                    collapseTimeoutRef.current = null;
-                }, FAB_TRANSITION_MS);
+                shouldUnmountComposerGroupRef.current = true;
             }
         }
 
@@ -74,10 +65,6 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
 
     useEffect(
         () => () => {
-            if (collapseTimeoutRef.current !== null) {
-                window.clearTimeout(collapseTimeoutRef.current);
-            }
-
             if (expandFrameRef.current !== null) {
                 window.cancelAnimationFrame(expandFrameRef.current);
             }
@@ -91,6 +78,13 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
             shouldFocusExpandedControlRef.current = false;
         }
     }, [isComposerExpanded]);
+
+    const handleComposerCollapseTransitionEnd = () => {
+        if (!isComposerExpanded && shouldUnmountComposerGroupRef.current) {
+            setIsComposerVisible(false);
+            shouldUnmountComposerGroupRef.current = false;
+        }
+    };
 
     const shouldRenderComposerGroup = isComposerVisible || isExpanded;
 
@@ -142,6 +136,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         aria-label="Close"
                         tabIndex={isComposerExpanded ? 0 : -1}
                         disabled={!isComposerExpanded}
+                        onTransitionEnd={handleComposerCollapseTransitionEnd}
                         onClick={onCollapse}
                     >
                         ×

--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Side } from '../data/debate';
 import '../styles/components/podium-fab.css';
 
@@ -9,72 +9,132 @@ export interface PodiumFABProps {
     onCollapse: () => void;
 }
 
+const FAB_TRANSITION_MS = 300;
+
 export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: PodiumFABProps) {
     const openComposerButtonRef = useRef<HTMLButtonElement>(null);
     const tarkComposerButtonRef = useRef<HTMLButtonElement>(null);
     const wasExpandedRef = useRef(isExpanded);
+    const collapseTimeoutRef = useRef<number | null>(null);
+    const expandFrameRef = useRef<number | null>(null);
+    const [isComposerVisible, setIsComposerVisible] = useState(isExpanded);
+    const [isComposerExpanded, setIsComposerExpanded] = useState(isExpanded);
 
     useEffect(() => {
-        if (isExpanded && !wasExpandedRef.current) {
-            tarkComposerButtonRef.current?.focus();
+        const wasExpanded = wasExpandedRef.current;
+
+        if (isExpanded) {
+            if (collapseTimeoutRef.current !== null) {
+                window.clearTimeout(collapseTimeoutRef.current);
+                collapseTimeoutRef.current = null;
+            }
+
+            setIsComposerVisible(true);
+
+            if (!wasExpanded) {
+                setIsComposerExpanded(false);
+
+                if (expandFrameRef.current !== null) {
+                    window.cancelAnimationFrame(expandFrameRef.current);
+                }
+
+                expandFrameRef.current = window.requestAnimationFrame(() => {
+                    setIsComposerExpanded(true);
+                    tarkComposerButtonRef.current?.focus();
+                });
+            } else {
+                setIsComposerExpanded(true);
+            }
         }
 
-        if (!isExpanded && wasExpandedRef.current) {
-            openComposerButtonRef.current?.focus();
+        if (!isExpanded) {
+            if (expandFrameRef.current !== null) {
+                window.cancelAnimationFrame(expandFrameRef.current);
+                expandFrameRef.current = null;
+            }
+
+            if (wasExpanded) {
+                openComposerButtonRef.current?.focus();
+            }
+
+            setIsComposerExpanded(false);
+
+            if (isComposerVisible) {
+                collapseTimeoutRef.current = window.setTimeout(() => {
+                    setIsComposerVisible(false);
+                    collapseTimeoutRef.current = null;
+                }, FAB_TRANSITION_MS);
+            }
         }
 
         wasExpandedRef.current = isExpanded;
-    }, [isExpanded]);
+    }, [isExpanded, isComposerVisible]);
+
+    useEffect(
+        () => () => {
+            if (collapseTimeoutRef.current !== null) {
+                window.clearTimeout(collapseTimeoutRef.current);
+            }
+
+            if (expandFrameRef.current !== null) {
+                window.cancelAnimationFrame(expandFrameRef.current);
+            }
+        },
+        []
+    );
+
+    const shouldRenderComposerGroup = isComposerVisible || isExpanded;
 
     return (
-        <div className={`podium-fab-shell${isExpanded ? ' podium-fab-shell--expanded' : ''}`}>
-            <button
-                ref={openComposerButtonRef}
-                type="button"
-                className="podium-fab podium-fab__trigger"
-                aria-label="Open post composer"
-                aria-expanded={isExpanded ? 'true' : 'false'}
-                aria-hidden={isExpanded}
-                tabIndex={isExpanded ? -1 : 0}
-                onClick={onExpand}
-            >
-                <span aria-hidden="true">+</span>
-            </button>
-            <div
-                className="podium-fab podium-fab--expanded"
-                role={isExpanded ? 'group' : undefined}
-                aria-label={isExpanded ? 'Post composer options' : undefined}
-                aria-hidden={!isExpanded}
-            >
+        <div className="podium-fab-shell">
+            {!isExpanded && (
                 <button
-                    ref={tarkComposerButtonRef}
+                    ref={openComposerButtonRef}
                     type="button"
-                    className="podium-fab__mini-btn podium-fab__mini-btn--tark"
-                    aria-label="Post as Tark"
-                    tabIndex={isExpanded ? 0 : -1}
-                    onClick={() => onSideSelect('tark')}
+                    className="podium-fab"
+                    aria-label="Open post composer"
+                    aria-expanded={false}
+                    onClick={onExpand}
                 >
-                    T
+                    <span aria-hidden="true">+</span>
                 </button>
-                <button
-                    type="button"
-                    className="podium-fab__mini-btn podium-fab__mini-btn--vitark"
-                    aria-label="Post as Vitark"
-                    tabIndex={isExpanded ? 0 : -1}
-                    onClick={() => onSideSelect('vitark')}
+            )}
+            {shouldRenderComposerGroup && (
+                <div
+                    className={`podium-fab-group${isComposerExpanded ? ' podium-fab-group--expanded' : ''}`}
+                    role={isComposerExpanded ? 'group' : undefined}
+                    aria-label={isComposerExpanded ? 'Post composer options' : undefined}
                 >
-                    V
-                </button>
-                <button
-                    type="button"
-                    className="podium-fab__dismiss"
-                    aria-label="Close"
-                    tabIndex={isExpanded ? 0 : -1}
-                    onClick={onCollapse}
-                >
-                    ×
-                </button>
-            </div>
+                    <button
+                        ref={tarkComposerButtonRef}
+                        type="button"
+                        className="podium-fab__mini-btn podium-fab__mini-btn--tark"
+                        aria-label="Post as Tark"
+                        tabIndex={isComposerExpanded ? 0 : -1}
+                        onClick={() => onSideSelect('tark')}
+                    >
+                        T
+                    </button>
+                    <button
+                        type="button"
+                        className="podium-fab__mini-btn podium-fab__mini-btn--vitark"
+                        aria-label="Post as Vitark"
+                        tabIndex={isComposerExpanded ? 0 : -1}
+                        onClick={() => onSideSelect('vitark')}
+                    >
+                        V
+                    </button>
+                    <button
+                        type="button"
+                        className="podium-fab__dismiss"
+                        aria-label="Close"
+                        tabIndex={isComposerExpanded ? 0 : -1}
+                        onClick={onCollapse}
+                    >
+                        ×
+                    </button>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -15,6 +15,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
     const wasExpandedRef = useRef(isExpanded);
     const shouldFocusExpandedControlRef = useRef(false);
     const shouldUnmountComposerGroupRef = useRef(false);
+    const shouldRestoreOpenComposerFocusRef = useRef(false);
     const expandFrameRef = useRef<number | null>(null);
     const [isComposerVisible, setIsComposerVisible] = useState(isExpanded);
     const [isComposerExpanded, setIsComposerExpanded] = useState(isExpanded);
@@ -24,6 +25,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
 
         if (isExpanded) {
             shouldUnmountComposerGroupRef.current = false;
+            shouldRestoreOpenComposerFocusRef.current = false;
             setIsComposerVisible(true);
 
             if (!wasExpanded) {
@@ -48,10 +50,11 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                 expandFrameRef.current = null;
             }
 
-            if (wasExpanded) {
+            if (wasExpanded && shouldRestoreOpenComposerFocusRef.current) {
                 openComposerButtonRef.current?.focus();
             }
 
+            shouldRestoreOpenComposerFocusRef.current = false;
             shouldFocusExpandedControlRef.current = false;
             setIsComposerExpanded(false);
 
@@ -87,6 +90,15 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
     };
 
     const shouldRenderComposerGroup = isComposerVisible || isExpanded;
+    const handleSideSelection = (side: Side) => {
+        shouldRestoreOpenComposerFocusRef.current = false;
+        onSideSelect(side);
+    };
+
+    const handleComposerCollapse = () => {
+        shouldRestoreOpenComposerFocusRef.current = true;
+        onCollapse();
+    };
 
     return (
         <>
@@ -116,7 +128,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         aria-label="Post as Tark"
                         tabIndex={isComposerExpanded ? 0 : -1}
                         disabled={!isComposerExpanded}
-                        onClick={() => onSideSelect('tark')}
+                        onClick={() => handleSideSelection('tark')}
                     >
                         T
                     </button>
@@ -126,7 +138,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         aria-label="Post as Vitark"
                         tabIndex={isComposerExpanded ? 0 : -1}
                         disabled={!isComposerExpanded}
-                        onClick={() => onSideSelect('vitark')}
+                        onClick={() => handleSideSelection('vitark')}
                     >
                         V
                     </button>
@@ -137,7 +149,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                         tabIndex={isComposerExpanded ? 0 : -1}
                         disabled={!isComposerExpanded}
                         onTransitionEnd={handleComposerCollapseTransitionEnd}
-                        onClick={onCollapse}
+                        onClick={handleComposerCollapse}
                     >
                         ×
                     </button>

--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -15,6 +15,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
     const openComposerButtonRef = useRef<HTMLButtonElement>(null);
     const tarkComposerButtonRef = useRef<HTMLButtonElement>(null);
     const wasExpandedRef = useRef(isExpanded);
+    const shouldFocusExpandedControlRef = useRef(false);
     const collapseTimeoutRef = useRef<number | null>(null);
     const expandFrameRef = useRef<number | null>(null);
     const [isComposerVisible, setIsComposerVisible] = useState(isExpanded);
@@ -38,9 +39,9 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                     window.cancelAnimationFrame(expandFrameRef.current);
                 }
 
+                shouldFocusExpandedControlRef.current = true;
                 expandFrameRef.current = window.requestAnimationFrame(() => {
                     setIsComposerExpanded(true);
-                    tarkComposerButtonRef.current?.focus();
                 });
             } else {
                 setIsComposerExpanded(true);
@@ -57,6 +58,7 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                 openComposerButtonRef.current?.focus();
             }
 
+            shouldFocusExpandedControlRef.current = false;
             setIsComposerExpanded(false);
 
             if (isComposerVisible) {
@@ -83,10 +85,17 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
         []
     );
 
+    useEffect(() => {
+        if (isComposerExpanded && shouldFocusExpandedControlRef.current) {
+            tarkComposerButtonRef.current?.focus();
+            shouldFocusExpandedControlRef.current = false;
+        }
+    }, [isComposerExpanded]);
+
     const shouldRenderComposerGroup = isComposerVisible || isExpanded;
 
     return (
-        <div className="podium-fab-shell">
+        <>
             {!isExpanded && (
                 <button
                     ref={openComposerButtonRef}
@@ -101,9 +110,9 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
             )}
             {shouldRenderComposerGroup && (
                 <div
-                    className={`podium-fab podium-fab--group${isComposerExpanded ? ' podium-fab--expanded' : ''}`}
-                    role={isComposerExpanded ? 'group' : undefined}
-                    aria-label={isComposerExpanded ? 'Post composer options' : undefined}
+                    className={`podium-fab${isComposerExpanded ? ' podium-fab--expanded' : ''}`}
+                    role="group"
+                    aria-label="Post composer options"
                     aria-hidden={!isComposerExpanded}
                 >
                     <button
@@ -139,6 +148,6 @@ export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: Po
                     </button>
                 </div>
             )}
-        </div>
+        </>
     );
 }

--- a/src/components/PodiumFAB.tsx
+++ b/src/components/PodiumFAB.tsx
@@ -1,0 +1,54 @@
+import type { Side } from '../data/debate';
+import '../styles/components/podium-fab.css';
+
+export interface PodiumFABProps {
+    isExpanded: boolean;
+    onExpand: () => void;
+    onSideSelect: (side: Side) => void;
+    onCollapse: () => void;
+}
+
+export function PodiumFAB({ isExpanded, onExpand, onSideSelect, onCollapse }: PodiumFABProps) {
+    if (!isExpanded) {
+        return (
+            <button
+                type="button"
+                className="podium-fab"
+                aria-label="Open post composer"
+                aria-expanded="false"
+                onClick={onExpand}
+            >
+                <span aria-hidden="true">+</span>
+            </button>
+        );
+    }
+
+    return (
+        <div className="podium-fab podium-fab--expanded" role="group" aria-label="Post composer options">
+            <button
+                type="button"
+                className="podium-fab__mini-btn podium-fab__mini-btn--tark"
+                aria-label="Post as Tark"
+                onClick={() => onSideSelect('tark')}
+            >
+                T
+            </button>
+            <button
+                type="button"
+                className="podium-fab__mini-btn podium-fab__mini-btn--vitark"
+                aria-label="Post as Vitark"
+                onClick={() => onSideSelect('vitark')}
+            >
+                V
+            </button>
+            <button
+                type="button"
+                className="podium-fab__dismiss"
+                aria-label="Close"
+                onClick={onCollapse}
+            >
+                ×
+            </button>
+        </div>
+    );
+}

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -8,26 +8,23 @@
 }
 
 .podium-fab {
-    border: 0;
-    padding: 0;
-    cursor: pointer;
-}
-
-.podium-fab__trigger {
     display: grid;
     place-items: center;
     width: 56px;
     height: 56px;
+    border: 0;
     border-radius: 28px;
+    padding: 0;
     background-color: var(--color-brand-primary);
     color: var(--color-brand-on-primary);
     box-shadow:
         0 4px 8px 0 var(--color-elevation-shadow-ambient),
         0 1px 3px 0 var(--color-elevation-shadow-key);
-    transition: opacity 300ms ease-out, transform 300ms ease-out;
+    font: inherit;
+    cursor: pointer;
 }
 
-.podium-fab__trigger > span {
+.podium-fab > span {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -37,7 +34,7 @@
     line-height: 1;
 }
 
-.podium-fab--expanded {
+.podium-fab-group {
     position: absolute;
     right: 0;
     bottom: 0;
@@ -52,6 +49,7 @@
 .podium-fab__dismiss {
     border: 0;
     padding: 0;
+    font: inherit;
     cursor: pointer;
     transform: scale(0.8);
     opacity: 0;
@@ -94,20 +92,17 @@
     line-height: 1;
 }
 
-.podium-fab-shell--expanded .podium-fab--expanded {
-    pointer-events: auto;
-}
-
-.podium-fab-shell--expanded .podium-fab__trigger {
-    transform: scale(0.8);
-    opacity: 0;
-    pointer-events: none;
-}
-
-.podium-fab-shell--expanded .podium-fab__mini-btn,
-.podium-fab-shell--expanded .podium-fab__dismiss {
+.podium-fab-group--expanded .podium-fab__mini-btn,
+.podium-fab-group--expanded .podium-fab__dismiss {
     transform: scale(1);
     opacity: 1;
+}
+
+.podium-fab:focus-visible,
+.podium-fab__mini-btn:focus-visible,
+.podium-fab__dismiss:focus-visible {
+    outline: 2px solid var(--color-on-surface);
+    outline-offset: 2px;
 }
 
 @media (min-width: 768px) {

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,0 +1,94 @@
+.podium-fab {
+    position: fixed;
+    right: var(--space-4);
+    bottom: var(--space-4);
+    z-index: 30;
+    display: grid;
+    place-items: center;
+    width: 56px;
+    height: 56px;
+    border: 0;
+    border-radius: 28px;
+    padding: 0;
+    background-color: var(--color-brand-primary);
+    color: var(--color-brand-on-primary);
+    box-shadow:
+        0 4px 8px 0 rgb(0 0 0 / 15%),
+        0 1px 3px 0 rgb(0 0 0 / 30%);
+    cursor: pointer;
+}
+
+.podium-fab > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.podium-fab--expanded {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 12px;
+}
+
+.podium-fab__mini-btn,
+.podium-fab__dismiss {
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+    transform: scale(0.8);
+    opacity: 0;
+    transition: opacity 300ms ease-out, transform 300ms ease-out;
+}
+
+.podium-fab__mini-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 20px;
+    box-shadow:
+        0 4px 8px 3px rgb(0 0 0 / 15%),
+        0 1px 3px 0 rgb(0 0 0 / 30%);
+    font-size: var(--typescale-label-md-size);
+    font-weight: var(--typescale-label-md-weight);
+    line-height: var(--typescale-label-md-line-height);
+    letter-spacing: var(--typescale-label-md-tracking);
+}
+
+.podium-fab__mini-btn--tark {
+    background-color: var(--color-tark-surface);
+    color: var(--color-tark-on-surface);
+}
+
+.podium-fab__mini-btn--vitark {
+    background-color: var(--color-vitark-surface);
+    color: var(--color-vitark-on-surface);
+}
+
+.podium-fab__dismiss {
+    width: 56px;
+    height: 56px;
+    border-radius: 28px;
+    background-color: var(--color-brand-primary);
+    color: var(--color-brand-on-primary);
+    box-shadow:
+        0 4px 8px 3px rgb(0 0 0 / 15%),
+        0 1px 3px 0 rgb(0 0 0 / 30%);
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.podium-fab--expanded .podium-fab__mini-btn,
+.podium-fab--expanded .podium-fab__dismiss {
+    transform: scale(1);
+    opacity: 1;
+}
+
+@media (min-width: 768px) {
+    .podium-fab {
+        display: none;
+    }
+}

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,10 +1,9 @@
-.podium-fab-shell {
+button.podium-fab,
+div.podium-fab[role="group"] {
     position: fixed;
     right: var(--space-4);
     bottom: var(--space-4);
     z-index: 30;
-    width: 56px;
-    height: 56px;
 }
 
 button.podium-fab {
@@ -34,10 +33,7 @@ button.podium-fab > span {
     line-height: 1;
 }
 
-.podium-fab--group {
-    position: absolute;
-    right: 0;
-    bottom: 0;
+div.podium-fab[role="group"] {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -110,7 +106,7 @@ button.podium-fab > span {
 }
 
 @media (min-width: 768px) {
-    .podium-fab-shell {
+    .podium-fab {
         display: none;
     }
 }

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,24 +1,33 @@
-.podium-fab {
+.podium-fab-shell {
     position: fixed;
     right: var(--space-4);
     bottom: var(--space-4);
     z-index: 30;
+    width: 56px;
+    height: 56px;
+}
+
+.podium-fab {
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+}
+
+.podium-fab__trigger {
     display: grid;
     place-items: center;
     width: 56px;
     height: 56px;
-    border: 0;
     border-radius: 28px;
-    padding: 0;
     background-color: var(--color-brand-primary);
     color: var(--color-brand-on-primary);
     box-shadow:
-        0 4px 8px 0 rgb(0 0 0 / 15%),
-        0 1px 3px 0 rgb(0 0 0 / 30%);
-    cursor: pointer;
+        0 4px 8px 0 var(--color-elevation-shadow-ambient),
+        0 1px 3px 0 var(--color-elevation-shadow-key);
+    transition: opacity 300ms ease-out, transform 300ms ease-out;
 }
 
-.podium-fab > span {
+.podium-fab__trigger > span {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -29,10 +38,14 @@
 }
 
 .podium-fab--expanded {
+    position: absolute;
+    right: 0;
+    bottom: 0;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     gap: 12px;
+    pointer-events: none;
 }
 
 .podium-fab__mini-btn,
@@ -50,8 +63,8 @@
     height: 40px;
     border-radius: 20px;
     box-shadow:
-        0 4px 8px 3px rgb(0 0 0 / 15%),
-        0 1px 3px 0 rgb(0 0 0 / 30%);
+        0 4px 8px 3px var(--color-elevation-shadow-ambient),
+        0 1px 3px 0 var(--color-elevation-shadow-key);
     font-size: var(--typescale-label-md-size);
     font-weight: var(--typescale-label-md-weight);
     line-height: var(--typescale-label-md-line-height);
@@ -75,20 +88,30 @@
     background-color: var(--color-brand-primary);
     color: var(--color-brand-on-primary);
     box-shadow:
-        0 4px 8px 3px rgb(0 0 0 / 15%),
-        0 1px 3px 0 rgb(0 0 0 / 30%);
+        0 4px 8px 3px var(--color-elevation-shadow-ambient),
+        0 1px 3px 0 var(--color-elevation-shadow-key);
     font-size: 1.5rem;
     line-height: 1;
 }
 
-.podium-fab--expanded .podium-fab__mini-btn,
-.podium-fab--expanded .podium-fab__dismiss {
+.podium-fab-shell--expanded .podium-fab--expanded {
+    pointer-events: auto;
+}
+
+.podium-fab-shell--expanded .podium-fab__trigger {
+    transform: scale(0.8);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.podium-fab-shell--expanded .podium-fab__mini-btn,
+.podium-fab-shell--expanded .podium-fab__dismiss {
     transform: scale(1);
     opacity: 1;
 }
 
 @media (min-width: 768px) {
-    .podium-fab {
+    .podium-fab-shell {
         display: none;
     }
 }

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -7,7 +7,7 @@
     height: 56px;
 }
 
-.podium-fab {
+button.podium-fab {
     display: grid;
     place-items: center;
     width: 56px;
@@ -24,7 +24,7 @@
     cursor: pointer;
 }
 
-.podium-fab > span {
+button.podium-fab > span {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -34,7 +34,7 @@
     line-height: 1;
 }
 
-.podium-fab-group {
+.podium-fab--group {
     position: absolute;
     right: 0;
     bottom: 0;
@@ -92,8 +92,8 @@
     line-height: 1;
 }
 
-.podium-fab-group--expanded .podium-fab__mini-btn,
-.podium-fab-group--expanded .podium-fab__dismiss {
+.podium-fab--expanded .podium-fab__mini-btn,
+.podium-fab--expanded .podium-fab__dismiss {
     transform: scale(1);
     opacity: 1;
 }
@@ -101,7 +101,7 @@
 .podium-fab:focus-visible,
 .podium-fab__mini-btn:focus-visible,
 .podium-fab__dismiss:focus-visible {
-    outline: 2px solid var(--color-on-surface);
+    outline: 2px solid currentColor;
     outline-offset: 2px;
 }
 

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -45,6 +45,10 @@ button.podium-fab > span {
     pointer-events: none;
 }
 
+.podium-fab--expanded {
+    pointer-events: auto;
+}
+
 .podium-fab__mini-btn,
 .podium-fab__dismiss {
     border: 0;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -38,6 +38,8 @@
 
   /* Scrim */
   --color-scrim: rgba(0, 0, 0, 0.32);
+  --color-elevation-shadow-ambient: rgba(0, 0, 0, 0.15);
+  --color-elevation-shadow-key: rgba(0, 0, 0, 0.3);
 
   /* ── Typography (M3 Type Scale) ── */
   --font-family-plain: Inter, "Segoe UI", Arial, sans-serif;

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -11,7 +11,7 @@ const podiumFabCss = readFileSync(
 
 describe('PodiumFAB', () => {
     it('renders collapsed state with + button aria contract', () => {
-        render(
+        const { container } = render(
             <PodiumFAB
                 isExpanded={false}
                 onExpand={() => {}}
@@ -25,6 +25,7 @@ describe('PodiumFAB', () => {
         expect(openButton).toHaveAttribute('aria-expanded', 'false');
         expect(openButton).toHaveClass('podium-fab');
         expect(screen.queryByRole('group', { name: 'Post composer options' })).not.toBeInTheDocument();
+        expect(container.querySelector('.podium-fab--expanded')).toBeInTheDocument();
     });
 
     it('calls onExpand when + is clicked', () => {
@@ -83,12 +84,52 @@ describe('PodiumFAB', () => {
         expect(onCollapse).toHaveBeenCalledTimes(1);
     });
 
+    it('moves focus into composer controls on expand and restores it on collapse', () => {
+        const { rerender } = render(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
+
+        const openButton = screen.getByRole('button', { name: 'Open post composer' });
+        openButton.focus();
+
+        rerender(
+            <PodiumFAB
+                isExpanded
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveFocus();
+
+        rerender(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: 'Open post composer' })).toHaveFocus();
+    });
+
     it('defines tokenized colors and 300ms scale/opacity transitions in CSS source', () => {
         expect(podiumFabCss).toContain('background-color: var(--color-brand-primary);');
         expect(podiumFabCss).toContain('background-color: var(--color-tark-surface);');
         expect(podiumFabCss).toContain('background-color: var(--color-vitark-surface);');
+        expect(podiumFabCss).toContain('var(--color-elevation-shadow-ambient)');
+        expect(podiumFabCss).toContain('var(--color-elevation-shadow-key)');
         expect(podiumFabCss).toContain('transition: opacity 300ms ease-out, transform 300ms ease-out;');
         expect(podiumFabCss).toContain('transform: scale(0.8);');
         expect(podiumFabCss).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+        expect(podiumFabCss).not.toMatch(/\brgba?\s*\(/i);
+        expect(podiumFabCss).not.toMatch(/\bhsla?\s*\(/i);
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -176,6 +176,7 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-key\)/);
         expect(podiumFabCss).toMatch(/transition:\s*opacity\s+300ms\s+ease-out,\s*transform\s+300ms\s+ease-out/);
         expect(podiumFabCss).toMatch(/transform:\s*scale\(0\.8\)/);
+        expect(podiumFabCss).toMatch(/\.podium-fab--expanded\s*\{[\s\S]*pointer-events:\s*auto;/);
         expect(podiumFabCss).not.toMatch(/#[0-9a-fA-F]{3,8}/);
         expect(podiumFabCss).not.toMatch(/\brgba?\s*\(/i);
         expect(podiumFabCss).not.toMatch(/\bhsla?\s*\(/i);

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -151,7 +151,7 @@ describe('PodiumFAB', () => {
                 />
             );
 
-            const collapsingGroup = container.querySelector('.podium-fab--group');
+            const collapsingGroup = container.querySelector('div.podium-fab[role="group"]');
             expect(collapsingGroup).toBeInTheDocument();
             expect(collapsingGroup).toHaveAttribute('aria-hidden', 'true');
             expect(collapsingGroup).not.toHaveClass('podium-fab--expanded');
@@ -162,7 +162,7 @@ describe('PodiumFAB', () => {
                 vi.advanceTimersByTime(300);
             });
 
-            expect(container.querySelector('.podium-fab--group')).not.toBeInTheDocument();
+            expect(container.querySelector('div.podium-fab[role="group"]')).not.toBeInTheDocument();
         } finally {
             vi.useRealTimers();
         }

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -54,8 +54,8 @@ describe('PodiumFAB', () => {
         );
 
         const group = screen.getByRole('group', { name: 'Post composer options' });
-        expect(group).toHaveClass('podium-fab-group');
-        expect(group).toHaveClass('podium-fab-group--expanded');
+        expect(group).toHaveClass('podium-fab');
+        expect(group).toHaveClass('podium-fab--expanded');
         expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveTextContent('T');
         expect(screen.getByRole('button', { name: 'Post as Vitark' })).toHaveTextContent('V');
         expect(screen.getByRole('button', { name: 'Close' })).toHaveTextContent('×');
@@ -151,15 +151,18 @@ describe('PodiumFAB', () => {
                 />
             );
 
-            const collapsingGroup = container.querySelector('.podium-fab-group');
+            const collapsingGroup = container.querySelector('.podium-fab--group');
             expect(collapsingGroup).toBeInTheDocument();
-            expect(collapsingGroup).not.toHaveClass('podium-fab-group--expanded');
+            expect(collapsingGroup).toHaveAttribute('aria-hidden', 'true');
+            expect(collapsingGroup).not.toHaveClass('podium-fab--expanded');
+            expect(container.querySelector('.podium-fab__mini-btn')).toBeDisabled();
+            expect(container.querySelector('.podium-fab__dismiss')).toBeDisabled();
 
             act(() => {
                 vi.advanceTimersByTime(300);
             });
 
-            expect(container.querySelector('.podium-fab-group')).not.toBeInTheDocument();
+            expect(container.querySelector('.podium-fab--group')).not.toBeInTheDocument();
         } finally {
             vi.useRealTimers();
         }

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -112,7 +112,10 @@ describe('PodiumFAB', () => {
                 vi.advanceTimersByTime(16);
             });
 
-            expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveFocus();
+            const tarkButton = screen.getByRole('button', { name: 'Post as Tark' });
+            const closeButton = screen.getByRole('button', { name: 'Close' });
+            expect(tarkButton).toHaveFocus();
+            fireEvent.click(closeButton);
 
             rerender(
                 <PodiumFAB
@@ -127,6 +130,33 @@ describe('PodiumFAB', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it('does not restore open button focus after side selection collapse handoff', () => {
+        const onSideSelect = vi.fn();
+
+        const { rerender } = render(
+            <PodiumFAB
+                isExpanded
+                onExpand={() => {}}
+                onSideSelect={onSideSelect}
+                onCollapse={() => {}}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        expect(onSideSelect).toHaveBeenCalledWith('tark');
+
+        rerender(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={() => {}}
+                onSideSelect={onSideSelect}
+                onCollapse={() => {}}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: 'Open post composer' })).not.toHaveFocus();
     });
 
     it('keeps expanded controls mounted long enough for collapse transition then unmounts', () => {

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -130,42 +130,35 @@ describe('PodiumFAB', () => {
     });
 
     it('keeps expanded controls mounted long enough for collapse transition then unmounts', () => {
-        vi.useFakeTimers();
+        const { container, rerender } = render(
+            <PodiumFAB
+                isExpanded
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
 
-        try {
-            const { container, rerender } = render(
-                <PodiumFAB
-                    isExpanded
-                    onExpand={() => {}}
-                    onSideSelect={() => {}}
-                    onCollapse={() => {}}
-                />
-            );
+        rerender(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
 
-            rerender(
-                <PodiumFAB
-                    isExpanded={false}
-                    onExpand={() => {}}
-                    onSideSelect={() => {}}
-                    onCollapse={() => {}}
-                />
-            );
+        const collapsingGroup = container.querySelector('div.podium-fab[role="group"]');
+        expect(collapsingGroup).toBeInTheDocument();
+        expect(collapsingGroup).toHaveAttribute('aria-hidden', 'true');
+        expect(collapsingGroup).not.toHaveClass('podium-fab--expanded');
+        expect(container.querySelector('.podium-fab__mini-btn')).toBeDisabled();
 
-            const collapsingGroup = container.querySelector('div.podium-fab[role="group"]');
-            expect(collapsingGroup).toBeInTheDocument();
-            expect(collapsingGroup).toHaveAttribute('aria-hidden', 'true');
-            expect(collapsingGroup).not.toHaveClass('podium-fab--expanded');
-            expect(container.querySelector('.podium-fab__mini-btn')).toBeDisabled();
-            expect(container.querySelector('.podium-fab__dismiss')).toBeDisabled();
+        fireEvent.transitionEnd(screen.getByRole('button', { name: 'Close', hidden: true }), {
+            propertyName: 'opacity',
+        });
 
-            act(() => {
-                vi.advanceTimersByTime(300);
-            });
-
-            expect(container.querySelector('div.podium-fab[role="group"]')).not.toBeInTheDocument();
-        } finally {
-            vi.useRealTimers();
-        }
+        expect(container.querySelector('div.podium-fab[role="group"]')).not.toBeInTheDocument();
     });
 
     it('defines tokenized colors and 300ms scale/opacity transitions in CSS source', () => {

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { PodiumFAB } from '../../src/components/PodiumFAB';
 
@@ -11,7 +11,7 @@ const podiumFabCss = readFileSync(
 
 describe('PodiumFAB', () => {
     it('renders collapsed state with + button aria contract', () => {
-        const { container } = render(
+        render(
             <PodiumFAB
                 isExpanded={false}
                 onExpand={() => {}}
@@ -25,7 +25,6 @@ describe('PodiumFAB', () => {
         expect(openButton).toHaveAttribute('aria-expanded', 'false');
         expect(openButton).toHaveClass('podium-fab');
         expect(screen.queryByRole('group', { name: 'Post composer options' })).not.toBeInTheDocument();
-        expect(container.querySelector('.podium-fab--expanded')).toBeInTheDocument();
     });
 
     it('calls onExpand when + is clicked', () => {
@@ -55,8 +54,8 @@ describe('PodiumFAB', () => {
         );
 
         const group = screen.getByRole('group', { name: 'Post composer options' });
-        expect(group).toHaveClass('podium-fab');
-        expect(group).toHaveClass('podium-fab--expanded');
+        expect(group).toHaveClass('podium-fab-group');
+        expect(group).toHaveClass('podium-fab-group--expanded');
         expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveTextContent('T');
         expect(screen.getByRole('button', { name: 'Post as Vitark' })).toHaveTextContent('V');
         expect(screen.getByRole('button', { name: 'Close' })).toHaveTextContent('×');
@@ -85,49 +84,95 @@ describe('PodiumFAB', () => {
     });
 
     it('moves focus into composer controls on expand and restores it on collapse', () => {
-        const { rerender } = render(
-            <PodiumFAB
-                isExpanded={false}
-                onExpand={() => {}}
-                onSideSelect={() => {}}
-                onCollapse={() => {}}
-            />
-        );
+        vi.useFakeTimers();
 
-        const openButton = screen.getByRole('button', { name: 'Open post composer' });
-        openButton.focus();
+        try {
+            const { rerender } = render(
+                <PodiumFAB
+                    isExpanded={false}
+                    onExpand={() => {}}
+                    onSideSelect={() => {}}
+                    onCollapse={() => {}}
+                />
+            );
 
-        rerender(
-            <PodiumFAB
-                isExpanded
-                onExpand={() => {}}
-                onSideSelect={() => {}}
-                onCollapse={() => {}}
-            />
-        );
+            const openButton = screen.getByRole('button', { name: 'Open post composer' });
+            openButton.focus();
 
-        expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveFocus();
+            rerender(
+                <PodiumFAB
+                    isExpanded
+                    onExpand={() => {}}
+                    onSideSelect={() => {}}
+                    onCollapse={() => {}}
+                />
+            );
 
-        rerender(
-            <PodiumFAB
-                isExpanded={false}
-                onExpand={() => {}}
-                onSideSelect={() => {}}
-                onCollapse={() => {}}
-            />
-        );
+            act(() => {
+                vi.advanceTimersByTime(16);
+            });
 
-        expect(screen.getByRole('button', { name: 'Open post composer' })).toHaveFocus();
+            expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveFocus();
+
+            rerender(
+                <PodiumFAB
+                    isExpanded={false}
+                    onExpand={() => {}}
+                    onSideSelect={() => {}}
+                    onCollapse={() => {}}
+                />
+            );
+
+            expect(screen.getByRole('button', { name: 'Open post composer' })).toHaveFocus();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('keeps expanded controls mounted long enough for collapse transition then unmounts', () => {
+        vi.useFakeTimers();
+
+        try {
+            const { container, rerender } = render(
+                <PodiumFAB
+                    isExpanded
+                    onExpand={() => {}}
+                    onSideSelect={() => {}}
+                    onCollapse={() => {}}
+                />
+            );
+
+            rerender(
+                <PodiumFAB
+                    isExpanded={false}
+                    onExpand={() => {}}
+                    onSideSelect={() => {}}
+                    onCollapse={() => {}}
+                />
+            );
+
+            const collapsingGroup = container.querySelector('.podium-fab-group');
+            expect(collapsingGroup).toBeInTheDocument();
+            expect(collapsingGroup).not.toHaveClass('podium-fab-group--expanded');
+
+            act(() => {
+                vi.advanceTimersByTime(300);
+            });
+
+            expect(container.querySelector('.podium-fab-group')).not.toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('defines tokenized colors and 300ms scale/opacity transitions in CSS source', () => {
-        expect(podiumFabCss).toContain('background-color: var(--color-brand-primary);');
-        expect(podiumFabCss).toContain('background-color: var(--color-tark-surface);');
-        expect(podiumFabCss).toContain('background-color: var(--color-vitark-surface);');
-        expect(podiumFabCss).toContain('var(--color-elevation-shadow-ambient)');
-        expect(podiumFabCss).toContain('var(--color-elevation-shadow-key)');
-        expect(podiumFabCss).toContain('transition: opacity 300ms ease-out, transform 300ms ease-out;');
-        expect(podiumFabCss).toContain('transform: scale(0.8);');
+        expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-brand-primary\)/);
+        expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-tark-surface\)/);
+        expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-vitark-surface\)/);
+        expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-ambient\)/);
+        expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-key\)/);
+        expect(podiumFabCss).toMatch(/transition:\s*opacity\s+300ms\s+ease-out,\s*transform\s+300ms\s+ease-out/);
+        expect(podiumFabCss).toMatch(/transform:\s*scale\(0\.8\)/);
         expect(podiumFabCss).not.toMatch(/#[0-9a-fA-F]{3,8}/);
         expect(podiumFabCss).not.toMatch(/\brgba?\s*\(/i);
         expect(podiumFabCss).not.toMatch(/\bhsla?\s*\(/i);

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PodiumFAB } from '../../src/components/PodiumFAB';
+
+const podiumFabCss = readFileSync(
+    resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
+    'utf-8'
+);
+
+describe('PodiumFAB', () => {
+    it('renders collapsed state with + button aria contract', () => {
+        render(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
+
+        const openButton = screen.getByRole('button', { name: 'Open post composer' });
+        expect(openButton).toHaveTextContent('+');
+        expect(openButton).toHaveAttribute('aria-expanded', 'false');
+        expect(openButton).toHaveClass('podium-fab');
+        expect(screen.queryByRole('group', { name: 'Post composer options' })).not.toBeInTheDocument();
+    });
+
+    it('calls onExpand when + is clicked', () => {
+        const onExpand = vi.fn();
+
+        render(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={onExpand}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+        expect(onExpand).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders expanded state buttons with aria labels and expanded class', () => {
+        render(
+            <PodiumFAB
+                isExpanded
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
+
+        const group = screen.getByRole('group', { name: 'Post composer options' });
+        expect(group).toHaveClass('podium-fab');
+        expect(group).toHaveClass('podium-fab--expanded');
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toHaveTextContent('T');
+        expect(screen.getByRole('button', { name: 'Post as Vitark' })).toHaveTextContent('V');
+        expect(screen.getByRole('button', { name: 'Close' })).toHaveTextContent('×');
+    });
+
+    it('wires expanded actions for side selection and collapse', () => {
+        const onSideSelect = vi.fn();
+        const onCollapse = vi.fn();
+
+        render(
+            <PodiumFAB
+                isExpanded
+                onExpand={() => {}}
+                onSideSelect={onSideSelect}
+                onCollapse={onCollapse}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Vitark' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+        expect(onSideSelect).toHaveBeenNthCalledWith(1, 'tark');
+        expect(onSideSelect).toHaveBeenNthCalledWith(2, 'vitark');
+        expect(onCollapse).toHaveBeenCalledTimes(1);
+    });
+
+    it('defines tokenized colors and 300ms scale/opacity transitions in CSS source', () => {
+        expect(podiumFabCss).toContain('background-color: var(--color-brand-primary);');
+        expect(podiumFabCss).toContain('background-color: var(--color-tark-surface);');
+        expect(podiumFabCss).toContain('background-color: var(--color-vitark-surface);');
+        expect(podiumFabCss).toContain('transition: opacity 300ms ease-out, transform 300ms ease-out;');
+        expect(podiumFabCss).toContain('transform: scale(0.8);');
+        expect(podiumFabCss).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+    });
+});

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -260,4 +260,19 @@ describe('tokens.css — M3 3-layer token presence', () => {
   it('--color-scrim is not duplicated in prefers-color-scheme dark fallback', () => {
     expect(mediaFallbackBlock).not.toMatch(/--color-scrim\s*:/);
   });
+
+  it('defines elevation shadow tokens in light/default block with exact values', () => {
+    expect(lightBlock).toContain('--color-elevation-shadow-ambient: rgba(0, 0, 0, 0.15);');
+    expect(lightBlock).toContain('--color-elevation-shadow-key: rgba(0, 0, 0, 0.3);');
+  });
+
+  it('elevation shadow tokens are not duplicated in [data-theme="dark"] override block', () => {
+    expect(darkBlock).not.toMatch(/--color-elevation-shadow-ambient\s*:/);
+    expect(darkBlock).not.toMatch(/--color-elevation-shadow-key\s*:/);
+  });
+
+  it('elevation shadow tokens are not duplicated in prefers-color-scheme dark fallback', () => {
+    expect(mediaFallbackBlock).not.toMatch(/--color-elevation-shadow-ambient\s*:/);
+    expect(mediaFallbackBlock).not.toMatch(/--color-elevation-shadow-key\s*:/);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `PodiumFAB` with the required interface contract (`isExpanded`, `onExpand`, `onSideSelect`, `onCollapse`) and state-specific DOM output.
- Adds `src/styles/components/podium-fab.css` using only project CSS custom properties for color tokens and Figma-derived sizing/spacing/shadow values.
- Adds `tests/components/PodiumFAB.test.tsx` covering collapsed/expanded accessibility and callback wiring (`onExpand`, `onSideSelect`, `onCollapse`) plus CSS token/animation assertions.

Closes #155.

## Verification Evidence
- `npm run test -- tests/components/PodiumFAB.test.tsx`
- `npm run test`
- `npm run build`

### Figma Traceability
| Frame / Node | Extracted value | Code location | Status |
|---|---|---|---|
| 641:362 (Collapsed FAB) | FAB size `56x56`, radius `28`, offset `right 16`, `bottom 16` | `src/styles/components/podium-fab.css` (`.podium-fab`) | exact |
| 641:362 / 669:197 | Mini FAB size `40x40`, radius `20`, vertical gap `12` | `src/styles/components/podium-fab.css` (`.podium-fab__mini-btn`, `.podium-fab--expanded`) | exact |
| 641:362 / 669:197 | Colors use brand/tark/vitark tokens | `src/styles/components/podium-fab.css` (`var(--color-*)`) | exact |
| 669:197 | Expanded menu shadow values + transition `opacity/scale 300ms ease-out` | `src/styles/components/podium-fab.css` | exact |

### Visual Validation Evidence
Route-level runtime screenshots are not yet applicable in this task because `PodiumFAB` is not mounted by `DebateScreen` until follow-up wiring task #157. This PR provides component-level behavioral coverage and Figma value traceability for handoff.

## BDD Evidence
| Scenario | Test mapping |
|---|---|
| Collapsed FAB renders as `+` with `aria-label="Open post composer"` and `aria-expanded="false"` | `PodiumFAB > renders collapsed state with + button aria contract` |
| `onExpand` fires on `+` click | `PodiumFAB > calls onExpand when + is clicked` |
| Expanded state renders `T`, `V`, `×` with proper labels and expanded class | `PodiumFAB > renders expanded state buttons with aria labels and expanded class` |
| `onSideSelect('tark'/'vitark')` and `onCollapse` wiring | `PodiumFAB > wires expanded actions for side selection and collapse` |
| CSS transition/token compliance | `PodiumFAB > defines tokenized colors and 300ms scale/opacity transitions in CSS source` |

## Runtime QA Handoff Package (for Gate 5.5)
- **Journey map:** mobile user taps `Open post composer` (`+`) → sees `Post as Tark`, `Post as Vitark`, and `Close` controls.
- **Route list:** `DebateScreen` mobile route after #157 wiring.
- **Expected states:** collapsed FAB (`+` only), expanded FAB group (`T/V/×`) with 300ms scale+opacity transition.
- **Setup/test data:** default debate seed data; no additional fixtures required.
- **Known risks:** transition-out visual behavior in integrated route depends on parent mount/unmount orchestration in #157.

## Residual Risk
- Full viewport/theme runtime parity screenshots depend on integration in #157; this PR is intentionally scoped to isolated component + CSS + unit tests.

## Rollback Note
- Revert commit `8ee67ea` to remove `PodiumFAB` component, associated CSS, and unit tests.

## Agent Provenance
run-id: 8c811283-0ce4-41ee-b809-6cf0141fdfd2
task-id: #155
role: dev
dispatched: 2026-04-19T14:56:59.722Z
model: gpt-5.3-codex