### PR TITLE
test(a11y): FAB + BottomSheet accessibility tests

### DIFF
--- a/tests/a11y/podium-bottom-sheet-a11y.test.tsx
+++ b/tests/a11y/podium-bottom-sheet-a11y.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
 
-describe('PodiumBottomSheet accessibility semantics', () => {
-    it('does not render in DOM when isOpen is false', () => {
+describe('PodiumBottomSheet accessibility contract', () => {
+    it('scenario 6: closed sheet is not rendered', () => {
         render(
             <PodiumBottomSheet
                 isOpen={false}
@@ -18,7 +18,7 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
     });
 
-    it('open state exposes dialog role, modal semantics, and label', () => {
+    it('scenario 7: open sheet exposes required dialog attributes', () => {
         render(
             <PodiumBottomSheet
                 isOpen
@@ -34,7 +34,7 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         expect(dialog).toHaveAttribute('aria-label', 'Post composer');
     });
 
-    it('moves focus to first interactive element when opened', async () => {
+    it('scenario 8: focus moves to first interactive element when sheet opens', async () => {
         render(
             <PodiumBottomSheet
                 isOpen
@@ -45,17 +45,16 @@ describe('PodiumBottomSheet accessibility semantics', () => {
             />
         );
 
-        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         await waitFor(() => {
-            expect(closeButton).toHaveFocus();
+            expect(screen.getByRole('button', { name: 'Close post composer' })).toHaveFocus();
         });
     });
 
-    it('keeps tab focus within the sheet boundary', async () => {
+    it('scenario 9: tab navigation remains trapped inside the sheet', async () => {
         const user = userEvent.setup();
         render(
             <>
-                <button type="button">Outside before</button>
+                <button type="button">Outside focus target</button>
                 <PodiumBottomSheet
                     isOpen
                     selectedSide="tark"
@@ -63,12 +62,12 @@ describe('PodiumBottomSheet accessibility semantics', () => {
                     onPublish={() => {}}
                     onClose={() => {}}
                 />
-                <button type="button">Outside after</button>
             </>
         );
 
         const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
+        const outsideButton = screen.getByRole('button', { name: 'Outside focus target' });
 
         await waitFor(() => {
             expect(closeButton).toHaveFocus();
@@ -78,10 +77,10 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         await user.tab();
 
         expect(closeButton).toHaveFocus();
-        expect(screen.getByRole('button', { name: 'Outside after' })).not.toHaveFocus();
+        expect(outsideButton).not.toHaveFocus();
     });
 
-    it('Shift+Tab from first element wraps focus to last element', async () => {
+    it('scenario 10: Shift+Tab from first element wraps to last element', async () => {
         const user = userEvent.setup();
         render(
             <PodiumBottomSheet
@@ -104,8 +103,7 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         expect(publishButton).toHaveFocus();
     });
 
-    it('Escape key triggers onClose', async () => {
-        const user = userEvent.setup();
+    it('scenario 11: Escape key closes the sheet', () => {
         const onClose = vi.fn();
 
         render(
@@ -118,16 +116,11 @@ describe('PodiumBottomSheet accessibility semantics', () => {
             />
         );
 
-        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
-        await waitFor(() => {
-            expect(closeButton).toHaveFocus();
-        });
-
-        await user.keyboard('{Escape}');
+        fireEvent.keyDown(screen.getByRole('dialog', { name: 'Post composer' }), { key: 'Escape' });
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('scrim is hidden from assistive technologies', () => {
+    it('scenario 12: scrim is hidden from the accessibility tree', () => {
         render(
             <PodiumBottomSheet
                 isOpen
@@ -141,8 +134,7 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         expect(screen.getByTestId('podium-sheet-scrim')).toHaveAttribute('aria-hidden', 'true');
     });
 
-    it('validation error announces via alert + polite live region', async () => {
-        const user = userEvent.setup();
+    it('scenario 13: error message uses alert role and polite live region', () => {
         render(
             <PodiumBottomSheet
                 isOpen
@@ -153,15 +145,17 @@ describe('PodiumBottomSheet accessibility semantics', () => {
             />
         );
 
-        await user.click(screen.getByRole('button', { name: 'Publish post' }));
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
 
-        const validationAlert = screen.getByRole('alert');
-        expect(validationAlert).toHaveAttribute('aria-live', 'polite');
-        expect(validationAlert).toHaveTextContent('Text cannot be empty or whitespace only.');
+        fireEvent.change(textarea, { target: { value: '   ' } });
+        fireEvent.click(publishButton);
+
+        const errorMessage = screen.getByRole('alert');
+        expect(errorMessage).toHaveAttribute('aria-live', 'polite');
     });
 
-    it('textarea sets aria-invalid=true when validation error is present', async () => {
-        const user = userEvent.setup();
+    it('scenario 14: textarea marks aria-invalid=true when validation error is present', () => {
         render(
             <PodiumBottomSheet
                 isOpen
@@ -172,8 +166,12 @@ describe('PodiumBottomSheet accessibility semantics', () => {
             />
         );
 
-        await user.click(screen.getByRole('button', { name: 'Publish post' }));
+        const textarea = screen.getByRole('textbox', { name: 'Post text' });
+        const publishButton = screen.getByRole('button', { name: 'Publish post' });
 
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toHaveAttribute('aria-invalid', 'true');
+        fireEvent.change(textarea, { target: { value: '   ' } });
+        fireEvent.click(publishButton);
+
+        expect(textarea).toHaveAttribute('aria-invalid', 'true');
     });
 });

--- a/tests/a11y/podium-bottom-sheet-a11y.test.tsx
+++ b/tests/a11y/podium-bottom-sheet-a11y.test.tsx
@@ -83,17 +83,21 @@ describe('PodiumBottomSheet accessibility contract', () => {
     it('scenario 10: Shift+Tab from first element wraps to last element', async () => {
         const user = userEvent.setup();
         render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
+            <>
+                <button type="button">Outside focus target</button>
+                <PodiumBottomSheet
+                    isOpen
+                    selectedSide="tark"
+                    onSideChange={() => {}}
+                    onPublish={() => {}}
+                    onClose={() => {}}
+                />
+            </>
         );
 
         const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
+        const outsideButton = screen.getByRole('button', { name: 'Outside focus target' });
 
         await waitFor(() => {
             expect(closeButton).toHaveFocus();
@@ -101,6 +105,7 @@ describe('PodiumBottomSheet accessibility contract', () => {
 
         await user.tab({ shift: true });
         expect(publishButton).toHaveFocus();
+        expect(outsideButton).not.toHaveFocus();
     });
 
     it('scenario 11: Escape key closes the sheet', () => {
@@ -153,6 +158,7 @@ describe('PodiumBottomSheet accessibility contract', () => {
 
         const errorMessage = screen.getByRole('alert');
         expect(errorMessage).toHaveAttribute('aria-live', 'polite');
+        expect(errorMessage).toHaveTextContent('Text cannot be empty or whitespace only.');
     });
 
     it('scenario 14: textarea marks aria-invalid=true when validation error is present', () => {

--- a/tests/a11y/podium-fab-a11y.test.tsx
+++ b/tests/a11y/podium-fab-a11y.test.tsx
@@ -6,7 +6,7 @@ import { PodiumFAB } from '../../src/components/PodiumFAB';
 
 function MobileComposerHarness({ isMobile }: { isMobile: boolean }) {
     if (!isMobile) {
-        return null;
+        return <section aria-label="Desktop composer surface">Desktop composer</section>;
     }
 
     return (
@@ -93,5 +93,6 @@ describe('PodiumFAB accessibility contract', () => {
 
         expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
         expect(screen.queryByRole('group', { name: 'Post composer options', hidden: true })).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Desktop composer surface')).toBeInTheDocument();
     });
 });

--- a/tests/a11y/podium-fab-a11y.test.tsx
+++ b/tests/a11y/podium-fab-a11y.test.tsx
@@ -1,61 +1,66 @@
-import { useState } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { PodiumFAB } from '../../src/components/PodiumFAB';
 
-function PodiumFABHarness() {
-    const [isExpanded, setIsExpanded] = useState(false);
-
-    return (
-        <PodiumFAB
-            isExpanded={isExpanded}
-            onExpand={() => setIsExpanded(true)}
-            onSideSelect={() => setIsExpanded(false)}
-            onCollapse={() => setIsExpanded(false)}
-        />
-    );
-}
-
-function PodiumComposerSurfaceHarness({ isMobile }: { isMobile: boolean }) {
-    const [isExpanded, setIsExpanded] = useState(false);
-
+function MobileComposerHarness({ isMobile }: { isMobile: boolean }) {
     if (!isMobile) {
-        return <section aria-label="Desktop composer surface">Desktop composer</section>;
+        return null;
     }
 
     return (
         <PodiumFAB
+            isExpanded={false}
+            onExpand={() => {}}
+            onSideSelect={() => {}}
+            onCollapse={() => {}}
+        />
+    );
+}
+
+function ExpandableFabHarness() {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    return (
+        <PodiumFAB
             isExpanded={isExpanded}
             onExpand={() => setIsExpanded(true)}
-            onSideSelect={() => setIsExpanded(false)}
+            onSideSelect={() => {}}
             onCollapse={() => setIsExpanded(false)}
         />
     );
 }
 
-describe('PodiumFAB accessibility semantics', () => {
-    it('collapsed FAB has aria-label and aria-expanded=false', () => {
-        render(<PodiumFABHarness />);
+describe('PodiumFAB accessibility contract', () => {
+    it('scenario 1: collapsed FAB exposes accessible collapsed state', () => {
+        render(
+            <PodiumFAB
+                isExpanded={false}
+                onExpand={() => {}}
+                onSideSelect={() => {}}
+                onCollapse={() => {}}
+            />
+        );
 
-        const openComposerButton = screen.getByRole('button', { name: 'Open post composer' });
-        expect(openComposerButton).toHaveAttribute('aria-label', 'Open post composer');
-        expect(openComposerButton).toHaveAttribute('aria-expanded', 'false');
+        const openButton = screen.getByRole('button', { name: 'Open post composer' });
+        expect(openButton).toHaveAttribute('aria-label', 'Open post composer');
+        expect(openButton).toHaveAttribute('aria-expanded', 'false');
     });
 
-    it('after expand click, composer options group is exposed for assistive tech', async () => {
+    it('scenario 2: expand action transitions composer group to expanded ARIA state', async () => {
         const user = userEvent.setup();
-        render(<PodiumFABHarness />);
+        render(<ExpandableFabHarness />);
 
         await user.click(screen.getByRole('button', { name: 'Open post composer' }));
 
-        const composerOptionsGroup = await screen.findByRole('group', { name: 'Post composer options' });
+        const composerGroup = screen.getByRole('group', { name: 'Post composer options', hidden: true });
         await waitFor(() => {
-            expect(composerOptionsGroup).toHaveAttribute('aria-hidden', 'false');
+            expect(composerGroup).toHaveAttribute('aria-hidden', 'false');
         });
     });
 
-    it('expanded mini-buttons expose correct side labels', () => {
+    it('scenario 3: expanded mini buttons expose correct aria labels', () => {
         render(
             <PodiumFAB
                 isExpanded
@@ -69,7 +74,7 @@ describe('PodiumFAB accessibility semantics', () => {
         expect(screen.getByRole('button', { name: 'Post as Vitark' })).toBeInTheDocument();
     });
 
-    it('dismiss mini-button has aria-label Close', () => {
+    it('scenario 4: dismiss mini button exposes aria-label="Close"', () => {
         render(
             <PodiumFAB
                 isExpanded
@@ -79,13 +84,14 @@ describe('PodiumFAB accessibility semantics', () => {
             />
         );
 
-        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+        const dismissButton = screen.getByRole('button', { name: 'Close' });
+        expect(dismissButton).toHaveAttribute('aria-label', 'Close');
     });
 
-    it('FAB is not rendered when mobile surface is disabled (desktop path)', () => {
-        render(<PodiumComposerSurfaceHarness isMobile={false} />);
+    it('scenario 5: FAB is absent on desktop (isMobile=false)', () => {
+        render(<MobileComposerHarness isMobile={false} />);
 
         expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
-        expect(screen.getByLabelText('Desktop composer surface')).toBeInTheDocument();
+        expect(screen.queryByRole('group', { name: 'Post composer options', hidden: true })).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary
- add `tests/a11y/podium-fab-a11y.test.tsx` for all PodiumFAB accessibility scenarios (#1-#5)
- add `tests/a11y/podium-bottom-sheet-a11y.test.tsx` for all PodiumBottomSheet accessibility scenarios (#6-#14)
- cover ARIA contracts, keyboard/focus behavior, focus-trap boundaries, Escape handling, scrim semantics, and validation-driven `aria-invalid`

## Scenario-to-test traceability
| Scenario | Test |
|---|---|
| 1. Collapsed FAB `aria-label` + `aria-expanded=false` | `tests/a11y/podium-fab-a11y.test.tsx` → `scenario 1: collapsed FAB exposes accessible collapsed state` |
| 2. Expanded state ARIA after expand action | `tests/a11y/podium-fab-a11y.test.tsx` → `scenario 2: expand action transitions composer group to expanded ARIA state` |
| 3. Mini-button labels for Tark/Vitark | `tests/a11y/podium-fab-a11y.test.tsx` → `scenario 3: expanded mini buttons expose correct aria labels` |
| 4. Dismiss mini-button label `Close` | `tests/a11y/podium-fab-a11y.test.tsx` → `scenario 4: dismiss mini button exposes aria-label="Close"` |
| 5. FAB absent on desktop (`isMobile=false`) | `tests/a11y/podium-fab-a11y.test.tsx` → `scenario 5: FAB is absent on desktop (isMobile=false)` |
| 6. Closed bottom sheet not in DOM | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 6: closed sheet is not rendered` |
| 7. Open sheet `role=dialog`, `aria-modal=true`, `aria-label` | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 7: open sheet exposes required dialog attributes` |
| 8. Focus enters first interactive element on open | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 8: focus moves to first interactive element when sheet opens` |
| 9. Tab stays trapped in sheet boundary | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 9: tab navigation remains trapped inside the sheet` |
| 10. Shift+Tab wraps first→last and does not escape | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 10: Shift+Tab from first element wraps to last element` |
| 11. Escape invokes `onClose` | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 11: Escape key closes the sheet` |
| 12. Scrim `aria-hidden=true` | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 12: scrim is hidden from the accessibility tree` |
| 13. Error message `role=alert` + `aria-live=polite` | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 13: error message uses alert role and polite live region` |
| 14. Textarea `aria-invalid=true` on error | `tests/a11y/podium-bottom-sheet-a11y.test.tsx` → `scenario 14: textarea marks aria-invalid=true when validation error is present` |

## Verification
- `npm run test -- tests/a11y/podium-fab-a11y.test.tsx tests/a11y/podium-bottom-sheet-a11y.test.tsx`
- `npm run build`
- `npm run test`
- `npm run test:bdd`

## Residual Risk
- GitHub MCP did not expose per-thread IDs in `get_review_comments`, so review dispositions were logged in PR conversation comments rather than direct thread replies/resolutions.

## Rollback
- Revert commits `3adbd26` and `1c3c896`.

Closes #158

## Agent Provenance
run-id: 592521b8-38c1-47cb-9874-8963b78b436a
task-id: #158
role: dev
dispatched: 2026-04-19T16:12:41.074Z
model: gpt-5.3-codex