### PR TITLE
test(a11y): FAB + BottomSheet accessibility tests

### DIFF
--- a/tests/a11y/podium-bottom-sheet-a11y.test.tsx
+++ b/tests/a11y/podium-bottom-sheet-a11y.test.tsx
@@ -1,74 +1,61 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
 
-describe('PodiumBottomSheet accessibility semantics', () => {
-    it('does not render in DOM when isOpen is false', () => {
-        render(
+function renderBottomSheet(overrides?: Partial<ComponentProps<typeof PodiumBottomSheet>>) {
+    const onClose = overrides?.onClose ?? vi.fn();
+
+    const view = render(
+        <>
+            <button type="button">Outside page control</button>
             <PodiumBottomSheet
-                isOpen={false}
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
+                isOpen={overrides?.isOpen ?? true}
+                selectedSide={overrides?.selectedSide ?? 'tark'}
+                onSideChange={overrides?.onSideChange ?? vi.fn()}
+                onPublish={overrides?.onPublish ?? vi.fn()}
+                onClose={onClose}
             />
-        );
+        </>
+    );
+
+    return { ...view, onClose };
+}
+
+describe('PodiumBottomSheet a11y scenarios', () => {
+    it('is not rendered when closed', () => {
+        renderBottomSheet({ isOpen: false });
 
         expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog', { name: 'Post composer', hidden: true })).not.toBeInTheDocument();
+        expect(screen.queryByTestId('podium-sheet-scrim')).not.toBeInTheDocument();
     });
 
-    it('open state exposes dialog role, modal semantics, and label', () => {
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
-        );
+    it('renders required dialog role and ARIA attributes when open', () => {
+        renderBottomSheet();
 
         const dialog = screen.getByRole('dialog', { name: 'Post composer' });
+        expect(dialog).toHaveAttribute('role', 'dialog');
         expect(dialog).toHaveAttribute('aria-modal', 'true');
         expect(dialog).toHaveAttribute('aria-label', 'Post composer');
     });
 
-    it('moves focus to first interactive element when opened', async () => {
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
-        );
+    it('moves focus to the first interactive element on open', async () => {
+        renderBottomSheet();
 
-        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         await waitFor(() => {
-            expect(closeButton).toHaveFocus();
+            expect(screen.getByRole('button', { name: 'Close post composer' })).toHaveFocus();
         });
     });
 
-    it('keeps tab focus within the sheet boundary', async () => {
+    it('keeps tab navigation within the dialog boundary', async () => {
         const user = userEvent.setup();
-        render(
-            <>
-                <button type="button">Outside before</button>
-                <PodiumBottomSheet
-                    isOpen
-                    selectedSide="tark"
-                    onSideChange={() => {}}
-                    onPublish={() => {}}
-                    onClose={() => {}}
-                />
-                <button type="button">Outside after</button>
-            </>
-        );
+        renderBottomSheet();
 
         const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
+        const outsidePageControl = screen.getByRole('button', { name: 'Outside page control' });
 
         await waitFor(() => {
             expect(closeButton).toHaveFocus();
@@ -78,20 +65,12 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         await user.tab();
 
         expect(closeButton).toHaveFocus();
-        expect(screen.getByRole('button', { name: 'Outside after' })).not.toHaveFocus();
+        expect(outsidePageControl).not.toHaveFocus();
     });
 
-    it('Shift+Tab from first element wraps focus to last element', async () => {
+    it('moves focus from first element to last on Shift+Tab', async () => {
         const user = userEvent.setup();
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
-        );
+        renderBottomSheet();
 
         const closeButton = screen.getByRole('button', { name: 'Close post composer' });
         const publishButton = screen.getByRole('button', { name: 'Publish post' });
@@ -104,76 +83,43 @@ describe('PodiumBottomSheet accessibility semantics', () => {
         expect(publishButton).toHaveFocus();
     });
 
-    it('Escape key triggers onClose', async () => {
-        const user = userEvent.setup();
-        const onClose = vi.fn();
+    it('calls onClose when Escape is pressed inside the dialog', () => {
+        const { onClose } = renderBottomSheet();
 
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={onClose}
-            />
-        );
+        fireEvent.keyDown(screen.getByRole('dialog', { name: 'Post composer' }), { key: 'Escape' });
 
-        const closeButton = screen.getByRole('button', { name: 'Close post composer' });
-        await waitFor(() => {
-            expect(closeButton).toHaveFocus();
-        });
-
-        await user.keyboard('{Escape}');
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('scrim is hidden from assistive technologies', () => {
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
-        );
+    it('marks the scrim as aria-hidden', () => {
+        renderBottomSheet();
 
-        expect(screen.getByTestId('podium-sheet-scrim')).toHaveAttribute('aria-hidden', 'true');
+        const scrim = screen.getByTestId('podium-sheet-scrim');
+        expect(scrim).toHaveAttribute('aria-hidden', 'true');
     });
 
-    it('validation error announces via alert + polite live region', async () => {
+    it('surfaces errors as polite live alerts', async () => {
         const user = userEvent.setup();
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
-        );
+        renderBottomSheet();
 
+        const postTextField = screen.getByRole('textbox', { name: 'Post text' });
+        await user.type(postTextField, '   ');
         await user.click(screen.getByRole('button', { name: 'Publish post' }));
 
-        const validationAlert = screen.getByRole('alert');
-        expect(validationAlert).toHaveAttribute('aria-live', 'polite');
-        expect(validationAlert).toHaveTextContent('Text cannot be empty or whitespace only.');
+        const errorMessage = screen.getByRole('alert');
+        expect(errorMessage).toHaveAttribute('role', 'alert');
+        expect(errorMessage).toHaveAttribute('aria-live', 'polite');
+        expect(errorMessage).toHaveTextContent('Text cannot be empty or whitespace only.');
     });
 
-    it('textarea sets aria-invalid=true when validation error is present', async () => {
+    it('marks the textarea as aria-invalid when an error is present', async () => {
         const user = userEvent.setup();
-        render(
-            <PodiumBottomSheet
-                isOpen
-                selectedSide="tark"
-                onSideChange={() => {}}
-                onPublish={() => {}}
-                onClose={() => {}}
-            />
-        );
+        renderBottomSheet();
 
+        const postTextField = screen.getByRole('textbox', { name: 'Post text' });
+        await user.type(postTextField, '   ');
         await user.click(screen.getByRole('button', { name: 'Publish post' }));
 
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toHaveAttribute('aria-invalid', 'true');
+        expect(postTextField).toHaveAttribute('aria-invalid', 'true');
     });
 });

--- a/tests/a11y/podium-fab-a11y.test.tsx
+++ b/tests/a11y/podium-fab-a11y.test.tsx
@@ -4,24 +4,15 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import { PodiumFAB } from '../../src/components/PodiumFAB';
 
-function PodiumFABHarness() {
-    const [isExpanded, setIsExpanded] = useState(false);
-
-    return (
-        <PodiumFAB
-            isExpanded={isExpanded}
-            onExpand={() => setIsExpanded(true)}
-            onSideSelect={() => setIsExpanded(false)}
-            onCollapse={() => setIsExpanded(false)}
-        />
-    );
+interface PodiumFabHarnessProps {
+    isMobile: boolean;
 }
 
-function PodiumComposerSurfaceHarness({ isMobile }: { isMobile: boolean }) {
+function PodiumFabHarness({ isMobile }: PodiumFabHarnessProps) {
     const [isExpanded, setIsExpanded] = useState(false);
 
     if (!isMobile) {
-        return <section aria-label="Desktop composer surface">Desktop composer</section>;
+        return null;
     }
 
     return (
@@ -34,58 +25,54 @@ function PodiumComposerSurfaceHarness({ isMobile }: { isMobile: boolean }) {
     );
 }
 
-describe('PodiumFAB accessibility semantics', () => {
-    it('collapsed FAB has aria-label and aria-expanded=false', () => {
-        render(<PodiumFABHarness />);
+async function expandComposerAndWaitUntilAccessible(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole('button', { name: 'Open post composer' }));
+
+    await waitFor(() => {
+        const composerGroup = screen.getByRole('group', { name: 'Post composer options' });
+        expect(composerGroup).toHaveAttribute('aria-hidden', 'false');
+    });
+}
+
+describe('PodiumFAB a11y scenarios', () => {
+    it('keeps aria-label and collapsed aria-expanded contract on the closed FAB', () => {
+        render(<PodiumFabHarness isMobile />);
 
         const openComposerButton = screen.getByRole('button', { name: 'Open post composer' });
         expect(openComposerButton).toHaveAttribute('aria-label', 'Open post composer');
         expect(openComposerButton).toHaveAttribute('aria-expanded', 'false');
     });
 
-    it('after expand click, composer options group is exposed for assistive tech', async () => {
+    it('shows expanded composer group state after expand interaction', async () => {
         const user = userEvent.setup();
-        render(<PodiumFABHarness />);
+        render(<PodiumFabHarness isMobile />);
 
-        await user.click(screen.getByRole('button', { name: 'Open post composer' }));
-
-        const composerOptionsGroup = await screen.findByRole('group', { name: 'Post composer options' });
-        await waitFor(() => {
-            expect(composerOptionsGroup).toHaveAttribute('aria-hidden', 'false');
-        });
+        await expandComposerAndWaitUntilAccessible(user);
     });
 
-    it('expanded mini-buttons expose correct side labels', () => {
-        render(
-            <PodiumFAB
-                isExpanded
-                onExpand={() => {}}
-                onSideSelect={() => {}}
-                onCollapse={() => {}}
-            />
-        );
+    it('exposes mini-button aria labels for side selection', async () => {
+        const user = userEvent.setup();
+        render(<PodiumFabHarness isMobile />);
+
+        await expandComposerAndWaitUntilAccessible(user);
 
         expect(screen.getByRole('button', { name: 'Post as Tark' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Post as Vitark' })).toBeInTheDocument();
     });
 
-    it('dismiss mini-button has aria-label Close', () => {
-        render(
-            <PodiumFAB
-                isExpanded
-                onExpand={() => {}}
-                onSideSelect={() => {}}
-                onCollapse={() => {}}
-            />
-        );
+    it('exposes aria-label="Close" for the dismiss mini-button', async () => {
+        const user = userEvent.setup();
+        render(<PodiumFabHarness isMobile />);
 
-        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+        await expandComposerAndWaitUntilAccessible(user);
+
+        expect(screen.getByRole('button', { name: 'Close' })).toHaveAttribute('aria-label', 'Close');
     });
 
-    it('FAB is not rendered when mobile surface is disabled (desktop path)', () => {
-        render(<PodiumComposerSurfaceHarness isMobile={false} />);
+    it('does not render FAB controls when mobile mode is disabled', () => {
+        render(<PodiumFabHarness isMobile={false} />);
 
         expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
-        expect(screen.getByLabelText('Desktop composer surface')).toBeInTheDocument();
+        expect(screen.queryByRole('group', { name: 'Post composer options' })).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary
- refine and stabilize dedicated a11y scenario coverage for `PodiumFAB` and `PodiumBottomSheet`
- enforce deterministic expanded-state assertions for FAB by waiting for accessible group state after RAF-driven transitions
- strengthen BottomSheet closed-state semantics assertions (including hidden-role and scrim absence checks)

## Scenario-to-test traceability
1. FAB collapsed `aria-label="Open post composer"` + `aria-expanded="false"` → `podium-fab-a11y.test.tsx` / `keeps aria-label and collapsed aria-expanded contract on the closed FAB`
2. Expand interaction exposes expanded group ARIA state → `podium-fab-a11y.test.tsx` / `shows expanded composer group state after expand interaction`
3. Mini-buttons expose aria labels for Tark/Vitark → `podium-fab-a11y.test.tsx` / `exposes mini-button aria labels for side selection`
4. Dismiss mini-button has `aria-label="Close"` → `podium-fab-a11y.test.tsx` / `exposes aria-label="Close" for the dismiss mini-button`
5. FAB absent when desktop mode (`isMobile=false`) → `podium-fab-a11y.test.tsx` / `does not render FAB controls when mobile mode is disabled`
6. BottomSheet closed (`isOpen=false`) is absent from DOM → `podium-bottom-sheet-a11y.test.tsx` / `is not rendered when closed`
7. BottomSheet open has `role="dialog"`, `aria-modal="true"`, `aria-label="Post composer"` → `podium-bottom-sheet-a11y.test.tsx` / `renders required dialog role and ARIA attributes when open`
8. Focus moves to first interactive element on open → `podium-bottom-sheet-a11y.test.tsx` / `moves focus to the first interactive element on open`
9. Tab cycles within sheet boundary (no page escape) → `podium-bottom-sheet-a11y.test.tsx` / `keeps tab navigation within the dialog boundary`
10. Shift+Tab from first moves to last element in sheet → `podium-bottom-sheet-a11y.test.tsx` / `moves focus from first element to last on Shift+Tab`
11. Escape key triggers `onClose` → `podium-bottom-sheet-a11y.test.tsx` / `calls onClose when Escape is pressed inside the dialog`
12. Scrim has `aria-hidden="true"` → `podium-bottom-sheet-a11y.test.tsx` / `marks the scrim as aria-hidden`
13. Error message uses `role="alert"` + `aria-live="polite"` → `podium-bottom-sheet-a11y.test.tsx` / `surfaces errors as polite live alerts`
14. Textarea sets `aria-invalid="true"` on error → `podium-bottom-sheet-a11y.test.tsx` / `marks the textarea as aria-invalid when an error is present`

## Verification
- `npm run build`
- `npm test`
- `npx vitest run tests/a11y/podium-fab-a11y.test.tsx tests/a11y/podium-bottom-sheet-a11y.test.tsx`

Closes #158

Supersedes #167 (closed during forced-update/rebase sync).

## Agent Provenance
run-id: da7199ce-f9a3-44d6-aafa-7979646816f0
task-id: #158
role: dev
dispatched: 2026-04-19T16:12:50.294Z
model: gpt-5.3-codex