### PR TITLE
test(bdd): podium-fab-collapse AC-19 through AC-23 scenarios

### DIFF
--- a/features/podium-fab-collapse.feature
+++ b/features/podium-fab-collapse.feature
@@ -1,0 +1,39 @@
+Feature: Podium FAB Collapse
+  As a mobile user
+  I want to access the Podium via a floating action button
+  So that debate content is not obscured on small screens
+
+  Scenario: AC-19 — FAB visible on mobile, Podium hidden
+    Given I am on the debate screen
+    And the viewport is mobile (width < 768px)
+    Then I see the Podium FAB button
+    And I do not see the inline Podium
+
+  Scenario: AC-20 — FAB expands to show mini-buttons
+    Given I am on the debate screen
+    And the viewport is mobile (width < 768px)
+    When I tap the Podium FAB
+    Then I see the Tark mini-button
+    And I see the Vitark mini-button
+    And I see the dismiss mini-button
+
+  Scenario: AC-21 — Tark side selection opens bottom sheet
+    Given I am on the debate screen
+    And the viewport is mobile (width < 768px)
+    And the FAB is expanded
+    When I tap the Tark mini-button
+    Then the bottom sheet opens
+    And the SegmentedControl has Tark selected
+
+  Scenario: AC-22 — Post submitted via bottom sheet
+    Given the bottom sheet is open with Tark selected
+    When I type "test argument" in the post text area
+    And I tap the Publish button
+    Then the post is submitted with side Tark and text "test argument"
+    And the bottom sheet closes
+
+  Scenario: AC-23 — FAB and sheet not rendered on desktop
+    Given I am on the debate screen
+    And the viewport is desktop (width >= 768px)
+    Then I do not see the Podium FAB
+    And I see the inline Podium

--- a/features/step-definitions/podium-fab-collapse.steps.ts
+++ b/features/step-definitions/podium-fab-collapse.steps.ts
@@ -1,5 +1,5 @@
 import { After, Given, Then, When, World } from '@cucumber/cucumber';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
 import * as assert from 'assert';
 import { createElement } from 'react';
@@ -154,14 +154,16 @@ Given('I am on the debate screen', function (this: PodiumFabCollapseWorld) {
 
 Given(/^the viewport is mobile \(width < 768px\)$/, function (this: PodiumFabCollapseWorld) {
     assert.ok(this.viewportController, 'Expected viewport controller to be configured.');
-    this.viewportController.setIsMobile(true);
-    renderDebateScreen(this);
+    act(() => {
+        this.viewportController?.setIsMobile(true);
+    });
 });
 
 Given(/^the viewport is desktop \(width >= 768px\)$/, function (this: PodiumFabCollapseWorld) {
     assert.ok(this.viewportController, 'Expected viewport controller to be configured.');
-    this.viewportController.setIsMobile(false);
-    renderDebateScreen(this);
+    act(() => {
+        this.viewportController?.setIsMobile(false);
+    });
 });
 
 Then('I see the Podium FAB button', function (this: PodiumFabCollapseWorld) {

--- a/features/step-definitions/podium-fab-collapse.steps.ts
+++ b/features/step-definitions/podium-fab-collapse.steps.ts
@@ -139,6 +139,10 @@ async function expandFab(world: PodiumFabCollapseWorld): Promise<void> {
 }
 
 After(function (this: PodiumFabCollapseWorld) {
+    this.renderResult?.unmount();
+    this.renderResult = null;
+    cleanup();
+
     if (this.originalMatchMedia) {
         window.matchMedia = this.originalMatchMedia;
     }

--- a/features/step-definitions/podium-fab-collapse.steps.ts
+++ b/features/step-definitions/podium-fab-collapse.steps.ts
@@ -1,0 +1,326 @@
+import { After, Given, Then, When, World } from '@cucumber/cucumber';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
+import * as assert from 'assert';
+import { createElement } from 'react';
+import { DebateScreen } from '../../src/components/DebateScreen';
+
+type MediaQueryChangeListener = (event: MediaQueryListEvent) => void;
+
+interface MutableMediaQueryList extends MediaQueryList {
+    updateMatches: (nextValue: boolean) => void;
+}
+
+interface MatchMediaController {
+    setIsMobile: (nextValue: boolean) => void;
+}
+
+interface PodiumFabCollapseWorld extends World {
+    renderResult: RenderResult | null;
+    baselineCount: number;
+    originalMatchMedia?: typeof window.matchMedia;
+    viewportController?: MatchMediaController;
+}
+
+function createMediaQueryList(
+    media: string,
+    matches: boolean,
+    listeners?: Set<MediaQueryChangeListener>
+): MutableMediaQueryList {
+    let currentMatches = matches;
+
+    return {
+        get matches() {
+            return currentMatches;
+        },
+        set matches(nextValue: boolean) {
+            currentMatches = nextValue;
+        },
+        media,
+        onchange: null,
+        addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+            if (typeof listener === 'function') {
+                listeners?.add(listener as MediaQueryChangeListener);
+            }
+        },
+        removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+            if (typeof listener === 'function') {
+                listeners?.delete(listener as MediaQueryChangeListener);
+            }
+        },
+        addListener: (listener: MediaQueryChangeListener) => {
+            listeners?.add(listener);
+        },
+        removeListener: (listener: MediaQueryChangeListener) => {
+            listeners?.delete(listener);
+        },
+        dispatchEvent: () => true,
+        updateMatches(nextValue: boolean) {
+            currentMatches = nextValue;
+        },
+    } as MutableMediaQueryList;
+}
+
+function installViewportController(
+    world: PodiumFabCollapseWorld,
+    isMobileAtMount: boolean
+): MatchMediaController {
+    const viewportListeners = new Set<MediaQueryChangeListener>();
+    const viewportQuery = '(max-width: 767px)';
+    const viewportMediaQueryList = createMediaQueryList(
+        viewportQuery,
+        isMobileAtMount,
+        viewportListeners
+    );
+    const fallbackMatchMedia = world.originalMatchMedia ?? window.matchMedia;
+
+    window.matchMedia = ((query: string) => {
+        if (query === viewportQuery) {
+            return viewportMediaQueryList;
+        }
+
+        return fallbackMatchMedia(query);
+    }) as typeof window.matchMedia;
+
+    return {
+        setIsMobile(nextValue: boolean) {
+            viewportMediaQueryList.updateMatches(nextValue);
+            const event = {
+                matches: nextValue,
+                media: viewportQuery,
+            } as MediaQueryListEvent;
+
+            viewportListeners.forEach((listener) => {
+                listener(event);
+            });
+            viewportMediaQueryList.onchange?.(event);
+        },
+    };
+}
+
+function activeRender(world: PodiumFabCollapseWorld): RenderResult {
+    assert.ok(world.renderResult, 'Expected the debate screen to be rendered.');
+    return world.renderResult;
+}
+
+function ensureAnimationFrameApi(): void {
+    if (typeof window.requestAnimationFrame !== 'function') {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) =>
+            window.setTimeout(() => callback(Date.now()), 0);
+    }
+
+    if (typeof window.cancelAnimationFrame !== 'function') {
+        window.cancelAnimationFrame = (id: number) => {
+            window.clearTimeout(id);
+        };
+    }
+}
+
+function renderDebateScreen(world: PodiumFabCollapseWorld): void {
+    ensureAnimationFrameApi();
+    cleanup();
+    world.renderResult = render(createElement(DebateScreen));
+    world.baselineCount = activeRender(world).getAllByRole('listitem').length;
+}
+
+async function expandFab(world: PodiumFabCollapseWorld): Promise<void> {
+    fireEvent.click(
+        activeRender(world).getByRole('button', { name: 'Open post composer' })
+    );
+
+    await waitFor(() => {
+        const tarkMiniButton = activeRender(world).getByRole('button', {
+            name: 'Post as Tark',
+        }) as HTMLButtonElement;
+        assert.equal(tarkMiniButton.disabled, false);
+    });
+}
+
+After(function (this: PodiumFabCollapseWorld) {
+    if (this.originalMatchMedia) {
+        window.matchMedia = this.originalMatchMedia;
+    }
+    this.viewportController = undefined;
+});
+
+Given('I am on the debate screen', function (this: PodiumFabCollapseWorld) {
+    if (!this.originalMatchMedia) {
+        this.originalMatchMedia = window.matchMedia;
+    }
+
+    this.viewportController = installViewportController(this, false);
+    renderDebateScreen(this);
+});
+
+Given(/^the viewport is mobile \(width < 768px\)$/, function (this: PodiumFabCollapseWorld) {
+    assert.ok(this.viewportController, 'Expected viewport controller to be configured.');
+    this.viewportController.setIsMobile(true);
+    renderDebateScreen(this);
+});
+
+Given(/^the viewport is desktop \(width >= 768px\)$/, function (this: PodiumFabCollapseWorld) {
+    assert.ok(this.viewportController, 'Expected viewport controller to be configured.');
+    this.viewportController.setIsMobile(false);
+    renderDebateScreen(this);
+});
+
+Then('I see the Podium FAB button', function (this: PodiumFabCollapseWorld) {
+    const fabButton = activeRender(this).getByRole('button', {
+        name: 'Open post composer',
+    });
+    assert.ok(fabButton.classList.contains('podium-fab'));
+});
+
+Then('I do not see the inline Podium', function (this: PodiumFabCollapseWorld) {
+    assert.equal(
+        activeRender(this).queryByRole('switch', { name: 'Post as Tark' }),
+        null
+    );
+});
+
+When('I tap the Podium FAB', function (this: PodiumFabCollapseWorld) {
+    fireEvent.click(
+        activeRender(this).getByRole('button', { name: 'Open post composer' })
+    );
+});
+
+Then('I see the Tark mini-button', async function (this: PodiumFabCollapseWorld) {
+    await waitFor(() => {
+        const tarkMiniButton = activeRender(this).getByRole('button', {
+            name: 'Post as Tark',
+        }) as HTMLButtonElement;
+        assert.equal(tarkMiniButton.disabled, false);
+    });
+});
+
+Then(
+    'I see the Vitark mini-button',
+    async function (this: PodiumFabCollapseWorld) {
+        await waitFor(() => {
+            const vitarkMiniButton = activeRender(this).getByRole('button', {
+                name: 'Post as Vitark',
+            }) as HTMLButtonElement;
+            assert.equal(vitarkMiniButton.disabled, false);
+        });
+    }
+);
+
+Then(
+    'I see the dismiss mini-button',
+    async function (this: PodiumFabCollapseWorld) {
+        await waitFor(() => {
+            const dismissMiniButton = activeRender(this).getByRole('button', {
+                name: 'Close',
+            }) as HTMLButtonElement;
+            assert.equal(dismissMiniButton.disabled, false);
+        });
+    }
+);
+
+Given('the FAB is expanded', async function (this: PodiumFabCollapseWorld) {
+    await expandFab(this);
+});
+
+When('I tap the Tark mini-button', function (this: PodiumFabCollapseWorld) {
+    fireEvent.click(
+        activeRender(this).getByRole('button', { name: 'Post as Tark' })
+    );
+});
+
+Then('the bottom sheet opens', async function (this: PodiumFabCollapseWorld) {
+    await waitFor(() => {
+        assert.ok(
+            activeRender(this).getByRole('dialog', { name: 'Post composer' })
+        );
+    });
+});
+
+Then(
+    'the SegmentedControl has Tark selected',
+    function (this: PodiumFabCollapseWorld) {
+        const tarkRadio = activeRender(this).getByRole('radio', { name: 'Tark' });
+        assert.equal(tarkRadio.getAttribute('aria-checked'), 'true');
+    }
+);
+
+Given(
+    'the bottom sheet is open with Tark selected',
+    async function (this: PodiumFabCollapseWorld) {
+        if (!this.originalMatchMedia) {
+            this.originalMatchMedia = window.matchMedia;
+        }
+
+        this.viewportController = installViewportController(this, true);
+        renderDebateScreen(this);
+        await expandFab(this);
+        fireEvent.click(activeRender(this).getByRole('button', { name: 'Post as Tark' }));
+
+        await waitFor(() => {
+            assert.ok(
+                activeRender(this).getByRole('dialog', { name: 'Post composer' })
+            );
+            const tarkRadio = activeRender(this).getByRole('radio', { name: 'Tark' });
+            assert.equal(tarkRadio.getAttribute('aria-checked'), 'true');
+        });
+    }
+);
+
+When(
+    'I type {string} in the post text area',
+    function (this: PodiumFabCollapseWorld, postText: string) {
+        fireEvent.change(activeRender(this).getByRole('textbox', { name: 'Post text' }), {
+            target: { value: postText },
+        });
+    }
+);
+
+When('I tap the Publish button', function (this: PodiumFabCollapseWorld) {
+    fireEvent.click(activeRender(this).getByRole('button', { name: 'Publish post' }));
+});
+
+Then(
+    'the post is submitted with side Tark and text {string}',
+    async function (this: PodiumFabCollapseWorld, expectedText: string) {
+        await waitFor(() => {
+            const timelineItems = Array.from(
+                activeRender(this).container.querySelectorAll<HTMLElement>(
+                    '.timeline__list > li'
+                )
+            );
+            assert.equal(timelineItems.length, this.baselineCount + 1);
+
+            const latestTimelineItem = timelineItems[timelineItems.length - 1];
+            assert.ok(latestTimelineItem);
+            assert.ok(
+                latestTimelineItem.classList.contains('timeline__item--tark')
+            );
+            assert.ok(latestTimelineItem.textContent?.includes(expectedText));
+        });
+    }
+);
+
+Then('the bottom sheet closes', async function (this: PodiumFabCollapseWorld) {
+    await waitFor(() => {
+        assert.equal(
+            activeRender(this).queryByRole('dialog', { name: 'Post composer' }),
+            null
+        );
+    });
+});
+
+Then('I do not see the Podium FAB', function (this: PodiumFabCollapseWorld) {
+    assert.equal(
+        activeRender(this).queryByRole('button', { name: 'Open post composer' }),
+        null
+    );
+    assert.equal(
+        activeRender(this).queryByRole('dialog', { name: 'Post composer' }),
+        null
+    );
+});
+
+Then('I see the inline Podium', function (this: PodiumFabCollapseWorld) {
+    assert.ok(activeRender(this).getByRole('switch', { name: 'Post as Tark' }));
+    assert.ok(activeRender(this).getByRole('textbox', { name: 'Post text' }));
+    assert.ok(activeRender(this).getByRole('button', { name: 'Publish post' }));
+});

--- a/features/step-definitions/podium-fab-collapse.steps.ts
+++ b/features/step-definitions/podium-fab-collapse.steps.ts
@@ -120,7 +120,9 @@ function renderDebateScreen(world: PodiumFabCollapseWorld): void {
     ensureAnimationFrameApi();
     cleanup();
     world.renderResult = render(createElement(DebateScreen));
-    world.baselineCount = activeRender(world).getAllByRole('listitem').length;
+    world.baselineCount = activeRender(world).container.querySelectorAll(
+        '.timeline__list > li'
+    ).length;
 }
 
 async function expandFab(world: PodiumFabCollapseWorld): Promise<void> {

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -98,7 +98,15 @@ export function DebateScreen() {
                         isOpen={isSheetOpen}
                         selectedSide={selectedSide}
                         onSideChange={setSelectedSide}
-                        onPublish={handlePublish}
+                        onPublish={(text, side) => {
+                            const publishError = handlePublish(text, side);
+                            if (publishError) {
+                                return publishError;
+                            }
+
+                            setIsSheetOpen(false);
+                            return null;
+                        }}
                         onClose={() => {
                             if (ignoreNextSheetCloseRef.current) {
                                 ignoreNextSheetCloseRef.current = false;

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -41,7 +41,7 @@ div.podium-fab[role="group"] {
     pointer-events: none;
 }
 
-div.podium-fab[role='group'].podium-fab--expanded {
+.podium-fab--expanded {
     pointer-events: auto;
 }
 

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -245,24 +245,31 @@ describe('DebateScreen', () => {
         expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
     });
 
-    it('opens bottom sheet immediately with selected side after mobile FAB side selection', () => {
+    it('opens bottom sheet immediately with selected side after mobile FAB side selection', async () => {
         mockViewportQuery(true);
         render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
         const vitarkAction = screen.getByRole('button', { name: 'Post as Vitark' });
+        await waitFor(() => {
+            expect(vitarkAction).toBeEnabled();
+        });
         fireEvent.click(vitarkAction);
 
         expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute('aria-checked', 'true');
     });
 
-    it('resets FAB and sheet state on resize from mobile to desktop', () => {
+    it('resets FAB and sheet state on resize from mobile to desktop', async () => {
         const mediaController = mockViewportQuery(true);
         render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        const tarkAction = screen.getByRole('button', { name: 'Post as Tark' });
+        await waitFor(() => {
+            expect(tarkAction).toBeEnabled();
+        });
+        fireEvent.click(tarkAction);
         expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
 
         act(() => {


### PR DESCRIPTION
## Summary
- add `features/podium-fab-collapse.feature` with AC-19 through AC-23 scenarios for mobile FAB collapse and desktop absence
- add `features/step-definitions/podium-fab-collapse.steps.ts` with jsdom-only viewport + interaction steps aligned to FAB and bottom-sheet states
- close the mobile bottom sheet after a successful publish in `DebateScreen` so AC-22 behavior is exercised and passes end-to-end

## BDD scenario-to-step traceability
| Scenario | Key step definitions |
|---|---|
| AC-19 | `I am on the debate screen` + `the viewport is mobile (width < 768px)` + `I see the Podium FAB button` |
| AC-20 | `I tap the Podium FAB` + mini-button visibility steps |
| AC-21 | `the FAB is expanded` + `I tap the Tark mini-button` + sheet open/selection assertions |
| AC-22 | `the bottom sheet is open with Tark selected` + post publish + submission and close assertions |
| AC-23 | `the viewport is desktop (width >= 768px)` + FAB absent + inline podium visible assertions |

## Figma alignment notes
Validated state wording against the provided frame set for closed FAB, expanded FAB, and open bottom sheet in light/dark mobile variants, then encoded those states as behavior assertions (no browser-specific visual assumptions).

## Verification
- `npm run test:bdd`
- `npm run test`
- `npm run build`

## Runtime QA handoff package (UI-impacting behavior)
- Journey map: debate screen mobile FAB -> expand -> choose Tark -> bottom sheet open -> publish -> sheet closes
- Route list: Debate screen main route (single-screen flow)
- Setup/test data: default seed timeline + post text `test argument`
- Expected states: mobile FAB visible and expandable; Tark preselected on sheet open via Tark mini-button; publish appends Tark post and closes sheet; desktop renders inline podium with no FAB/sheet
- Known risk notes: step tests rely on matchMedia stubs and jsdom timing for RAF-driven transitions

Closes #159

## Agent Provenance
run-id: 8f39e4eb-d156-476b-8bdb-d1b98fd2da18
task-id: #159
role: dev
dispatched: 2026-04-19T16:38:33.031Z
model: gpt-5.3-codex