### PR TITLE
feat(podium-bottom-sheet): add PodiumBottomSheet component

### DIFF
--- a/src/components/PodiumBottomSheet.tsx
+++ b/src/components/PodiumBottomSheet.tsx
@@ -1,0 +1,229 @@
+import type { CSSProperties, FormEvent, KeyboardEvent, PointerEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { Side } from '../data/debate';
+import { validatePost } from '../lib/validatePost';
+import '../styles/components/podium-bottom-sheet.css';
+import { SegmentedControl } from './SegmentedControl';
+
+export interface PodiumBottomSheetProps {
+    isOpen: boolean;
+    selectedSide: Side;
+    onSideChange: (side: Side) => void;
+    onPublish: (text: string, side: Side) => void;
+    onClose: () => void;
+}
+
+const DISMISS_DRAG_THRESHOLD = 80;
+const SIDE_OPTIONS: readonly Side[] = ['tark', 'vitark'];
+const FOCUSABLE_SELECTOR =
+    'button:not([disabled]):not([tabindex="-1"]), [href], input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function PodiumBottomSheet({
+    isOpen,
+    selectedSide,
+    onSideChange,
+    onPublish,
+    onClose,
+}: PodiumBottomSheetProps) {
+    const [text, setText] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [isBusy, setIsBusy] = useState(false);
+    const [dragOffset, setDragOffset] = useState(0);
+    const [isDragging, setIsDragging] = useState(false);
+    const dragStartYRef = useRef<number | null>(null);
+    const dragOffsetRef = useRef(0);
+    const dialogRef = useRef<HTMLDivElement | null>(null);
+
+    const getFocusableElements = (): HTMLElement[] => {
+        const dialogNode = dialogRef.current;
+        if (!dialogNode) {
+            return [];
+        }
+
+        return Array.from(dialogNode.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    };
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const focusableElements = getFocusableElements();
+        focusableElements[0]?.focus();
+    }, [isOpen]);
+
+    const completeDrag = (endClientY?: number) => {
+        const startClientY = dragStartYRef.current;
+        if (startClientY === null) {
+            return;
+        }
+
+        setIsDragging(false);
+        dragStartYRef.current = null;
+        const resolvedDragOffset =
+            endClientY === undefined
+                ? dragOffsetRef.current
+                : Math.max(0, endClientY - startClientY);
+        dragOffsetRef.current = 0;
+
+        if (resolvedDragOffset > DISMISS_DRAG_THRESHOLD) {
+            onClose();
+            return;
+        }
+
+        setDragOffset(0);
+    };
+
+    const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+        dragStartYRef.current = event.clientY;
+        setIsDragging(true);
+        dragOffsetRef.current = 0;
+        setDragOffset(0);
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+    };
+
+    const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+        if (dragStartYRef.current === null) {
+            return;
+        }
+
+        const deltaY = Math.max(0, event.clientY - dragStartYRef.current);
+        dragOffsetRef.current = deltaY;
+        setDragOffset(deltaY);
+    };
+
+    const handleDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            onClose();
+            return;
+        }
+
+        if (event.key !== 'Tab') {
+            return;
+        }
+
+        const focusableElements = getFocusableElements();
+        if (focusableElements.length === 0) {
+            return;
+        }
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+        const activeElement = document.activeElement as HTMLElement | null;
+
+        if (event.shiftKey && activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+            return;
+        }
+
+        if (!event.shiftKey && activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+        }
+    };
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isBusy) {
+            return;
+        }
+
+        const validation = validatePost(text);
+        if (!validation.valid) {
+            setError(validation.message);
+            return;
+        }
+
+        setError(null);
+        setIsBusy(true);
+
+        try {
+            await Promise.resolve(onPublish(text.trim(), selectedSide));
+            setText('');
+        } finally {
+            setIsBusy(false);
+        }
+    };
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const sheetStyle = {
+        '--podium-sheet-drag-offset': `${dragOffset}px`,
+    } as CSSProperties;
+
+    return (
+        <>
+            <div
+                className="podium-sheet-scrim"
+                aria-hidden="true"
+                data-testid="podium-sheet-scrim"
+                onClick={onClose}
+            />
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Post composer"
+                className={`podium-bottom-sheet podium-bottom-sheet--open${
+                    isDragging ? ' podium-bottom-sheet--dragging' : ''
+                }`}
+                style={sheetStyle}
+                onKeyDown={handleDialogKeyDown}
+            >
+                <div
+                    className="podium-bottom-sheet__handle"
+                    aria-hidden="true"
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={(event) => completeDrag(event.clientY)}
+                    onPointerCancel={() => completeDrag()}
+                />
+                <button
+                    type="button"
+                    className="podium-bottom-sheet__close"
+                    aria-label="Close post composer"
+                    onClick={onClose}
+                >
+                    ×
+                </button>
+                <form className="podium-bottom-sheet__form" onSubmit={handleSubmit} aria-label="Post composer">
+                    <SegmentedControl
+                        options={SIDE_OPTIONS}
+                        value={selectedSide}
+                        onChange={onSideChange}
+                    />
+                    <textarea
+                        className="podium-bottom-sheet__textarea"
+                        value={text}
+                        onChange={(event) => setText(event.target.value)}
+                        placeholder="Post text…"
+                        aria-label="Post text"
+                        aria-describedby="sheet-podium-error"
+                        aria-invalid={error !== null}
+                    />
+                    <button
+                        type="submit"
+                        className="podium-bottom-sheet__publish"
+                        aria-label="Publish post"
+                        disabled={isBusy}
+                    >
+                        Publish ↑
+                    </button>
+                    <p
+                        id="sheet-podium-error"
+                        className="podium-bottom-sheet__error"
+                        role="alert"
+                        aria-live="polite"
+                    >
+                        {error ?? ''}
+                    </p>
+                </form>
+            </div>
+        </>
+    );
+}

--- a/src/components/PodiumBottomSheet.tsx
+++ b/src/components/PodiumBottomSheet.tsx
@@ -33,6 +33,8 @@ export function PodiumBottomSheet({
     const [hasEntered, setHasEntered] = useState(false);
     const dragStartYRef = useRef<number | null>(null);
     const dragOffsetRef = useRef(0);
+    const pendingDragOffsetRef = useRef(0);
+    const dragAnimationFrameRef = useRef<number | null>(null);
     const dialogRef = useRef<HTMLDivElement | null>(null);
 
     const getFocusableElements = (): HTMLElement[] => {
@@ -68,10 +70,23 @@ export function PodiumBottomSheet({
         };
     }, [isOpen]);
 
+    useEffect(() => {
+        return () => {
+            if (dragAnimationFrameRef.current !== null) {
+                window.cancelAnimationFrame(dragAnimationFrameRef.current);
+            }
+        };
+    }, []);
+
     const completeDrag = (endClientY?: number) => {
         const startClientY = dragStartYRef.current;
         if (startClientY === null) {
             return;
+        }
+
+        if (dragAnimationFrameRef.current !== null) {
+            window.cancelAnimationFrame(dragAnimationFrameRef.current);
+            dragAnimationFrameRef.current = null;
         }
 
         setIsDragging(false);
@@ -81,6 +96,7 @@ export function PodiumBottomSheet({
                 ? dragOffsetRef.current
                 : Math.max(0, endClientY - startClientY);
         dragOffsetRef.current = 0;
+        pendingDragOffsetRef.current = 0;
 
         if (resolvedDragOffset > DISMISS_DRAG_THRESHOLD) {
             onClose();
@@ -94,6 +110,7 @@ export function PodiumBottomSheet({
         dragStartYRef.current = event.clientY;
         setIsDragging(true);
         dragOffsetRef.current = 0;
+        pendingDragOffsetRef.current = 0;
         setDragOffset(0);
         event.currentTarget.setPointerCapture?.(event.pointerId);
     };
@@ -105,7 +122,16 @@ export function PodiumBottomSheet({
 
         const deltaY = Math.max(0, event.clientY - dragStartYRef.current);
         dragOffsetRef.current = deltaY;
-        setDragOffset(deltaY);
+        pendingDragOffsetRef.current = deltaY;
+
+        if (dragAnimationFrameRef.current !== null) {
+            return;
+        }
+
+        dragAnimationFrameRef.current = window.requestAnimationFrame(() => {
+            dragAnimationFrameRef.current = null;
+            setDragOffset(pendingDragOffsetRef.current);
+        });
     };
 
     const handleDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/PodiumBottomSheet.tsx
+++ b/src/components/PodiumBottomSheet.tsx
@@ -30,6 +30,7 @@ export function PodiumBottomSheet({
     const [isBusy, setIsBusy] = useState(false);
     const [dragOffset, setDragOffset] = useState(0);
     const [isDragging, setIsDragging] = useState(false);
+    const [hasEntered, setHasEntered] = useState(false);
     const dragStartYRef = useRef<number | null>(null);
     const dragOffsetRef = useRef(0);
     const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -50,6 +51,21 @@ export function PodiumBottomSheet({
 
         const focusableElements = getFocusableElements();
         focusableElements[0]?.focus();
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            setHasEntered(false);
+            return;
+        }
+
+        const animationFrameId = window.requestAnimationFrame(() => {
+            setHasEntered(true);
+        });
+
+        return () => {
+            window.cancelAnimationFrame(animationFrameId);
+        };
     }, [isOpen]);
 
     const completeDrag = (endClientY?: number) => {
@@ -169,7 +185,7 @@ export function PodiumBottomSheet({
                 role="dialog"
                 aria-modal="true"
                 aria-label="Post composer"
-                className={`podium-bottom-sheet podium-bottom-sheet--open${
+                className={`podium-bottom-sheet${hasEntered ? ' podium-bottom-sheet--open' : ''}${
                     isDragging ? ' podium-bottom-sheet--dragging' : ''
                 }`}
                 style={sheetStyle}

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -1,0 +1,136 @@
+.podium-sheet-scrim {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    z-index: 120;
+}
+
+.podium-bottom-sheet {
+    --podium-sheet-offset: 100%;
+    --podium-sheet-drag-offset: 0px;
+
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    max-width: 390px;
+    max-height: 232px;
+    margin: 0 auto;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+    padding: 12px 16px 20px;
+    border-radius: 28px 28px 0 0;
+    background: var(--color-surface-container-high);
+    transform: translateY(calc(var(--podium-sheet-offset, 100%) + var(--podium-sheet-drag-offset, 0px)));
+    transition: transform 300ms ease-out;
+    will-change: transform;
+    z-index: 121;
+}
+
+.podium-bottom-sheet--open {
+    --podium-sheet-offset: 0%;
+}
+
+.podium-bottom-sheet--dragging {
+    transition: none;
+}
+
+.podium-bottom-sheet__handle {
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    touch-action: none;
+    user-select: none;
+    cursor: grab;
+}
+
+.podium-bottom-sheet__handle::before {
+    content: '';
+    width: 32px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--color-outline-variant);
+}
+
+.podium-bottom-sheet__close {
+    position: absolute;
+    top: 8px;
+    right: 16px;
+    width: 32px;
+    height: 32px;
+    border: 0;
+    border-radius: 16px;
+    background: transparent;
+    color: var(--color-on-surface-variant);
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.podium-bottom-sheet__close:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+.podium-bottom-sheet__form {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+    touch-action: pan-y;
+}
+
+.podium-bottom-sheet__textarea {
+    width: 100%;
+    height: 80px;
+    padding: 12px;
+    border: 1px solid var(--color-outline);
+    border-radius: 8px;
+    box-sizing: border-box;
+    background: var(--color-surface-container-lowest);
+    color: var(--color-on-surface);
+    font: inherit;
+    font-size: 14px;
+    resize: none;
+}
+
+.podium-bottom-sheet__textarea::placeholder {
+    color: var(--color-on-surface-variant);
+}
+
+.podium-bottom-sheet__publish {
+    align-self: flex-end;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 40px;
+    border: 0;
+    border-radius: 20px;
+    padding: 10px 24px;
+    background: var(--color-brand-primary);
+    color: var(--color-brand-on-primary);
+    font: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.podium-bottom-sheet__publish:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.podium-bottom-sheet__error {
+    margin: 0;
+    min-height: 1rem;
+    color: var(--color-error);
+    font-size: 0.75rem;
+    line-height: 1rem;
+}

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -22,7 +22,7 @@
     flex-direction: column;
     gap: 12px;
     align-items: stretch;
-    padding: 12px 16px 20px;
+    padding: 12px 16px calc(20px + env(safe-area-inset-bottom));
     border-radius: 28px 28px 0 0;
     background: var(--color-surface-container-high);
     transform: translateY(calc(var(--podium-sheet-offset, 100%) + var(--podium-sheet-drag-offset, 0px)));

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -15,6 +15,7 @@
     bottom: 0;
     width: 100%;
     max-width: 390px;
+    max-height: 90vh;
     max-height: 90dvh;
     margin: 0 auto;
     box-sizing: border-box;

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -15,7 +15,7 @@
     bottom: 0;
     width: 100%;
     max-width: 390px;
-    max-height: 232px;
+    max-height: 90dvh;
     margin: 0 auto;
     box-sizing: border-box;
     display: flex;
@@ -28,6 +28,7 @@
     transform: translateY(calc(var(--podium-sheet-offset, 100%) + var(--podium-sheet-drag-offset, 0px)));
     transition: transform 300ms ease-out;
     will-change: transform;
+    overflow-y: auto;
     z-index: 121;
 }
 

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -2,6 +2,7 @@
     display: flex;
     width: 100%;
     height: 40px;
+    box-sizing: border-box;
     border: var(--divider-thickness) solid var(--color-brand-primary);
     border-radius: 20px;
     overflow: hidden;

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -1,20 +1,28 @@
 .segmented-control {
     display: flex;
     width: 100%;
+    height: 40px;
     border: var(--divider-thickness) solid var(--color-brand-primary);
-    border-radius: 24px;
+    border-radius: 20px;
     overflow: hidden;
 }
 
 .segmented-control__segment {
     flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: 0;
     background: transparent;
     color: var(--color-brand-primary);
     cursor: pointer;
-    padding: var(--space-4) var(--space-4);
-    min-height: var(--space-10);
+    gap: 4px;
+    padding: 0 12px;
+    min-height: 40px;
     font: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: normal;
 }
 
 .segmented-control__segment + .segmented-control__segment {
@@ -24,6 +32,11 @@
 .segmented-control__segment--selected {
     background: var(--color-brand-primary);
     color: var(--color-brand-on-primary);
+}
+
+.segmented-control__segment--selected .segmented-control__label::before {
+    content: '\2713';
+    margin-right: 4px;
 }
 
 .segmented-control__segment:focus-visible {

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -18,7 +18,7 @@
     color: var(--color-brand-primary);
     cursor: pointer;
     padding: 0 12px;
-    min-height: 40px;
+    height: 100%;
     font: inherit;
     font-size: 14px;
     font-weight: 500;

--- a/src/styles/components/segmented-control.css
+++ b/src/styles/components/segmented-control.css
@@ -16,7 +16,6 @@
     background: transparent;
     color: var(--color-brand-primary);
     cursor: pointer;
-    gap: 4px;
     padding: 0 12px;
     min-height: 40px;
     font: inherit;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -8,7 +8,7 @@
   --color-brand-primary: #4555B7;
   --color-brand-on-primary: #FFFFFF;
 
-  /* Spine (maps to M3 outline-variant) */
+  /* Spine (maps to M3 outline) */
   --color-spine-line: #767680;
 
   --color-on-surface-variant: #49454E;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -13,6 +13,10 @@
 
   --color-on-surface-variant: #49454E;
   --color-error: #B3261E;
+  --color-surface-container-high: #E9E7EF;
+  --color-surface-container-lowest: #FFFFFF;
+  --color-outline: #767680;
+  --color-outline-variant: #C7C5D0;
 
   /* ── Layer 2: Brand Override (empty — no M3 values overridden) ── */
 
@@ -86,6 +90,10 @@
 
   --color-on-surface-variant: #CAC4D0;
   --color-error: #F2B8B5;
+  --color-surface-container-high: #2A2A30;
+  --color-surface-container-lowest: #0E0E13;
+  --color-outline: #90909A;
+  --color-outline-variant: #46464F;
 
   /* ── Layer 3: Functional Override ── */
   --color-tark-surface: #1565C0;
@@ -115,6 +123,10 @@
 
     --color-on-surface-variant: #CAC4D0;
     --color-error: #F2B8B5;
+    --color-surface-container-high: #2A2A30;
+    --color-surface-container-lowest: #0E0E13;
+    --color-outline: #90909A;
+    --color-outline-variant: #46464F;
 
     /* ── Layer 3: Functional Override ── */
     --color-tark-surface: #1565C0;

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
 import type { Side } from '../../src/data/debate';
 
@@ -34,6 +34,10 @@ function renderBottomSheet(options: RenderBottomSheetOptions = {}) {
 }
 
 describe('PodiumBottomSheet', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
     it('does not render when isOpen is false', () => {
         renderBottomSheet({ isOpen: false });
 
@@ -142,13 +146,19 @@ describe('PodiumBottomSheet', () => {
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 
+    it('applies open-state class after mount so enter transition can run', async () => {
+        renderBottomSheet();
+
+        const dialog = screen.getByRole('dialog', { name: 'Post composer' });
+
+        expect(dialog).not.toHaveClass('podium-bottom-sheet--open');
+        await waitFor(() => {
+            expect(dialog).toHaveClass('podium-bottom-sheet--open');
+        });
+    });
+
     it('dismisses when dragged beyond threshold and snaps back otherwise', () => {
-        if (!window.PointerEvent) {
-            Object.defineProperty(window, 'PointerEvent', {
-                value: MouseEvent,
-                writable: true,
-            });
-        }
+        vi.stubGlobal('PointerEvent', window.PointerEvent ?? MouseEvent);
 
         const onClose = vi.fn();
         const { container } = renderBottomSheet({ onClose });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -1,0 +1,182 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
+import type { Side } from '../../src/data/debate';
+
+const podiumBottomSheetCss = readFileSync(
+    resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
+    'utf-8'
+);
+
+interface RenderBottomSheetOptions {
+    isOpen?: boolean;
+    selectedSide?: Side;
+    onSideChange?: (side: Side) => void;
+    onPublish?: (text: string, side: Side) => void;
+    onClose?: () => void;
+}
+
+function renderBottomSheet(options: RenderBottomSheetOptions = {}) {
+    const props = {
+        isOpen: options.isOpen ?? true,
+        selectedSide: options.selectedSide ?? 'tark',
+        onSideChange: options.onSideChange ?? vi.fn(),
+        onPublish: options.onPublish ?? vi.fn(),
+        onClose: options.onClose ?? vi.fn(),
+    };
+
+    const renderResult = render(<PodiumBottomSheet {...props} />);
+
+    return { ...renderResult, ...props };
+}
+
+describe('PodiumBottomSheet', () => {
+    it('does not render when isOpen is false', () => {
+        renderBottomSheet({ isOpen: false });
+
+        expect(
+            screen.queryByRole('dialog', { name: 'Post composer' })
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders dialog, segmented control, textarea, and publish action when open', () => {
+        renderBottomSheet();
+
+        expect(
+            screen.getByRole('dialog', { name: 'Post composer' })
+        ).toBeInTheDocument();
+        expect(screen.getByRole('radiogroup', { name: 'Side selection' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
+    });
+
+    it('sets required dialog accessibility attributes', () => {
+        renderBottomSheet();
+
+        const dialog = screen.getByRole('dialog', { name: 'Post composer' });
+
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(dialog).toHaveAttribute('aria-label', 'Post composer');
+    });
+
+    it('delegates side selection changes through SegmentedControl', () => {
+        const onSideChange = vi.fn();
+        renderBottomSheet({ onSideChange });
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Vitark' }));
+
+        expect(onSideChange).toHaveBeenCalledTimes(1);
+        expect(onSideChange).toHaveBeenCalledWith('vitark');
+    });
+
+    it('closes on close-button and scrim interactions', () => {
+        const onClose = vi.fn();
+        renderBottomSheet({ onClose });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close post composer' }));
+        fireEvent.click(screen.getByTestId('podium-sheet-scrim'));
+
+        expect(onClose).toHaveBeenCalledTimes(2);
+    });
+
+    it('validates with validatePost on submit and surfaces validation errors', () => {
+        const onPublish = vi.fn();
+        renderBottomSheet({ onPublish });
+
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+
+        fireEvent.change(textarea, { target: { value: '   ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Publish post' }));
+
+        expect(onPublish).not.toHaveBeenCalled();
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            'Text cannot be empty or whitespace only.'
+        );
+        expect(textarea).toHaveAttribute('aria-invalid', 'true');
+        expect(textarea).toHaveAttribute('aria-describedby', 'sheet-podium-error');
+    });
+
+    it('publishes trimmed text with selected side and clears input on success', async () => {
+        const onPublish = vi.fn();
+        renderBottomSheet({ onPublish, selectedSide: 'vitark' });
+
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+
+        fireEvent.change(textarea, {
+            target: { value: '   This submission is long enough.   ' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Publish post' }));
+
+        await waitFor(() => {
+            expect(onPublish).toHaveBeenCalledWith('This submission is long enough.', 'vitark');
+        });
+
+        expect(textarea).toHaveValue('');
+        expect(screen.getByRole('alert')).toHaveTextContent('');
+    });
+
+    it('focuses the first interactive element, traps tabbing, and closes on Escape', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderBottomSheet({ onClose });
+
+        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+
+        await waitFor(() => {
+            expect(closeButton).toHaveFocus();
+        });
+
+        await user.tab({ shift: true });
+        expect(publishButton).toHaveFocus();
+
+        await user.tab();
+        expect(closeButton).toHaveFocus();
+
+        fireEvent.keyDown(screen.getByRole('dialog', { name: 'Post composer' }), {
+            key: 'Escape',
+        });
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses when dragged beyond threshold and snaps back otherwise', () => {
+        if (!window.PointerEvent) {
+            Object.defineProperty(window, 'PointerEvent', {
+                value: MouseEvent,
+                writable: true,
+            });
+        }
+
+        const onClose = vi.fn();
+        const { container } = renderBottomSheet({ onClose });
+        const dragHandle = container.querySelector('.podium-bottom-sheet__handle') as HTMLDivElement;
+        expect(dragHandle).toBeInTheDocument();
+
+        fireEvent.pointerDown(dragHandle, { pointerId: 1, clientY: 100 });
+        fireEvent.pointerMove(dragHandle, { pointerId: 1, clientY: 190 });
+        fireEvent.pointerUp(dragHandle, { pointerId: 1, clientY: 190 });
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        fireEvent.pointerDown(dragHandle, { pointerId: 2, clientY: 100 });
+        fireEvent.pointerMove(dragHandle, { pointerId: 2, clientY: 150 });
+        fireEvent.pointerUp(dragHandle, { pointerId: 2, clientY: 150 });
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('binds all bottom sheet colors and motion properties to design tokens and required animation rules', () => {
+        expect(podiumBottomSheetCss).toContain('var(--color-scrim)');
+        expect(podiumBottomSheetCss).toContain('var(--color-surface-container-high)');
+        expect(podiumBottomSheetCss).toContain('var(--color-surface-container-lowest)');
+        expect(podiumBottomSheetCss).toContain('var(--color-outline)');
+        expect(podiumBottomSheetCss).toContain('var(--color-outline-variant)');
+        expect(podiumBottomSheetCss).toContain('transition: transform 300ms ease-out;');
+        expect(podiumBottomSheetCss).toContain('will-change: transform;');
+        expect(podiumBottomSheetCss).toContain('touch-action: none;');
+        expect(podiumBottomSheetCss).toContain('touch-action: pan-y;');
+    });
+});

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -188,5 +188,6 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('will-change: transform;');
         expect(podiumBottomSheetCss).toContain('touch-action: none;');
         expect(podiumBottomSheetCss).toContain('touch-action: pan-y;');
+        expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom)');
     });
 });

--- a/tests/components/SegmentedControl.test.tsx
+++ b/tests/components/SegmentedControl.test.tsx
@@ -248,9 +248,10 @@ describe('SegmentedControl', () => {
         expect(segmentedControlCss).toContain('var(--color-brand-on-primary)');
     });
 
-    it('uses defined spacing tokens and state-aware focus color in segmented-control CSS', () => {
-        expect(segmentedControlCss).not.toContain('var(--space-2)');
-        expect(segmentedControlCss).toContain('padding: var(--space-4) var(--space-4);');
+    it('uses Figma-derived segmented-control sizing and state-aware focus color in CSS', () => {
+        expect(segmentedControlCss).toContain('height: 40px;');
+        expect(segmentedControlCss).toContain('border-radius: 20px;');
+        expect(segmentedControlCss).toContain('padding: 0 12px;');
         expect(segmentedControlCss).toContain('outline: 2px solid currentColor;');
     });
 });


### PR DESCRIPTION
## Summary
- add `PodiumBottomSheet` as a dialog-only mobile composer with `SegmentedControl`, textarea, publish action, close affordance, scrim dismissal, pointer drag-to-dismiss threshold, and focus trap (`Tab` loop + `Escape` close)
- add `podium-bottom-sheet.css` with Figma-derived layout/size values and token-driven colors, including required `--color-scrim` usage and 300ms slide transform animation
- align `segmented-control.css` to DS/Figma dimensions and state visuals (40px height, 20px radius, 12px horizontal padding, selected checkmark)
- add missing color tokens used by Figma bottom-sheet frames for both light/dark and `prefers-color-scheme` fallback
- add `PodiumBottomSheet` unit tests and update segmented-control CSS assertions

Closes #156.

## Verification
- `npm run test -- tests/components/PodiumBottomSheet.test.tsx`
- `npm run test -- tests/components/SegmentedControl.test.tsx tests/components/PodiumBottomSheet.test.tsx`
- `npm run test`
- `npm run build`

## Figma Traceability
| Frame / Node | Extracted value | Code location | Status |
|---|---|---|---|
| `704:253` + `709:276` (`Podium/BottomSheet`) | panel width `390`, top radius `28`, padding `12 16 20`, vertical gap `12`, handle row `16` | `src/styles/components/podium-bottom-sheet.css` (`.podium-bottom-sheet`, `.podium-bottom-sheet__handle`) | exact |
| `704:253` + `709:276` (`handle-bar`) | bar `32x4`, radius `2` | `podium-bottom-sheet.css` (`.podium-bottom-sheet__handle::before`) | exact |
| `704:253` + `709:276` (`SegmentedControl`) + DS `322:179` (`719:323/719:324`) | control height `40`, radius `20`, segment horizontal padding `12`, selected check marker + brand tokens | `src/styles/components/segmented-control.css` | exact |
| `704:253` + `709:276` (`textarea-placeholder`) | field height `80`, radius `8`, padding `12` | `podium-bottom-sheet.css` (`.podium-bottom-sheet__textarea`) | exact |
| `704:253` + `709:276` (`btn/publish`) | action height `40`, radius `20`, padding `10 24` | `podium-bottom-sheet.css` (`.podium-bottom-sheet__publish`) | exact |
| `704:253` + `709:276` | sheet surface token pair `#E9E7EF`/`#2A2A30`, textarea surface pair `#FFFFFF`/`#0E0E13`, outline pair `#767680`/`#90909A`, outline-variant pair `#C7C5D0`/`#46464F` | `src/styles/tokens.css` + `podium-bottom-sheet.css` | applied |

## Runtime QA Handoff Package (UI-impacting)
- **AC journey map:** expand FAB -> choose side -> sheet opens -> side can toggle -> invalid post shows alert -> valid post publishes + clears -> close via button/scrim/drag/Escape
- **Route list:** `DebateScreen` mobile viewport flow (runtime wiring is completed in downstream T4)
- **Setup notes:** viewport `390x844`; verify both `[data-theme="light"]` and `[data-theme="dark"]`
- **Setup/test data:** existing `DEBATE` argument list; post text samples `"   "` (invalid) and `"This submission is long enough."` (valid)
- **Known-risk notes:** full runtime screenshot parity matrix is blocked on T4 screen wiring (this PR is component-scope T3 only)

## Residual Risk / Rollback
- **Residual risk:** close-button placement depends on T4 integration context because frame-level open-state designs prioritize FAB close affordance while this component contract requires an internal close button.
- **Rollback:** revert commit `e6b8b16` to remove bottom-sheet component/CSS/tests and restore previous segmented control/token definitions.

## Agent Provenance

run-id: f6c34109-a667-4c75-a4b2-b214d43ea86f
task-id: #156
role: dev
dispatched: 2026-04-19T14:57:12.641Z
model: gpt-5.3-codex