### PR TITLE
test(a11y): FAB + BottomSheet accessibility tests

### DIFF
--- a/tests/a11y/podium-bottom-sheet-a11y.test.tsx
+++ b/tests/a11y/podium-bottom-sheet-a11y.test.tsx
@@ -90,9 +90,9 @@ describe('PodiumBottomSheet a11y scenarios', () => {
     });
 
     it('marks the scrim as aria-hidden', () => {
-        const { container } = renderOpenBottomSheet();
+        renderOpenBottomSheet();
 
-        const scrim = container.querySelector('.podium-sheet-scrim');
+        const scrim = screen.getByTestId('podium-sheet-scrim');
         expect(scrim).toHaveAttribute('aria-hidden', 'true');
     });
 
@@ -107,6 +107,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
         const errorMessage = screen.getByRole('alert');
         expect(errorMessage).toHaveAttribute('role', 'alert');
         expect(errorMessage).toHaveAttribute('aria-live', 'polite');
+        expect(errorMessage).toHaveTextContent('Text cannot be empty or whitespace only.');
     });
 
     it('marks the textarea as aria-invalid when an error is present', async () => {

--- a/tests/a11y/podium-bottom-sheet-a11y.test.tsx
+++ b/tests/a11y/podium-bottom-sheet-a11y.test.tsx
@@ -1,0 +1,122 @@
+import type { ComponentProps } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
+
+function renderOpenBottomSheet(overrides?: Partial<ComponentProps<typeof PodiumBottomSheet>>) {
+    const onClose = overrides?.onClose ?? vi.fn();
+
+    const view = render(
+        <>
+            <button type="button">Outside page control</button>
+            <PodiumBottomSheet
+                isOpen={overrides?.isOpen ?? true}
+                selectedSide={overrides?.selectedSide ?? 'tark'}
+                onSideChange={overrides?.onSideChange ?? vi.fn()}
+                onPublish={overrides?.onPublish ?? vi.fn()}
+                onClose={onClose}
+            />
+        </>
+    );
+
+    return { ...view, onClose };
+}
+
+describe('PodiumBottomSheet a11y scenarios', () => {
+    it('is not rendered when closed', () => {
+        renderOpenBottomSheet({ isOpen: false });
+
+        expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
+    });
+
+    it('renders required dialog role and ARIA attributes when open', () => {
+        renderOpenBottomSheet();
+
+        const dialog = screen.getByRole('dialog', { name: 'Post composer' });
+        expect(dialog).toHaveAttribute('role', 'dialog');
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(dialog).toHaveAttribute('aria-label', 'Post composer');
+    });
+
+    it('moves focus to the first interactive element on open', async () => {
+        renderOpenBottomSheet();
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Close post composer' })).toHaveFocus();
+        });
+    });
+
+    it('keeps tab navigation within the dialog boundary', async () => {
+        const user = userEvent.setup();
+        renderOpenBottomSheet();
+
+        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+        const outsidePageControl = screen.getByRole('button', { name: 'Outside page control' });
+
+        await waitFor(() => {
+            expect(closeButton).toHaveFocus();
+        });
+
+        publishButton.focus();
+        await user.tab();
+
+        expect(closeButton).toHaveFocus();
+        expect(outsidePageControl).not.toHaveFocus();
+    });
+
+    it('moves focus from first element to last on Shift+Tab', async () => {
+        const user = userEvent.setup();
+        renderOpenBottomSheet();
+
+        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
+
+        await waitFor(() => {
+            expect(closeButton).toHaveFocus();
+        });
+
+        await user.tab({ shift: true });
+        expect(publishButton).toHaveFocus();
+    });
+
+    it('calls onClose when Escape is pressed inside the dialog', () => {
+        const { onClose } = renderOpenBottomSheet();
+
+        fireEvent.keyDown(screen.getByRole('dialog', { name: 'Post composer' }), { key: 'Escape' });
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the scrim as aria-hidden', () => {
+        const { container } = renderOpenBottomSheet();
+
+        const scrim = container.querySelector('.podium-sheet-scrim');
+        expect(scrim).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('surfaces errors as polite live alerts', async () => {
+        const user = userEvent.setup();
+        renderOpenBottomSheet();
+
+        const postTextField = screen.getByRole('textbox', { name: 'Post text' });
+        await user.type(postTextField, '   ');
+        await user.click(screen.getByRole('button', { name: 'Publish post' }));
+
+        const errorMessage = screen.getByRole('alert');
+        expect(errorMessage).toHaveAttribute('role', 'alert');
+        expect(errorMessage).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('marks the textarea as aria-invalid when an error is present', async () => {
+        const user = userEvent.setup();
+        renderOpenBottomSheet();
+
+        const postTextField = screen.getByRole('textbox', { name: 'Post text' });
+        await user.type(postTextField, '   ');
+        await user.click(screen.getByRole('button', { name: 'Publish post' }));
+
+        expect(postTextField).toHaveAttribute('aria-invalid', 'true');
+    });
+});

--- a/tests/a11y/podium-bottom-sheet-a11y.test.tsx
+++ b/tests/a11y/podium-bottom-sheet-a11y.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
 
-function renderOpenBottomSheet(overrides?: Partial<ComponentProps<typeof PodiumBottomSheet>>) {
+function renderBottomSheet(overrides?: Partial<ComponentProps<typeof PodiumBottomSheet>>) {
     const onClose = overrides?.onClose ?? vi.fn();
 
     const view = render(
@@ -25,13 +25,15 @@ function renderOpenBottomSheet(overrides?: Partial<ComponentProps<typeof PodiumB
 
 describe('PodiumBottomSheet a11y scenarios', () => {
     it('is not rendered when closed', () => {
-        renderOpenBottomSheet({ isOpen: false });
+        renderBottomSheet({ isOpen: false });
 
         expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog', { name: 'Post composer', hidden: true })).not.toBeInTheDocument();
+        expect(screen.queryByTestId('podium-sheet-scrim')).not.toBeInTheDocument();
     });
 
     it('renders required dialog role and ARIA attributes when open', () => {
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         const dialog = screen.getByRole('dialog', { name: 'Post composer' });
         expect(dialog).toHaveAttribute('role', 'dialog');
@@ -40,7 +42,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
     });
 
     it('moves focus to the first interactive element on open', async () => {
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         await waitFor(() => {
             expect(screen.getByRole('button', { name: 'Close post composer' })).toHaveFocus();
@@ -49,7 +51,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
 
     it('keeps tab navigation within the dialog boundary', async () => {
         const user = userEvent.setup();
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
@@ -68,7 +70,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
 
     it('moves focus from first element to last on Shift+Tab', async () => {
         const user = userEvent.setup();
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
@@ -82,7 +84,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
     });
 
     it('calls onClose when Escape is pressed inside the dialog', () => {
-        const { onClose } = renderOpenBottomSheet();
+        const { onClose } = renderBottomSheet();
 
         fireEvent.keyDown(screen.getByRole('dialog', { name: 'Post composer' }), { key: 'Escape' });
 
@@ -90,7 +92,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
     });
 
     it('marks the scrim as aria-hidden', () => {
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         const scrim = screen.getByTestId('podium-sheet-scrim');
         expect(scrim).toHaveAttribute('aria-hidden', 'true');
@@ -98,7 +100,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
 
     it('surfaces errors as polite live alerts', async () => {
         const user = userEvent.setup();
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         const postTextField = screen.getByRole('textbox', { name: 'Post text' });
         await user.type(postTextField, '   ');
@@ -112,7 +114,7 @@ describe('PodiumBottomSheet a11y scenarios', () => {
 
     it('marks the textarea as aria-invalid when an error is present', async () => {
         const user = userEvent.setup();
-        renderOpenBottomSheet();
+        renderBottomSheet();
 
         const postTextField = screen.getByRole('textbox', { name: 'Post text' });
         await user.type(postTextField, '   ');

--- a/tests/a11y/podium-fab-a11y.test.tsx
+++ b/tests/a11y/podium-fab-a11y.test.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { PodiumFAB } from '../../src/components/PodiumFAB';
+
+interface PodiumFabHarnessProps {
+    isMobile: boolean;
+}
+
+function PodiumFabHarness({ isMobile }: PodiumFabHarnessProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    if (!isMobile) {
+        return null;
+    }
+
+    return (
+        <PodiumFAB
+            isExpanded={isExpanded}
+            onExpand={() => setIsExpanded(true)}
+            onSideSelect={() => setIsExpanded(false)}
+            onCollapse={() => setIsExpanded(false)}
+        />
+    );
+}
+
+describe('PodiumFAB a11y scenarios', () => {
+    it('keeps aria-label and collapsed aria-expanded contract on the closed FAB', () => {
+        render(<PodiumFabHarness isMobile />);
+
+        const openComposerButton = screen.getByRole('button', { name: 'Open post composer' });
+        expect(openComposerButton).toHaveAttribute('aria-label', 'Open post composer');
+        expect(openComposerButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('shows expanded composer group state after expand interaction', async () => {
+        const user = userEvent.setup();
+        render(<PodiumFabHarness isMobile />);
+
+        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+
+        const composerGroup = screen.getByRole('group', { name: 'Post composer options' });
+        await waitFor(() => {
+            expect(composerGroup).toHaveAttribute('aria-hidden', 'false');
+        });
+    });
+
+    it('exposes mini-button aria labels for side selection', async () => {
+        const user = userEvent.setup();
+        render(<PodiumFabHarness isMobile />);
+
+        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+
+        expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Post as Vitark' })).toBeInTheDocument();
+    });
+
+    it('exposes aria-label="Close" for the dismiss mini-button', async () => {
+        const user = userEvent.setup();
+        render(<PodiumFabHarness isMobile />);
+
+        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+
+        expect(screen.getByRole('button', { name: 'Close' })).toHaveAttribute('aria-label', 'Close');
+    });
+
+    it('does not render FAB controls when mobile mode is disabled', () => {
+        render(<PodiumFabHarness isMobile={false} />);
+
+        expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('group', { name: 'Post composer options' })).not.toBeInTheDocument();
+    });
+});

--- a/tests/a11y/podium-fab-a11y.test.tsx
+++ b/tests/a11y/podium-fab-a11y.test.tsx
@@ -40,8 +40,8 @@ describe('PodiumFAB a11y scenarios', () => {
 
         await user.click(screen.getByRole('button', { name: 'Open post composer' }));
 
-        const composerGroup = screen.getByRole('group', { name: 'Post composer options' });
         await waitFor(() => {
+            const composerGroup = screen.getByRole('group', { name: 'Post composer options' });
             expect(composerGroup).toHaveAttribute('aria-hidden', 'false');
         });
     });

--- a/tests/a11y/podium-fab-a11y.test.tsx
+++ b/tests/a11y/podium-fab-a11y.test.tsx
@@ -25,6 +25,15 @@ function PodiumFabHarness({ isMobile }: PodiumFabHarnessProps) {
     );
 }
 
+async function expandComposerAndWaitUntilAccessible(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+
+    await waitFor(() => {
+        const composerGroup = screen.getByRole('group', { name: 'Post composer options' });
+        expect(composerGroup).toHaveAttribute('aria-hidden', 'false');
+    });
+}
+
 describe('PodiumFAB a11y scenarios', () => {
     it('keeps aria-label and collapsed aria-expanded contract on the closed FAB', () => {
         render(<PodiumFabHarness isMobile />);
@@ -38,19 +47,14 @@ describe('PodiumFAB a11y scenarios', () => {
         const user = userEvent.setup();
         render(<PodiumFabHarness isMobile />);
 
-        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
-
-        await waitFor(() => {
-            const composerGroup = screen.getByRole('group', { name: 'Post composer options' });
-            expect(composerGroup).toHaveAttribute('aria-hidden', 'false');
-        });
+        await expandComposerAndWaitUntilAccessible(user);
     });
 
     it('exposes mini-button aria labels for side selection', async () => {
         const user = userEvent.setup();
         render(<PodiumFabHarness isMobile />);
 
-        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+        await expandComposerAndWaitUntilAccessible(user);
 
         expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Post as Vitark' })).toBeInTheDocument();
@@ -60,7 +64,7 @@ describe('PodiumFAB a11y scenarios', () => {
         const user = userEvent.setup();
         render(<PodiumFabHarness isMobile />);
 
-        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+        await expandComposerAndWaitUntilAccessible(user);
 
         expect(screen.getByRole('button', { name: 'Close' })).toHaveAttribute('aria-label', 'Close');
     });


### PR DESCRIPTION
## Summary
- add dedicated a11y scenario tests for `PodiumFAB` in `tests/a11y/podium-fab-a11y.test.tsx`
- add dedicated a11y scenario tests for `PodiumBottomSheet` in `tests/a11y/podium-bottom-sheet-a11y.test.tsx`
- cover ARIA contracts, focus placement, keyboard trap behavior, and error semantics in jsdom with Testing Library + user-event

## Scenario-to-test traceability
1. FAB collapsed `aria-label="Open post composer"` + `aria-expanded="false"` → `podium-fab-a11y.test.tsx` / `keeps aria-label and collapsed aria-expanded contract on the closed FAB`
2. Expand interaction exposes expanded group ARIA state → `podium-fab-a11y.test.tsx` / `shows expanded composer group state after expand interaction`
3. Mini-buttons expose aria labels for Tark/Vitark → `podium-fab-a11y.test.tsx` / `exposes mini-button aria labels for side selection`
4. Dismiss mini-button has `aria-label="Close"` → `podium-fab-a11y.test.tsx` / `exposes aria-label="Close" for the dismiss mini-button`
5. FAB absent when desktop mode (`isMobile=false`) → `podium-fab-a11y.test.tsx` / `does not render FAB controls when mobile mode is disabled`
6. BottomSheet closed (`isOpen=false`) is absent from DOM → `podium-bottom-sheet-a11y.test.tsx` / `is not rendered when closed`
7. BottomSheet open has `role="dialog"`, `aria-modal="true"`, `aria-label="Post composer"` → `podium-bottom-sheet-a11y.test.tsx` / `renders required dialog role and ARIA attributes when open`
8. Focus moves to first interactive element on open → `podium-bottom-sheet-a11y.test.tsx` / `moves focus to the first interactive element on open`
9. Tab cycles within sheet boundary (no page escape) → `podium-bottom-sheet-a11y.test.tsx` / `keeps tab navigation within the dialog boundary`
10. Shift+Tab from first moves to last element in sheet → `podium-bottom-sheet-a11y.test.tsx` / `moves focus from first element to last on Shift+Tab`
11. Escape key triggers `onClose` → `podium-bottom-sheet-a11y.test.tsx` / `calls onClose when Escape is pressed inside the dialog`
12. Scrim has `aria-hidden="true"` → `podium-bottom-sheet-a11y.test.tsx` / `marks the scrim as aria-hidden`
13. Error message uses `role="alert"` + `aria-live="polite"` → `podium-bottom-sheet-a11y.test.tsx` / `surfaces errors as polite live alerts`
14. Textarea sets `aria-invalid="true"` on error → `podium-bottom-sheet-a11y.test.tsx` / `marks the textarea as aria-invalid when an error is present`

## Verification
- `npm run build`
- `npm test`
- `npx vitest run tests/a11y/podium-fab-a11y.test.tsx tests/a11y/podium-bottom-sheet-a11y.test.tsx`

Closes #158

## Agent Provenance
run-id: da7199ce-f9a3-44d6-aafa-7979646816f0
task-id: #158
role: dev
dispatched: 2026-04-19T16:12:50.294Z
model: gpt-5.3-codex