### PR TITLE
chore: add review loop exit status taxonomy and skill quality improvements

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -157,7 +157,7 @@ The full PR review workflow — Strict Accept-vs-Challenge Lens, PR Review Intak
 
 The stacked PR review-loop workflow - pipelined review requests, base-to-tip disposition sequencing, retarget/sync order, and rebase-compatibility recovery - is defined in the `stacked-pr-review-loop` skill (`.github/skills/stacked-pr-review-loop/SKILL.md`). Agents must follow this skill when handling dependent PR chains.
 
-For orchestrator-managed dependent PR chains, review-loop ownership is centralized on the orchestrator: orchestrator requests Copilot reviews, polls live review state, triages dispositions, and sequences base-to-tip progression. In this mode, dev agents are code-only executors for assigned tasks and do not independently start or continue review loops unless the orchestrator explicitly delegates a specific review action.
+For orchestrator-managed dependent PR chains, ownership is split: orchestrator owns stack sequencing (merge order, base-to-tip progression, PR retargeting); dev agents own their assigned PR's full review loop (request Copilot review, poll to review-clean, triage and fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, return review-clean handback). Dev agents do not advance stack sequencing, trigger merges, or retarget PR bases.
 
 ## Gate Recovery And Resume Workflow
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -157,7 +157,7 @@ The full PR review workflow — Strict Accept-vs-Challenge Lens, PR Review Intak
 
 The stacked PR review-loop workflow - pipelined review requests, base-to-tip disposition sequencing, retarget/sync order, and rebase-compatibility recovery - is defined in the `stacked-pr-review-loop` skill (`.github/skills/stacked-pr-review-loop/SKILL.md`). Agents must follow this skill when handling dependent PR chains.
 
-For orchestrator-managed dependent PR chains, ownership is split: orchestrator owns stack sequencing (merge order, base-to-tip progression, PR retargeting); dev agents own their assigned PR's full review loop (request Copilot review, poll to review-clean, triage and fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, return review-clean handback). Dev agents do not advance stack sequencing, trigger merges, or retarget PR bases.
+For orchestrator-managed dependent PR chains, ownership is split: orchestrator owns stack sequencing (merge order, base-to-tip progression, PR retargeting); dev agents own their assigned PR's full review loop (request Copilot review, poll to review-clean, triage and fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, return a `REVIEW_CLEAN` or `REVIEW_CLEAN_WITH_ESCALATIONS` exit-status handback). Dev agents do not advance stack sequencing, trigger merges, or retarget PR bases.
 
 ## Gate Recovery And Resume Workflow
 

--- a/.github/agents/dev.agent.md
+++ b/.github/agents/dev.agent.md
@@ -57,7 +57,7 @@ Follow the `pr-review-loop` skill (`.github/skills/pr-review-loop/SKILL.md`) for
 
 For dependent PR chains, follow the `stacked-pr-review-loop` skill (`.github/skills/stacked-pr-review-loop/SKILL.md`) for efficient sequencing, base-to-tip fix order, and retarget/sync flow.
 
-In `Orchestrator-Managed Stacked Review Mode`, dev owns its assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return a review-clean handback. Dev does not advance stack sequencing, trigger merges, or retarget PR bases.
+In `Orchestrator-Managed Stacked Review Mode`, dev owns its assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return a `REVIEW_CLEAN` or `REVIEW_CLEAN_WITH_ESCALATIONS` exit-status handback. Dev does not advance stack sequencing, trigger merges, or retarget PR bases.
 
 Dev-specific note:
 

--- a/.github/agents/dev.agent.md
+++ b/.github/agents/dev.agent.md
@@ -40,7 +40,7 @@ You are the implementation specialist for one approved coding task at a time.
 9. DO NOT use raw color values, hardcoded spacing, or ad-hoc tokens in code. Reference only CSS custom properties from the project's token file (see Design System Foundation Policy in `.github/AGENTS.md`).
 10. DO NOT ship code that only supports one theme. All styling must work in both Light and Dark themes via the token system.
 11. For GitHub issue, pull request, review, comment, label, and status interactions, use GitHub MCP tools as the required interface. Only use a non-MCP fallback if the GitHub MCP server lacks the capability and Product Owner approves the exception.
-12. In `Orchestrator-Managed Stacked Review Mode`, DO NOT independently start or continue the PR review loop unless orchestrator explicitly delegates that action.
+12. In `Orchestrator-Managed Stacked Review Mode`, always complete your own PR review loop to review-clean before returning handback. The orchestrator owns stack sequencing (merge order, retarget, base-to-tip progression); you own your assigned PR's review loop. Do not trigger merges or retarget other PRs.
 13. For UI-impacting issues, provide the full Runtime QA handoff package evidence (journey map, route list, expected states, setup notes, setup/test data, and known-risk notes); this complements coded tests and does not replace them.
 
 ## Domain Language Policy
@@ -57,7 +57,7 @@ Follow the `pr-review-loop` skill (`.github/skills/pr-review-loop/SKILL.md`) for
 
 For dependent PR chains, follow the `stacked-pr-review-loop` skill (`.github/skills/stacked-pr-review-loop/SKILL.md`) for efficient sequencing, base-to-tip fix order, and retarget/sync flow.
 
-In `Orchestrator-Managed Stacked Review Mode`, dev scope is code-only for the assigned issue: implement requested changes, push commits, and return handback status. Unless explicitly delegated by orchestrator, dev does not independently request Copilot review, poll review status, classify review comments, or advance stack sequencing.
+In `Orchestrator-Managed Stacked Review Mode`, dev owns its assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return a review-clean handback. Dev does not advance stack sequencing, trigger merges, or retarget PR bases.
 
 Dev-specific note:
 
@@ -110,7 +110,7 @@ Expected input from Architect + Orchestrator:
 13. For UI-impacting issues, prepare a Runtime QA handoff package: acceptance-criterion journey mapping, route list, required setup/test data, expected states, and known-risk notes.
 14. Prepare PR that references and closes the issue and includes scenario-to-test traceability.
 15. Return build package with code/test/PR evidence and residual risks.
-16. If handoff specifies `Orchestrator-Managed Stacked Review Mode`, stop after push + handback package and wait for orchestrator-supplied fix instructions for any review feedback.
+16. If handoff specifies `Orchestrator-Managed Stacked Review Mode`, complete your own PR review loop to review-clean (implement → push → request review → poll → fix `Accept` items → escalate others → repeat until clean), then return handback with review-clean evidence. Do not trigger stack merges or retarget other PRs.
 
 ## Build Quality Checks
 
@@ -129,6 +129,7 @@ A build output is "Ready" only when all are true:
 11. Domain language compliance: all domain-facing identifiers (variable names, function names, class names, component names, CSS class names) use glossary-derived terms from `05-architecture.md` §2.3. Infrastructure terms (`div`, `span`, `render`, `component`) appear only in framework-required positions.
 12. For UI-impacting issues, runtime QA handoff package is included and sufficient for Gate 5.5 validation.
 13. For UI-impacting issues, browser screenshot evidence (at all required viewports and themes) paired with Figma reference screenshots is attached to the PR body; any intentional deviation is explicitly noted with justification.
+14. PR description accuracy: before opening the PR, run `git diff --stat origin/<base-branch>` and verify every file in the diff is listed in the PR body's `Files Changed` section, and every file listed in `Files Changed` appears in the diff. No fabricated entries, no silent omissions.
 
 ## Output Format
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,11 +6,13 @@ tark-vitark is a personal portfolio/product project. Current implementation is s
 
 ## Coding Conventions
 
-- Use CSS custom properties from the token system for colors, spacing, and shared style values.
-- Canonical token file path is `src/styles/tokens.css`.
-- Support both Light and Dark themes via `[data-theme]` selectors and `prefers-color-scheme` fallback.
-- Use domain-oriented naming in code and tests.
+- Use domain-oriented naming in code, tests, and PR descriptions.
 - Follow test-first behavior-driven development when feasible.
+- Language- and technology-specific rules live in `.github/instructions/`:
+  - React/TSX → `.github/instructions/react.instructions.md`
+  - CSS → `.github/instructions/css.instructions.md`
+  - Tests → `.github/instructions/tests.instructions.md`
+- To add or update instruction files, follow `.github/skills/coding-standards/SKILL.md`.
 
 ## Branching
 

--- a/.github/instructions/css.instructions.md
+++ b/.github/instructions/css.instructions.md
@@ -15,7 +15,7 @@ color: #1a1a1a;
 background: rgba(0, 0, 0, 0.5);
 
 /* Prefer */
-color: var(--color-text-primary);
+color: var(--color-on-surface);
 background: var(--color-scrim);
 ```
 
@@ -25,11 +25,21 @@ Theme variants must use `[data-theme]` attribute selectors. Always include a
 `prefers-color-scheme` fallback at the `:root` level for users without JS.
 
 ```css
-/* Prefer */
-:root { --color-bg: #fff; }
-@media (prefers-color-scheme: dark) { :root { --color-bg: #0d0d0d; } }
-[data-theme="dark"] { --color-bg: #0d0d0d; }
-[data-theme="light"] { --color-bg: #fff; }
+/* Prefer: keep color token definitions in src/styles/tokens.css */
+:root { color-scheme: light; }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) { color-scheme: dark; }
+}
+
+[data-theme="dark"] { color-scheme: dark; }
+[data-theme="light"] { color-scheme: light; }
+
+/* Component CSS should consume shared tokens rather than redefine them */
+.theme-demo {
+  color: var(--color-on-surface);
+  background: var(--color-scrim);
+}
 ```
 
 ## Safe-Area / Viewport
@@ -39,5 +49,5 @@ Use `env(safe-area-inset-*)` with a fallback for all bottom-anchored elements
 
 ```css
 /* Prefer */
-padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+padding-bottom: max(var(--space-4), env(safe-area-inset-bottom, 0px));
 ```

--- a/.github/instructions/css.instructions.md
+++ b/.github/instructions/css.instructions.md
@@ -1,0 +1,43 @@
+---
+applyTo: "**/*.css"
+---
+# CSS Standards
+
+## Token Usage
+
+All color, spacing, and shared style values must use CSS custom properties
+from `src/styles/tokens.css`. No hardcoded hex, rgb, hsl, or pixel values
+for anything covered by the token system.
+
+```css
+/* Avoid */
+color: #1a1a1a;
+background: rgba(0, 0, 0, 0.5);
+
+/* Prefer */
+color: var(--color-text-primary);
+background: var(--color-scrim);
+```
+
+## Theming
+
+Theme variants must use `[data-theme]` attribute selectors. Always include a
+`prefers-color-scheme` fallback at the `:root` level for users without JS.
+
+```css
+/* Prefer */
+:root { --color-bg: #fff; }
+@media (prefers-color-scheme: dark) { :root { --color-bg: #0d0d0d; } }
+[data-theme="dark"] { --color-bg: #0d0d0d; }
+[data-theme="light"] { --color-bg: #fff; }
+```
+
+## Safe-Area / Viewport
+
+Use `env(safe-area-inset-*)` with a fallback for all bottom-anchored elements
+(FABs, bottom sheets, sticky bars).
+
+```css
+/* Prefer */
+padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+```

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -15,8 +15,8 @@ validates once internally.
 ```tsx
 // Avoid: double validation
 function handleSubmit(text: string) {
-  const errors = validatePost(text); // ← form component already did this
-  if (errors.length) return;
+  const validation = validatePost(text); // ← form component already did this
+  if (!validation.valid) return;
   onPublish(text);
 }
 

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: "**/*.tsx"
+---
+# React Component Standards
+
+## Validation Boundary
+
+The component that owns the `<form>` element is the sole validation boundary.
+Downstream handlers (`onPublish`, `handlePublish`, etc.) must not re-validate
+the same input — they trust the caller.
+
+If a handler is called from multiple entry points without a form, the handler
+validates once internally.
+
+```tsx
+// Avoid: double validation
+function handleSubmit(text: string) {
+  const errors = validatePost(text); // ← form component already did this
+  if (errors.length) return;
+  onPublish(text);
+}
+
+// Prefer: trust the form boundary
+function handleSubmit(text: string) {
+  onPublish(text);
+}
+```
+
+## Domain Naming
+
+Use domain terminology in component names, prop names, and event handlers.
+Avoid generic names like `item`, `data`, `handleClick` — prefer `tark`,
+`vitark`, `onPublish`, `onChallenge`.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "**/tests/**"
+---
+# Test Standards
+
+## Domain Language
+
+Test descriptions and assertions must use domain terminology.
+Infrastructure terms must not appear in scenario names or `it()` descriptions.
+
+```ts
+// Avoid
+it('renders the component with correct DOM elements')
+it('component state updates on click')
+
+// Prefer
+it('publishes a tark when the submit button is pressed')
+it('shows a vitark after a challenge is accepted')
+```
+
+## BDD Step Quality
+
+Gherkin scenarios (`features/*.feature`) must map one step to one observable
+behavior. Steps must not bundle multiple actions or assertions into one line.
+
+```gherkin
+# Avoid
+When I fill in the form and click submit and see the result
+
+# Prefer
+When I fill in the tark text
+And I press "Publish"
+Then a new tark appears in the debate
+```
+
+## Acceptance Criteria Traceability
+
+Each `it()` or `test()` block must trace back to an acceptance criterion in
+the corresponding `.feature` file. The scenario title or a comment must make
+this link explicit.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,5 +1,8 @@
 ---
-applyTo: "**/tests/**"
+applyTo:
+  - "**/tests/**"
+  - "**/features/**/*.feature"
+  - "**/features/step-definitions/**/*.ts"
 ---
 # Test Standards
 

--- a/.github/skills/alarm/SKILL.md
+++ b/.github/skills/alarm/SKILL.md
@@ -14,7 +14,7 @@ The orchestrator has no built-in signal when background agents finish or when a 
 Step 1 — Run `date` to get the real current time (sync terminal call, before arming):
 
 ```bash
-date "+%H:%M IST" --date="TZ=\"Asia/Kolkata\" now"
+TZ=Asia/Kolkata date "+%H:%M %Z"
 ```
 
 Step 2 — Arm the alarm (async):

--- a/.github/skills/alarm/SKILL.md
+++ b/.github/skills/alarm/SKILL.md
@@ -11,13 +11,21 @@ The orchestrator has no built-in signal when background agents finish or when a 
 
 ## How To Arm
 
+Step 1 — Run `date` to get the real current time (sync terminal call, before arming):
+
+```bash
+date "+%H:%M IST" --date="TZ=\"Asia/Kolkata\" now"
+```
+
+Step 2 — Arm the alarm (async):
+
 ```bash
 sleep <SECONDS> && echo "ORCHESTRATOR WAKE CHECK: <one-line context>"
 ```
 
 Run with `mode=async`. Record the terminal ID.
 
-**Immediately before arming, run `date` to get the real current time.** Then arm the alarm. Then output the confirmation line — no exceptions:
+Step 3 — Immediately output the confirmation line — no exceptions:
 
 ```
 Alarm armed — terminal <id>, armed at <HH:MM IST>, ETA <HH:MM IST>.

--- a/.github/skills/alarm/SKILL.md
+++ b/.github/skills/alarm/SKILL.md
@@ -40,25 +40,9 @@ Use the table as the default. If urgency justifies a shorter interval, caller ma
 
 When the alarm fires, VS Code sends a turn-start notification. On that turn:
 
-1. Check the condition that triggered the wait (see below by situation).
+1. Check the condition that triggered the wait (caller's skill defines what to check).
 2. Act on findings autonomously without waiting for PO.
 3. If the wait state has not resolved, re-arm immediately with the same interval.
-
-### Situation: PR review pending
-
-On wake, call `get_reviews` on the PR via GitHub MCP. Check the latest Copilot review body:
-- **"generated 0 comments" / "generated no new comments" / "0 new comments"** → review-clean, proceed to next step autonomously.
-- **New comments present** → run PR Review Intake Protocol, address, push, re-request review, re-arm alarm.
-
-Do **not** run `wait_for_copilot_review.js` or any blocking script. The alarm replaces script-based polling entirely.
-
-### Situation: Agent build in progress
-
-On wake, run the GitHub PR cross-check: list open PRs on the active slice branch and look for a PR closing the task issue. GitHub PR presence is ground truth — if found, treat agent as done regardless of process state. If not found, re-arm.
-
-### Situation: Merge sequencing block
-
-On wake, verify the base PR has merged (`get` on the base PR, check `state=closed` + `merged=true`). If merged, retarget the dependent PR and continue. If not, re-arm.
 
 ## Re-Arm Rule
 
@@ -71,4 +55,3 @@ When the wait state resolves, let the existing alarm expire harmlessly (do not a
 ## Disallowed Alternatives
 
 - Do **not** use sync `sleep` — it blocks the chat session.
-- Do **not** run `wait_for_copilot_review.js` or any blocking polling script in orchestrator context. Script-based polling is for dev-agent context only (inside `run-agent.ts` with the `execute` tool).

--- a/.github/skills/build-evidence-and-merge-readiness/SKILL.md
+++ b/.github/skills/build-evidence-and-merge-readiness/SKILL.md
@@ -106,7 +106,7 @@ Rules:
 8. Rollback lock: verify rollback note is documented and feasible.
 9. Risk acceptance lock: verify residual risks are visible and explicitly accepted when required.
 10. AC SSoT lock: verify `02-prd.md`, `05-architecture.md`, and `06-tasks.md` do not contain copied AC prose — they must reference AC IDs and link to the canonical `.feature` file. Flag any artifact that re-states AC text as a drift risk.
-11. Architecture delta lock: verify the PR description includes either an `## Architecture Delta` section (for any task that changed an interface contract or a "no-changes" component) or an explicit `Architecture Delta: none` statement. Missing this is a Build Gate loop-back condition.
+11. Architecture delta lock: if the task changed an interface contract or a previously "no-changes" component, verify `05-architecture.md` includes an appended `## Architecture Delta` section as the canonical record; the PR description may link to or summarize that delta, but is not the source of truth. If there is no architecture delta, verify the PR description includes an explicit `Architecture Delta: none` statement. Missing the required evidence is a Build Gate loop-back condition.
 
 ## Merge Gate Output Contract
 

--- a/.github/skills/build-evidence-and-merge-readiness/SKILL.md
+++ b/.github/skills/build-evidence-and-merge-readiness/SKILL.md
@@ -52,6 +52,32 @@ A superset block injected by the orchestrator (with additional fields such as `t
 3. Product Owner remains the only authority who performs the actual merge.
 4. If merge readiness evidence is incomplete, the PR must loop back with explicit remediation items.
 
+## Architecture Delta Protocol (Dev-owned, Gate 5)
+
+During Gate 5 implementation, if any task:
+- changes an interface contract documented in `05-architecture.md` (e.g., prop types, return types, callback signatures), or
+- touches a component listed as "No changes" in `05-architecture.md`,
+
+then the dev agent **must** append an `## Architecture Delta` section to `05-architecture.md` before opening the PR. Format:
+
+```md
+## Architecture Delta
+
+### <Task ID> — <short title> (<date>)
+
+**Trigger:** <brief reason the deviation was necessary>
+
+| Item | Architecture doc says | What shipped | Justification |
+|---|---|---|---|
+| `ComponentName.prop` | `type A` | `type B` | <reason> |
+| `OtherComponent.tsx` | No changes | Modified | <reason> |
+```
+
+Rules:
+1. The original `05-architecture.md` content is **never rewritten** — the delta section is append-only.
+2. The delta is not a bug report. Justified deviations are expected; they just need to be recorded.
+3. If no interface contracts or "no-changes" components were touched, no delta section is needed — the dev agent explicitly states `Architecture Delta: none` in the PR description.
+
 ## Build Gate Checklist (Orchestrator-owned)
 
 1. Scope lock: verify implementation stayed within assigned Issue scope and architecture boundaries.
@@ -61,6 +87,7 @@ A superset block injected by the orchestrator (with additional fields such as `t
 5. Domain language lock: verify code uses domain terminology and concepts (e.g., `displayBrandMessage()` not `renderDOMElement()`). Variable names, function names, and class names reflect the problem domain.
 6. Verification lock: verify required test commands passed and evidence is explicit. All tests passing is mandatory.
 7. PR lock: verify PR exists and includes explicit issue-closing reference and scenario-to-test mapping evidence.
+7a. Description accuracy lock: verify the PR body's `Files Changed` section matches `git diff --stat <base>` — every changed file must appear in the description and no file may be listed that was not changed. A mismatch is a Build Gate loop-back condition.
 8. Provenance lock: verify PR body includes a full `## Agent Provenance` block with `run-id`, `task-id`, `role`, and `dispatched` fields.
 9. Risk lock: verify residual risks and rollback note are documented.
 10. Approval lock: verify unresolved open questions are resolved or explicitly accepted by Product Owner.
@@ -78,6 +105,8 @@ A superset block injected by the orchestrator (with additional fields such as `t
 7. Documentation lock: verify docs and release notes are updated when applicable.
 8. Rollback lock: verify rollback note is documented and feasible.
 9. Risk acceptance lock: verify residual risks are visible and explicitly accepted when required.
+10. AC SSoT lock: verify `02-prd.md`, `05-architecture.md`, and `06-tasks.md` do not contain copied AC prose — they must reference AC IDs and link to the canonical `.feature` file. Flag any artifact that re-states AC text as a drift risk.
+11. Architecture delta lock: verify the PR description includes either an `## Architecture Delta` section (for any task that changed an interface contract or a "no-changes" component) or an explicit `Architecture Delta: none` statement. Missing this is a Build Gate loop-back condition.
 
 ## Merge Gate Output Contract
 

--- a/.github/skills/build-evidence-and-merge-readiness/SKILL.md
+++ b/.github/skills/build-evidence-and-merge-readiness/SKILL.md
@@ -87,7 +87,7 @@ Rules:
 5. Domain language lock: verify code uses domain terminology and concepts (e.g., `displayBrandMessage()` not `renderDOMElement()`). Variable names, function names, and class names reflect the problem domain.
 6. Verification lock: verify required test commands passed and evidence is explicit. All tests passing is mandatory.
 7. PR lock: verify PR exists and includes explicit issue-closing reference and scenario-to-test mapping evidence.
-7a. Description accuracy lock: verify the PR body's `Files Changed` section matches `git diff --stat <base>` — every changed file must appear in the description and no file may be listed that was not changed. A mismatch is a Build Gate loop-back condition.
+7a. Description accuracy lock: verify the PR body's `Files Changed` section matches `git diff --stat origin/<base-branch>` (where `<base-branch>` is the PR target branch) — every changed file must appear in the description and no file may be listed that was not changed. A mismatch is a Build Gate loop-back condition.
 8. Provenance lock: verify PR body includes a full `## Agent Provenance` block with `run-id`, `task-id`, `role`, and `dispatched` fields.
 9. Risk lock: verify residual risks and rollback note are documented.
 10. Approval lock: verify unresolved open questions are resolved or explicitly accepted by Product Owner.

--- a/.github/skills/build-merge-gate-orchestration/SKILL.md
+++ b/.github/skills/build-merge-gate-orchestration/SKILL.md
@@ -71,10 +71,11 @@ When Gate 4 decomposes a slice into N issues, the orchestrator must evaluate ind
    Capture the terminal ID returned by each `run_in_terminal` call.
 2. **Immediately** write all terminal IDs to `/memories/session/active-state.md` under `## Pending Async Runs` before any other action.
 3. Arm an alarm (600 s interval, alarm skill) immediately after all terminals are launched. On each alarm wake:
-   - Check `get_terminal_output <terminal-id>` for each running agent. If the terminal has exited **and** its output contains a review-clean handback package, treat that task as done.
-   - If the terminal has exited but no review-clean signal is present, inspect the handback for errors or escalation notes and act accordingly.
+   - Check `get_terminal_output <terminal-id>` for each running agent. If the terminal has exited **and** its output reports `REVIEW_CLEAN`, treat that task as done.
+   - If the terminal has exited **and** its output reports `REVIEW_CLEAN_WITH_ESCALATIONS`, do **not** treat the task as done; route it to the Post-Loop Orchestrator Challenge Consolidation step and block sequencing until all escalations are resolved by PO.
+   - If the terminal has exited but no review status is present, inspect the handback for errors or escalation notes and act accordingly.
    - If still running, re-arm and wait.
-4. Terminal exit **combined with** a review-clean handback package in the output is the authoritative task-done signal. A review-clean package present in output before terminal exit is preliminary evidence only — wait for process exit to confirm. Dev agents run their own full review loop before returning; a PR being open is evidence of progress, not completion.
+4. Terminal exit **combined with** `REVIEW_CLEAN` in the output is the authoritative task-done signal. `REVIEW_CLEAN_WITH_ESCALATIONS` is not a completion signal — it must remain blocked until escalations are resolved. A review status present in output before terminal exit is preliminary evidence only — wait for process exit to confirm. Dev agents run their own full review loop before returning; a PR being open is evidence of progress, not completion.
 5. Validate each task PR independently (each targets `slice/<slice-name>`). After all task PRs are merged into the slice branch, open a single `slice/<slice-name> → master` PR for PO merge.
 
 **Sequential execution (when independence check fails or issues = 1):**

--- a/.github/skills/build-merge-gate-orchestration/SKILL.md
+++ b/.github/skills/build-merge-gate-orchestration/SKILL.md
@@ -71,10 +71,10 @@ When Gate 4 decomposes a slice into N issues, the orchestrator must evaluate ind
    Capture the terminal ID returned by each `run_in_terminal` call.
 2. **Immediately** write all terminal IDs to `/memories/session/active-state.md` under `## Pending Async Runs` before any other action.
 3. Arm an alarm (600 s interval, alarm skill) immediately after all terminals are launched. On each alarm wake:
-   - Check `get_terminal_output <terminal-id>` for each running agent. If the terminal output contains a review-clean handback package, treat that task as done.
+   - Check `get_terminal_output <terminal-id>` for each running agent. If the terminal has exited **and** its output contains a review-clean handback package, treat that task as done.
    - If the terminal has exited but no review-clean signal is present, inspect the handback for errors or escalation notes and act accordingly.
    - If still running, re-arm and wait.
-4. Terminal exit with a review-clean handback package is the authoritative task-done signal. Dev agents run their own full review loop before returning; a PR being open is evidence of progress, not completion.
+4. Terminal exit **combined with** a review-clean handback package in the output is the authoritative task-done signal. A review-clean package present in output before terminal exit is preliminary evidence only — wait for process exit to confirm. Dev agents run their own full review loop before returning; a PR being open is evidence of progress, not completion.
 5. Validate each task PR independently (each targets `slice/<slice-name>`). After all task PRs are merged into the slice branch, open a single `slice/<slice-name> → master` PR for PO merge.
 
 **Sequential execution (when independence check fails or issues = 1):**

--- a/.github/skills/build-merge-gate-orchestration/SKILL.md
+++ b/.github/skills/build-merge-gate-orchestration/SKILL.md
@@ -70,8 +70,11 @@ When Gate 4 decomposes a slice into N issues, the orchestrator must evaluate ind
    ```
    Capture the terminal ID returned by each `run_in_terminal` call.
 2. **Immediately** write all terminal IDs to `/memories/session/active-state.md` under `## Pending Async Runs` before any other action.
-3. Poll each terminal with `get_terminal_output <terminal-id>` until all agents exit.
-4. GitHub PR list is the authoritative completion signal — if a PR closing the issue is present, treat that task as done regardless of terminal poll state.
+3. Arm an alarm (600 s interval, alarm skill) immediately after all terminals are launched. On each alarm wake:
+   - Check `get_terminal_output <terminal-id>` for each running agent. If the terminal output contains a review-clean handback package, treat that task as done.
+   - If the terminal has exited but no review-clean signal is present, inspect the handback for errors or escalation notes and act accordingly.
+   - If still running, re-arm and wait.
+4. Terminal exit with a review-clean handback package is the authoritative task-done signal. Dev agents run their own full review loop before returning; a PR being open is evidence of progress, not completion.
 5. Validate each task PR independently (each targets `slice/<slice-name>`). After all task PRs are merged into the slice branch, open a single `slice/<slice-name> → master` PR for PO merge.
 
 **Sequential execution (when independence check fails or issues = 1):**

--- a/.github/skills/coding-standards/SKILL.md
+++ b/.github/skills/coding-standards/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: coding-standards
+description: "Coding standards authoring workflow: write, structure, and organize Copilot instruction files for code review and dev agent guidance. Covers file types, applyTo targeting, character limits, content rules, and what not to include. Use when: creating or updating .github/instructions/*.instructions.md files or copilot-instructions.md."
+last-refreshed: "2026-04-20"
+refresh-interval-days: 7
+refresh-source: "https://docs.github.com/en/copilot/tutorials/customize-code-review"
+---
+
+# Coding Standards
+
+Use this skill whenever writing or updating Copilot instruction files — for code review, dev agent guidance, or both.
+
+**Source authority:** [GitHub Docs — Customize Code Review](https://docs.github.com/en/copilot/tutorials/customize-code-review)
+
+**Last refreshed:** 2026-04-20 — refresh every 7 days.
+
+---
+
+## Refresh Protocol
+
+This skill must be kept in sync with the source authority page. Stale rules lead to wrong instruction files being created.
+
+**Trigger:** Any of the following:
+- Today's date minus `last-refreshed` in the frontmatter is ≥ 7 days.
+- A PR reviewer ignores an instruction that this skill says should work (observable, concrete signal).
+- A PR reviewer flags something that this skill says is unsupported.
+- A new `*.instructions.md` file is being authored and any limit or behavior in this skill is being relied upon.
+
+**How to refresh:**
+1. Fetch the source page: `https://docs.github.com/en/copilot/tutorials/customize-code-review`
+2. Check for changes in: character limits, supported/unsupported instruction types, `applyTo` behavior, file type support.
+3. Update the affected sections in this file.
+4. Update `last-refreshed` in the frontmatter and the **Last refreshed** line above to today's date (`YYYY-MM-DD`).
+5. Create a branch `chore/refresh-coding-standards-skill`, open a PR, and merge via the normal review flow. Never commit directly to `master`.
+
+---
+
+## File Types
+
+Two types of instruction files are supported:
+
+| File | Scope | `applyTo` required? |
+|---|---|---|
+| `.github/copilot-instructions.md` | Repository-wide (all files) | No |
+| `.github/instructions/*.instructions.md` | Path-specific | Yes |
+
+Both types are read by **Copilot code review (PR reviewer)** and by the **dev agent in VS Code** when editing matching files.
+
+---
+
+## Hard Constraints
+
+| Constraint | Limit | What happens if exceeded |
+|---|---|---|
+| File character limit (code review) | **4,000 characters** | Instructions beyond this point are silently ignored by the PR reviewer |
+| File line soft limit | **~1,000 lines** | Response quality degrades |
+
+> Measure files before committing. `wc -c` for chars, `wc -l` for lines.
+
+---
+
+## `applyTo` Frontmatter
+
+Every path-specific file **must** include an `applyTo` glob in YAML frontmatter:
+
+```yaml
+---
+applyTo: "**/*.tsx"
+---
+```
+
+Common patterns for this repo:
+
+| File | `applyTo` |
+|---|---|
+| `react.instructions.md` | `"**/*.tsx"` |
+| `css.instructions.md` | `"**/*.css"` |
+| `tests.instructions.md` | `"**/tests/**"` |
+
+---
+
+## Content Rules
+
+### DO
+
+- **Short, imperative directives** — not narrative paragraphs.
+- **Distinct headings** separating different topics.
+- **Bullet points** for rules that can be scanned independently.
+- **Concrete code examples** showing correct and incorrect patterns.
+
+```
+## Naming Conventions
+
+Use descriptive, intention-revealing names.
+
+\`\`\`ts
+// Avoid
+const d = new Date();
+
+// Prefer
+const currentDate = new Date();
+\`\`\`
+```
+
+- **Start minimal** — 10–20 specific instructions, then iterate based on actual review results.
+- **One purpose per file** — React rules in React file, CSS rules in CSS file; don't mix.
+
+### DO NOT
+
+The following instruction types are **not supported** by the code review agent and must not be included:
+
+| Unsupported type | Example |
+|---|---|
+| UX/formatting changes | `Use bold text for critical issues` |
+| PR overview modifications | `Add a testing checklist to the PR overview` |
+| Core function changes | `Block PR merging unless all comments addressed` |
+| External link references | `Review code per standards at https://example.com` |
+| Vague quality improvements | `Be more accurate`, `Don't miss any issues` |
+
+> Workaround for external links: copy the relevant content directly into the instruction file instead of linking.
+
+---
+
+## Recommended File Structure
+
+```
+.github/
+  copilot-instructions.md          ← global: branching, domain naming, process
+  instructions/
+    react.instructions.md          ← applyTo: **/*.tsx
+    css.instructions.md            ← applyTo: **/*.css
+    tests.instructions.md          ← applyTo: **/tests/**
+```
+
+### What belongs in `copilot-instructions.md` (global)
+
+- Branching and PR rules
+- Domain naming policy
+- Cross-cutting concerns (security requirements, error handling philosophy)
+- Pointers to the scoped instruction files
+
+### What belongs in scoped `*.instructions.md` files
+
+- Language-specific coding standards
+- Framework-specific patterns
+- Technology-specific security concerns
+- Different rules for different parts of the codebase
+
+---
+
+## Recommended Template for a Scoped File
+
+```markdown
+---
+applyTo: "**/*.{ts,tsx}"
+---
+# [Domain or Technology] Standards
+
+## Purpose
+
+One sentence: what this file covers and when it applies.
+
+## [Topic 1]
+
+- Rule 1
+- Rule 2
+
+\`\`\`ts
+// Avoid
+...
+
+// Prefer
+...
+\`\`\`
+
+## [Topic 2]
+
+- Rule 1
+- Rule 2
+```
+
+---
+
+## Testing Instruction Files
+
+After creating or updating an instruction file:
+
+1. Open a PR that touches files matching the `applyTo` glob.
+2. Request a Copilot code review.
+3. Observe which instructions are followed.
+4. Note instructions that are consistently missed — rewrite to be more specific, or add examples.
+5. Add new instructions one at a time; test before adding more.
+
+---
+
+## When Instructions Are Ignored (Troubleshooting)
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Instructions completely ignored | File over 4,000 chars | Trim to under limit |
+| Language rules applied to wrong files | Missing/wrong `applyTo` | Add or correct frontmatter |
+| Inconsistent behavior | Too many instructions; too vague | Prioritize; add examples |
+| Instructions in repo-wide file not taking effect for specific language | Rules in wrong file | Move to path-specific file |

--- a/.github/skills/coding-standards/SKILL.md
+++ b/.github/skills/coding-standards/SKILL.md
@@ -129,7 +129,7 @@ The following instruction types are **not supported** by the code review agent a
   instructions/
     react.instructions.md          ← applyTo: **/*.tsx
     css.instructions.md            ← applyTo: **/*.css
-    tests.instructions.md          ← applyTo: **/tests/**
+    tests.instructions.md          ← applyTo: **/tests/**, **/features/**/*.feature, **/features/step-definitions/**/*.ts
 ```
 
 ### What belongs in `copilot-instructions.md` (global)

--- a/.github/skills/coding-standards/SKILL.md
+++ b/.github/skills/coding-standards/SKILL.md
@@ -75,7 +75,7 @@ Common patterns for this repo:
 |---|---|
 | `react.instructions.md` | `"**/*.tsx"` |
 | `css.instructions.md` | `"**/*.css"` |
-| `tests.instructions.md` | `"**/tests/**"` |
+| `tests.instructions.md` | `["**/tests/**", "**/features/**/*.feature", "**/features/step-definitions/**/*.ts"]` |
 
 ---
 
@@ -114,10 +114,10 @@ The following instruction types are **not supported** by the code review agent a
 | UX/formatting changes | `Use bold text for critical issues` |
 | PR overview modifications | `Add a testing checklist to the PR overview` |
 | Core function changes | `Block PR merging unless all comments addressed` |
-| External link references | `Review code per standards at https://example.com` |
+| External links used as rules in instruction files | `In .github/*instructions*.md: review code per standards at https://example.com` |
 | Vague quality improvements | `Be more accurate`, `Don't miss any issues` |
 
-> Workaround for external links: copy the relevant content directly into the instruction file instead of linking.
+> Workaround for external links: if an instruction rule would otherwise point to an external standard, copy the relevant content directly into the instruction file instead of linking.
 
 ---
 

--- a/.github/skills/coding-standards/SKILL.md
+++ b/.github/skills/coding-standards/SKILL.md
@@ -88,19 +88,19 @@ Common patterns for this repo:
 - **Bullet points** for rules that can be scanned independently.
 - **Concrete code examples** showing correct and incorrect patterns.
 
-```
+````
 ## Naming Conventions
 
 Use descriptive, intention-revealing names.
 
-\`\`\`ts
+```ts
 // Avoid
 const d = new Date();
 
 // Prefer
 const currentDate = new Date();
-\`\`\`
 ```
+````
 
 - **Start minimal** — 10–20 specific instructions, then iterate based on actual review results.
 - **One purpose per file** — React rules in React file, CSS rules in CSS file; don't mix.
@@ -150,7 +150,7 @@ The following instruction types are **not supported** by the code review agent a
 
 ## Recommended Template for a Scoped File
 
-```markdown
+````markdown
 ---
 applyTo: "**/*.{ts,tsx}"
 ---
@@ -165,19 +165,19 @@ One sentence: what this file covers and when it applies.
 - Rule 1
 - Rule 2
 
-\`\`\`ts
+```ts
 // Avoid
 ...
 
 // Prefer
 ...
-\`\`\`
+```
 
 ## [Topic 2]
 
 - Rule 1
 - Rule 2
-```
+````
 
 ---
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -146,7 +146,7 @@ Before declaring the PR review workflow complete or saying the PR is "merge-read
 
 | # | Question | Pass condition |
 |---|---|---|
-| 1 | **Are there any open comments?** Fetch both PR review comments via `gh api repos/<owner>/<repo>/pulls/<n>/comments` and top-level PR conversation comments via `gh api repos/<owner>/<repo>/issues/<n>/comments`, then verify there are no unresolved review comments or PR conversation comments that still require a disposition reply from the **PR author**. | Zero unresolved review comments or PR conversation comments awaiting PR-author reply |
+| 1 | **Are there any open comments?** Fetch both PR review comments via GitHub MCP `pull_request_read` with `method=get_review_comments` and top-level PR conversation comments via GitHub MCP `issue_read` with `method=get_comments`, then verify there are no unresolved review comments or PR conversation comments that still require a disposition reply from the **PR author**. (`gh api` is a confirmed-gap fallback only — requires PO approval before use.) | Zero unresolved review comments or PR conversation comments awaiting PR-author reply |
 | 2 | **Did the latest Copilot review body indicate zero new comments (for example, "generated 0 comments", "0 new comments", or equivalent wording)?** | Yes — any semantically equivalent zero-comments wording, on the current head SHA |
 | 3 | **Is the branch up-to-date with the base?** | Branch sync check passed (Section 4) |
 | 4 | **Are all challenges resolved with Product Owner?** | No pending `Challenge` items awaiting PO disposition |

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -48,7 +48,7 @@ For every review comment actioned in a pass, execute these steps **in order**. N
 
 1. **Fix** — implement the code or content change (Accept path) or document the rationale (Challenge path). Push is deferred until all comments in this pass have completed steps 1 and 2.
 2. **Reply** — post a reply on the GitHub PR review thread for this comment stating:
-   - Disposition: `Accept` / `Challenge` / `Needs PO Decision`
+   - Disposition: `Accept` / `Challenge` / `Needs Product Owner Decision`
    - What changed (Accept): brief description of the fix, or
    - Why no change (Challenge): rationale, safer alternative, and citation of grounding rule/decision
    - **This reply must be posted before the fix commit is pushed.** Pushing first and replying later is not permitted — the reply may be forgotten if the session ends between push and reply.
@@ -91,7 +91,7 @@ Status: semantic-closed | semantic-open (reason)
    > 1. Use the GitHub MCP `request_copilot_review` tool to request a fresh Copilot review on the PR.
    > 2. Run `node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>` synchronously via the execute tool (do NOT background it — wait for the JSON output).
    > 3. If the review body says "0 comments" / "0 new comments" / "generated 0 comments" → report done and exit.
-   > 4. If there are new comments → run PR Review Intake Protocol (Accept/Challenge/Needs PO Decision), fix all Accepted items, commit, push, reply to threads, then return to step 1.
+   > 4. If there are new comments → run PR Review Intake Protocol (Accept/Challenge/Needs Product Owner Decision), fix all Accepted items, commit, push, reply to threads, then return to step 1.
    > 5. Only exit the loop when: (a) the review is clean, or (b) there is a genuine blocker requiring Product Owner input. For blockers, state the exact decision needed and exit.
    >
    > Exit condition: review body semantically indicates zero new comments. Do NOT exit based on thread resolution state alone.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -107,20 +107,20 @@ Status: semantic-closed | semantic-open (reason)
       1. Call `get_reviews` on the PR via GitHub MCP.
       2. If latest Copilot review body says "generated 0 comments" / "0 new comments" / "generated no new comments" → review-clean; proceed.
       3. If new comments are present → run PR Review Intake Protocol, address, push, then immediately re-request review and re-arm the alarm so polling restarts atomically after the new review request.
-      4. If no review yet → apply rule 11 (1-hour retry ladder): re-request and immediately re-arm if within 60 min of `T0`; escalate if `≥ 60 min`.
+      4. If no review yet → re-arm the alarm and continue polling. **Do NOT re-request on each wake** — the review was already requested; repeated re-requests flood Copilot's queue. Only re-request again after pushing a new commit. Escalate to PO if no review arrives within 60 min of `T0`.
     - **Dev agent context** (running inside `run-agent.ts` with `execute` tool): run the poll script **synchronously** via the execute tool — the agent has a 1-hour timeout and can block on the script:
       ```
       node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>
       ```
       Read the JSON output directly and act on it within the same session.
 10. Review threads should normally be resolved as part of disposition execution.
-11. **Review timeout — keep retrying for 1 hour.** If Copilot hasn't posted a review yet, don't stop immediately. Keep re-requesting and re-polling for up to 1 hour from when the last push happened, then escalate.
+11. **Review timeout — keep polling for 1 hour.** If Copilot hasn't posted a review yet, don't stop immediately. Keep polling for up to 1 hour from when the last push happened, then escalate. **Do not re-request on each wake** — re-requesting repeatedly floods Copilot's queue and does not speed up delivery. The review was already requested once when the polling window opened; that is sufficient.
 
     How to track the 1-hour window:
 
     - **Clock start (push time):** Call `pull_request_read` with `method=get` and read `updated_at`. This tells you when the PR head ref last changed — i.e., the actual push wall-clock time. Don't use the git commit's author/committer date; on rebases or cherry-picks that can be much earlier than the real push. If `pull_request_read` isn't available, fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — only after confirming the MCP gap and getting Product Owner approval.
-    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-request Copilot review, re-arm the alarm, emit `[REVIEW REQUESTED] → [POLLING STARTED]`, and keep going.
-    - **Once 1 hour has passed with still no review:** Stop retrying. Report to the Product Owner: PR link, head SHA, push time, how long you've been waiting, and how many re-request attempts were made. Something is stuck on GitHub's side.
+    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-arm the alarm and continue polling. Do not re-request.
+    - **Once 1 hour has passed with still no review:** Stop retrying. Report to the Product Owner: PR link, head SHA, push time, how long you've been waiting. Something is stuck on GitHub's side.
 
     Do not escalate while still within the 1-hour window.
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -114,13 +114,15 @@ Status: semantic-closed | semantic-open (reason)
       ```
       Read the JSON output directly and act on it within the same session.
 10. Review threads should normally be resolved as part of disposition execution.
-11. **Review timeout and retry ladder.** If no Copilot review arrives within the bounded polling window, do NOT immediately report blocked. Retry until 1 hour has elapsed since the head SHA was pushed (push wall-clock time), then escalate:
+11. **Review timeout — keep retrying for 1 hour.** If Copilot hasn't posted a review yet, don't stop immediately. Keep re-requesting and re-polling for up to 1 hour from when the last push happened, then escalate.
 
-    1. Record `T0` = the UTC timestamp of the head SHA push. Use the PR's `updated_at` field as a push-time proxy: call `pull_request_read` with `method=get` and read `updated_at`. This reflects when the PR head ref last changed (i.e., the push time), not the git commit author/committer date — which can be arbitrarily earlier on rebases or cherry-picks. Only if that MCP capability is unavailable may you fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — and only after explicitly confirming the MCP gap and obtaining Product Owner approval for the exception.
-    2. On each polling timeout: check `now − T0`. If `< 60 min` → re-request Copilot review via MCP → restart polling window → emit `[REVIEW REQUESTED] → [POLLING STARTED]` → continue.
-    3. If `now − T0 ≥ 60 min` and still no review → escalate: report blocked to Product Owner with PR link, head SHA, `T0`, elapsed time, and number of re-request attempts.
+    How to track the 1-hour window:
 
-    After each re-request, emit `[REVIEW REQUESTED] → [POLLING STARTED]` as required by rule 7. Do not escalate while within the 1-hour window.
+    - **Clock start (push time):** Call `pull_request_read` with `method=get` and read `updated_at`. This tells you when the PR head ref last changed — i.e., the actual push wall-clock time. Don't use the git commit's author/committer date; on rebases or cherry-picks that can be much earlier than the real push. If `pull_request_read` isn't available, fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — only after confirming the MCP gap and getting Product Owner approval.
+    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-request Copilot review, re-arm the alarm, emit `[REVIEW REQUESTED] → [POLLING STARTED]`, and keep going.
+    - **Once 1 hour has passed with still no review:** Stop retrying. Report to the Product Owner: PR link, head SHA, push time, how long you've been waiting, and how many re-request attempts were made. Something is stuck on GitHub's side.
+
+    Do not escalate while still within the 1-hour window.
 
 12. If a thread still remains outdated and unresolved after disposition execution, the agent must reconcile that thread state before declaring the loop complete, or explicitly record it as `semantically-closed/tooling-unresolved` when MCP lacks the required resolution capability.
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -109,8 +109,9 @@ Status: semantic-closed | semantic-open (reason)
       3. If new comments are present → run PR Review Intake Protocol, address, push, then immediately re-request review and re-arm the alarm so polling restarts atomically after the new review request.
       4. If no review yet → re-arm the alarm and continue polling. **Do NOT re-request on each wake** — the review was already requested; repeated re-requests flood Copilot's queue. Only re-request again after pushing a new commit. **Staleness heuristic:** if `get_reviews` has returned no review on the current head SHA for **3 or more consecutive wakes** (≈9 min), the MCP tool may be serving stale data. At this threshold, fall back to the GitHub REST API to get the latest review directly — bypassing the MCP cache:
       ```
-      gh api repos/<owner>/<repo>/pulls/<number>/reviews --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer")] | last'
+      gh api repos/<owner>/<repo>/pulls/<number>/reviews --paginate --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | {id: .id, body: .body[0:120], submitted_at: .submitted_at}' | tail -1
       ```
+      Note: `--paginate` is required — without it the response is truncated to the first 30 reviews, silently dropping recent ones. Use `tail -1` to get the chronologically last Copilot review.
       If the REST response shows a review body indicating zero new comments on the current head SHA → treat as `REVIEW_CLEAN` and proceed to the Pre-Completion Self-Check (section 5). If the REST response also returns nothing on the current head SHA → surface a staleness alert to the Product Owner (state head SHA, elapsed time, ask them to confirm GitHub). Escalate to PO if no review arrives within 60 min of `T0`.
     - **Dev agent context** (running inside `run-agent.ts` with `execute` tool): run the poll script **synchronously** via the execute tool — the agent has a 1-hour timeout and can block on the script:
       ```

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -123,7 +123,7 @@ Status: semantic-closed | semantic-open (reason)
 
     How to track the 1-hour window:
 
-    - **Clock start (push time):** Call `pull_request_read` with `method=get` and read `updated_at`. This tells you when the PR head ref last changed — i.e., the actual push wall-clock time. Don't use the git commit's author/committer date; on rebases or cherry-picks that can be much earlier than the real push. If `pull_request_read` isn't available, fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — only after confirming the MCP gap and getting Product Owner approval.
+    - **Clock start (push time):** Record T0 yourself immediately after `git push` completes — read the wall clock at that moment (e.g., `TZ=Asia/Kolkata date`). Do not use `updated_at` from the PR API: it resets on non-push events (new comments, label changes, review activity) and can silently extend or reset the 1-hour window. Do not use the git commit's author/committer date; on rebases or cherry-picks that can be much earlier than the real push.
     - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-arm the alarm and continue polling. Do not re-request. **If this is the 3rd or later consecutive wake with no review on the current head SHA**, apply the staleness heuristic in Rule 9, step 4 — fall back to the GitHub REST API before escalating to the Product Owner.
     - **Once 1 hour has passed with still no review:** Stop retrying. Report to the Product Owner: PR link, head SHA, push time, how long you've been waiting. Something is stuck on GitHub's side.
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -102,7 +102,7 @@ Status: semantic-closed | semantic-open (reason)
 6. If the loop cannot continue because of a protocol conflict, missing capability, or explicit owner-decision point, the agent must pause, discuss the issue with the Product Owner, and proceed only with the agreed position.
 7. **Review request and polling are a single atomic sequence (no gap permitted).** The tool call return value from the review request — including `(empty)` — is a trigger to begin polling immediately. It is not a completion signal, not a status, and not a reason to summarize or report. Any return value from the review request tool must be followed by polling without pause. Immediately after calling the review request tool, emit the log entry `[REVIEW REQUESTED] → [POLLING STARTED]` and begin the polling window. If this log entry is absent, the atomic sequence was broken — that is a workflow failure.
 8. Polling must use live GitHub MCP review data as the source of truth rather than relying on cached editor extension payloads.
-9. When a non-MCP polling fallback is used:
+9. When synchronous polling is not possible (orchestrator context — no blocking execute tool):
     - **Orchestrator context** (running in VS Code chat session): use the alarm skill (180 s interval) instead of the poll script. On each alarm wake:
       1. Call `get_reviews` on the PR via GitHub MCP.
       2. If latest Copilot review body says "generated 0 comments" / "0 new comments" / "generated no new comments" → review-clean; proceed.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -103,11 +103,11 @@ Status: semantic-closed | semantic-open (reason)
 7. **Review request and polling are a single atomic sequence (no gap permitted).** The tool call return value from the review request — including `(empty)` — is a trigger to begin polling immediately. It is not a completion signal, not a status, and not a reason to summarize or report. Any return value from the review request tool must be followed by polling without pause. Immediately after calling the review request tool, emit the log entry `[REVIEW REQUESTED] → [POLLING STARTED]` and begin the polling window. If this log entry is absent, the atomic sequence was broken — that is a workflow failure.
 8. Polling must use live GitHub MCP review data as the source of truth rather than relying on cached editor extension payloads.
 9. When synchronous polling is not possible (orchestrator context — no blocking execute tool):
-    - **Orchestrator context** (running in VS Code chat session): use the alarm skill (180 s interval) instead of the poll script. On each alarm wake:
+    - **Orchestrator context** (running in VS Code chat session): use the alarm skill (180 s interval) instead of the poll script. Immediately after `request_copilot_review` returns, arm the alarm and emit the required log entry `[REVIEW REQUESTED] → [POLLING STARTED]` at that moment. In orchestrator context, arming the alarm counts as polling having started for rule 7; alarm wakes are the polling mechanism. On each alarm wake:
       1. Call `get_reviews` on the PR via GitHub MCP.
       2. If latest Copilot review body says "generated 0 comments" / "0 new comments" / "generated no new comments" → review-clean; proceed.
-      3. If new comments are present → run PR Review Intake Protocol, address, push, re-request review, re-arm alarm.
-      4. If no review yet → apply rule 11 (1-hour retry ladder): re-request and re-arm if within 60 min of `T0`; escalate if `≥ 60 min`.
+      3. If new comments are present → run PR Review Intake Protocol, address, push, then immediately re-request review and re-arm the alarm so polling restarts atomically after the new review request.
+      4. If no review yet → apply rule 11 (1-hour retry ladder): re-request and immediately re-arm if within 60 min of `T0`; escalate if `≥ 60 min`.
     - **Dev agent context** (running inside `run-agent.ts` with `execute` tool): run the poll script **synchronously** via the execute tool — the agent has a 1-hour timeout and can block on the script:
       ```
       node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -107,7 +107,11 @@ Status: semantic-closed | semantic-open (reason)
       1. Call `get_reviews` on the PR via GitHub MCP.
       2. If latest Copilot review body says "generated 0 comments" / "0 new comments" / "generated no new comments" → review-clean; proceed.
       3. If new comments are present → run PR Review Intake Protocol, address, push, then immediately re-request review and re-arm the alarm so polling restarts atomically after the new review request.
-      4. If no review yet → re-arm the alarm and continue polling. **Do NOT re-request on each wake** — the review was already requested; repeated re-requests flood Copilot's queue. Only re-request again after pushing a new commit. **Staleness heuristic:** if `get_reviews` has returned no review on the current head SHA for **3 or more consecutive wakes** (≈9 min), the MCP tool may be serving stale data. At this threshold, surface a staleness alert to the Product Owner: state the head SHA, elapsed time since review was requested, and ask them to confirm visually whether a Copilot review is present on GitHub. Do not silently continue polling for the full 1-hour window when the tool is clearly lagging. If PO confirms the review is clean → treat as `REVIEW_CLEAN` and proceed to the Pre-Completion Self-Check (section 5). Escalate to PO if no review arrives within 60 min of `T0`.
+      4. If no review yet → re-arm the alarm and continue polling. **Do NOT re-request on each wake** — the review was already requested; repeated re-requests flood Copilot's queue. Only re-request again after pushing a new commit. **Staleness heuristic:** if `get_reviews` has returned no review on the current head SHA for **3 or more consecutive wakes** (≈9 min), the MCP tool may be serving stale data. At this threshold, fall back to the GitHub REST API to get the latest review directly — bypassing the MCP cache:
+      ```
+      gh api repos/<owner>/<repo>/pulls/<number>/reviews --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer")] | last'
+      ```
+      If the REST response shows a review body indicating zero new comments on the current head SHA → treat as `REVIEW_CLEAN` and proceed to the Pre-Completion Self-Check (section 5). If the REST response also returns nothing on the current head SHA → surface a staleness alert to the Product Owner (state head SHA, elapsed time, ask them to confirm GitHub). Escalate to PO if no review arrives within 60 min of `T0`.
     - **Dev agent context** (running inside `run-agent.ts` with `execute` tool): run the poll script **synchronously** via the execute tool — the agent has a 1-hour timeout and can block on the script:
       ```
       node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>
@@ -119,7 +123,7 @@ Status: semantic-closed | semantic-open (reason)
     How to track the 1-hour window:
 
     - **Clock start (push time):** Call `pull_request_read` with `method=get` and read `updated_at`. This tells you when the PR head ref last changed — i.e., the actual push wall-clock time. Don't use the git commit's author/committer date; on rebases or cherry-picks that can be much earlier than the real push. If `pull_request_read` isn't available, fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — only after confirming the MCP gap and getting Product Owner approval.
-    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-arm the alarm and continue polling. Do not re-request. **If this is the 3rd or later consecutive wake with no review on the current head SHA**, apply the staleness heuristic in Rule 9, step 4 — surface a staleness alert to the Product Owner rather than silently continuing.
+    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-arm the alarm and continue polling. Do not re-request. **If this is the 3rd or later consecutive wake with no review on the current head SHA**, apply the staleness heuristic in Rule 9, step 4 — fall back to the GitHub REST API before escalating to the Product Owner.
     - **Once 1 hour has passed with still no review:** Stop retrying. Report to the Product Owner: PR link, head SHA, push time, how long you've been waiting. Something is stuck on GitHub's side.
 
     Do not escalate while still within the 1-hour window.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -116,7 +116,7 @@ Status: semantic-closed | semantic-open (reason)
 10. Review threads should normally be resolved as part of disposition execution.
 11. **Review timeout and retry ladder.** If no Copilot review arrives within the bounded polling window, do NOT immediately report blocked. Retry until 1 hour has elapsed since the head SHA was pushed (commit timestamp), then escalate:
 
-    1. Record `T0` = the UTC timestamp of the head SHA push (obtain via `gh api repos/<owner>/<repo>/git/commits/<sha> --jq '.committer.date'` or equivalent).
+    1. Record `T0` = the UTC timestamp of the head SHA push. Obtain via GitHub MCP: call `get_commit` with the head SHA and read `committer.date`. Only if that MCP capability is unavailable may you fall back to `gh api repos/<owner>/<repo>/git/commits/<sha> --jq '.committer.date'` — and only after explicitly confirming the MCP gap and obtaining Product Owner approval for the exception.
     2. On each polling timeout: check `now − T0`. If `< 60 min` → re-request Copilot review via MCP → restart polling window → emit `[REVIEW REQUESTED] → [POLLING STARTED]` → continue.
     3. If `now − T0 ≥ 60 min` and still no review → escalate: report blocked to Product Owner with PR link, head SHA, `T0`, elapsed time, and number of re-request attempts.
 

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -107,7 +107,7 @@ Status: semantic-closed | semantic-open (reason)
       1. Call `get_reviews` on the PR via GitHub MCP.
       2. If latest Copilot review body says "generated 0 comments" / "0 new comments" / "generated no new comments" → review-clean; proceed.
       3. If new comments are present → run PR Review Intake Protocol, address, push, then immediately re-request review and re-arm the alarm so polling restarts atomically after the new review request.
-      4. If no review yet → re-arm the alarm and continue polling. **Do NOT re-request on each wake** — the review was already requested; repeated re-requests flood Copilot's queue. Only re-request again after pushing a new commit. Escalate to PO if no review arrives within 60 min of `T0`.
+      4. If no review yet → re-arm the alarm and continue polling. **Do NOT re-request on each wake** — the review was already requested; repeated re-requests flood Copilot's queue. Only re-request again after pushing a new commit. **Staleness heuristic:** if `get_reviews` has returned no review on the current head SHA for **3 or more consecutive wakes** (≈9 min), the MCP tool may be serving stale data. At this threshold, surface a staleness alert to the Product Owner: state the head SHA, elapsed time since review was requested, and ask them to confirm visually whether a Copilot review is present on GitHub. Do not silently continue polling for the full 1-hour window when the tool is clearly lagging. If PO confirms the review is clean → treat as `REVIEW_CLEAN` and proceed to the Pre-Completion Self-Check (section 5). Escalate to PO if no review arrives within 60 min of `T0`.
     - **Dev agent context** (running inside `run-agent.ts` with `execute` tool): run the poll script **synchronously** via the execute tool — the agent has a 1-hour timeout and can block on the script:
       ```
       node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>
@@ -119,7 +119,7 @@ Status: semantic-closed | semantic-open (reason)
     How to track the 1-hour window:
 
     - **Clock start (push time):** Call `pull_request_read` with `method=get` and read `updated_at`. This tells you when the PR head ref last changed — i.e., the actual push wall-clock time. Don't use the git commit's author/committer date; on rebases or cherry-picks that can be much earlier than the real push. If `pull_request_read` isn't available, fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — only after confirming the MCP gap and getting Product Owner approval.
-    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-arm the alarm and continue polling. Do not re-request.
+    - **On each wake with no review yet:** Check how long it's been since the push. If it's under 1 hour → re-arm the alarm and continue polling. Do not re-request. **If this is the 3rd or later consecutive wake with no review on the current head SHA**, apply the staleness heuristic in Rule 9, step 4 — surface a staleness alert to the Product Owner rather than silently continuing.
     - **Once 1 hour has passed with still no review:** Stop retrying. Report to the Product Owner: PR link, head SHA, push time, how long you've been waiting. Something is stuck on GitHub's side.
 
     Do not escalate while still within the 1-hour window.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -26,8 +26,8 @@ On-demand workflow for handling PR reviews end-to-end: intake triage, dispositio
 ## Review Loop Ownership
 
 1. By default, the implementing agent for a PR is the review-loop owner and runs this workflow.
-2. For dependent PR chains explicitly declared as `Orchestrator-Managed Stacked Review Mode`, the orchestrator is the review-loop owner for those PRs.
-3. In `Orchestrator-Managed Stacked Review Mode`, dev agents execute assigned code changes and push handback commits only; they do not independently request Copilot review, poll review state, or advance stack sequencing unless explicitly delegated by orchestrator.
+2. For dependent PR chains explicitly declared as `Orchestrator-Managed Stacked Review Mode`, ownership is split: each dev agent owns the full review loop for its own assigned PR; the orchestrator owns stack sequencing (merge order, base-to-tip progression, PR retargeting).
+3. In `Orchestrator-Managed Stacked Review Mode`, dev agents run this full review loop per-PR and exit with a formal Review Loop Exit Status package (see section 6). They do not advance stack sequencing, trigger merges, or retarget PR bases.
 
 ---
 
@@ -103,19 +103,25 @@ Status: semantic-closed | semantic-open (reason)
 7. **Review request and polling are a single atomic sequence (no gap permitted).** The tool call return value from the review request — including `(empty)` — is a trigger to begin polling immediately. It is not a completion signal, not a status, and not a reason to summarize or report. Any return value from the review request tool must be followed by polling without pause. Immediately after calling the review request tool, emit the log entry `[REVIEW REQUESTED] → [POLLING STARTED]` and begin the polling window. If this log entry is absent, the atomic sequence was broken — that is a workflow failure.
 8. Polling must use live GitHub MCP review data as the source of truth rather than relying on cached editor extension payloads.
 9. When a non-MCP polling fallback is used:
-    - **Orchestrator context** (running in VS Code chat session): launch the poll script as an async terminal so it does not block the chat session:
-      ```
-      mode: async
-      command: node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>
-      ```
-      Capture the terminal ID. Check completion with `get_terminal_output <terminal-id>`. Do not launch in sync/foreground mode; default timeout is 600 seconds and will block.
+    - **Orchestrator context** (running in VS Code chat session): use the alarm skill (180 s interval) instead of the poll script. On each alarm wake:
+      1. Call `get_reviews` on the PR via GitHub MCP.
+      2. If latest Copilot review body says "generated 0 comments" / "0 new comments" / "generated no new comments" → review-clean; proceed.
+      3. If new comments are present → run PR Review Intake Protocol, address, push, re-request review, re-arm alarm.
+      4. If no review yet → apply rule 11 (1-hour retry ladder): re-request and re-arm if within 60 min of `T0`; escalate if `≥ 60 min`.
     - **Dev agent context** (running inside `run-agent.ts` with `execute` tool): run the poll script **synchronously** via the execute tool — the agent has a 1-hour timeout and can block on the script:
       ```
       node scripts/wait_for_copilot_review.js --owner <owner> --repo <repo> --pr <number>
       ```
       Read the JSON output directly and act on it within the same session.
 10. Review threads should normally be resolved as part of disposition execution.
-11. If no new Copilot review arrives within the bounded polling window, the agent must report that the loop is blocked on external async review completion.
+11. **Review timeout and retry ladder.** If no Copilot review arrives within the bounded polling window, do NOT immediately report blocked. Retry until 1 hour has elapsed since the head SHA was pushed (commit timestamp), then escalate:
+
+    1. Record `T0` = the UTC timestamp of the head SHA push (obtain via `gh api repos/<owner>/<repo>/git/commits/<sha> --jq '.committer.date'` or equivalent).
+    2. On each polling timeout: check `now − T0`. If `< 60 min` → re-request Copilot review via MCP → restart polling window → emit `[REVIEW REQUESTED] → [POLLING STARTED]` → continue.
+    3. If `now − T0 ≥ 60 min` and still no review → escalate: report blocked to Product Owner with PR link, head SHA, `T0`, elapsed time, and number of re-request attempts.
+
+    After each re-request, emit `[REVIEW REQUESTED] → [POLLING STARTED]` as required by rule 7. Do not escalate while within the 1-hour window.
+
 12. If a thread still remains outdated and unresolved after disposition execution, the agent must reconcile that thread state before declaring the loop complete, or explicitly record it as `semantically-closed/tooling-unresolved` when MCP lacks the required resolution capability.
 
 ## 4. Branch Sync Protocol
@@ -146,3 +152,34 @@ Before declaring the PR review workflow complete or saying the PR is "merge-read
 | 4 | **Are all challenges resolved with Product Owner?** | No pending `Challenge` items awaiting PO disposition |
 
 **Hardening rule:** the agent must not declare "merge-ready" or call the overall task complete until it has explicitly run this self-check and confirmed all four items pass. Skipping this check is a workflow failure.
+---
+
+## 6. Review Loop Exit Status (Mandatory — Emit On Every Exit)
+
+Every agent must emit one of the two exit status packages below when completing its review loop. Exiting without a status package is a workflow failure.
+
+### `REVIEW_CLEAN`
+
+Condition: latest Copilot review body indicates zero new comments **and** no `Challenge` or `Needs Product Owner Decision` items are open.
+
+Required package fields:
+- `status: REVIEW_CLEAN`
+- `pr`: PR link
+- `head_sha`: head SHA of the reviewed commit
+- `copilot_review_excerpt`: verbatim opening line of the latest Copilot review body
+
+### `REVIEW_CLEAN_WITH_ESCALATIONS`
+
+Condition: latest Copilot review body indicates zero new comments **but** ≥ 1 `Challenge` or `Needs Product Owner Decision` items remain open (posted as thread replies, awaiting PO resolution).
+
+Required package fields:
+- `status: REVIEW_CLEAN_WITH_ESCALATIONS`
+- `pr`: PR link
+- `head_sha`: head SHA of the reviewed commit
+- `copilot_review_excerpt`: verbatim opening line of the latest Copilot review body
+- `escalations`: list — one entry per deferred item:
+  - `thread_link`: GitHub PR thread URL
+  - `classification`: `Challenge` or `Needs Product Owner Decision`
+  - `summary`: one-line description of the open item
+
+**Routing rule:** `REVIEW_CLEAN` → proceed to merge-ready declaration. `REVIEW_CLEAN_WITH_ESCALATIONS` → return package to orchestrator (stacked mode) or Product Owner (standalone mode) and wait for resolution before proceeding.

--- a/.github/skills/pr-review-loop/SKILL.md
+++ b/.github/skills/pr-review-loop/SKILL.md
@@ -114,9 +114,9 @@ Status: semantic-closed | semantic-open (reason)
       ```
       Read the JSON output directly and act on it within the same session.
 10. Review threads should normally be resolved as part of disposition execution.
-11. **Review timeout and retry ladder.** If no Copilot review arrives within the bounded polling window, do NOT immediately report blocked. Retry until 1 hour has elapsed since the head SHA was pushed (commit timestamp), then escalate:
+11. **Review timeout and retry ladder.** If no Copilot review arrives within the bounded polling window, do NOT immediately report blocked. Retry until 1 hour has elapsed since the head SHA was pushed (push wall-clock time), then escalate:
 
-    1. Record `T0` = the UTC timestamp of the head SHA push. Obtain via GitHub MCP: call `get_commit` with the head SHA and read `committer.date`. Only if that MCP capability is unavailable may you fall back to `gh api repos/<owner>/<repo>/git/commits/<sha> --jq '.committer.date'` — and only after explicitly confirming the MCP gap and obtaining Product Owner approval for the exception.
+    1. Record `T0` = the UTC timestamp of the head SHA push. Use the PR's `updated_at` field as a push-time proxy: call `pull_request_read` with `method=get` and read `updated_at`. This reflects when the PR head ref last changed (i.e., the push time), not the git commit author/committer date — which can be arbitrarily earlier on rebases or cherry-picks. Only if that MCP capability is unavailable may you fall back to `gh api repos/<owner>/<repo>/pulls/<number> --jq '.updated_at'` — and only after explicitly confirming the MCP gap and obtaining Product Owner approval for the exception.
     2. On each polling timeout: check `now − T0`. If `< 60 min` → re-request Copilot review via MCP → restart polling window → emit `[REVIEW REQUESTED] → [POLLING STARTED]` → continue.
     3. If `now − T0 ≥ 60 min` and still no review → escalate: report blocked to Product Owner with PR link, head SHA, `T0`, elapsed time, and number of re-request attempts.
 

--- a/.github/skills/requirement-gate-orchestration/SKILL.md
+++ b/.github/skills/requirement-gate-orchestration/SKILL.md
@@ -46,3 +46,16 @@ Context transfer rule:
 2. Persist it as the slice context source of truth for Gate 2.
 3. Use this package as the primary input to PRD drafting handoff.
 4. Freeze the Gate 1 contract for Gate 2: requirement statement, scope boundaries, and AC intent cannot change without explicit Product Owner decision recorded in context.
+
+## AC Single Source of Truth Rule
+
+At Gate 1 freeze:
+
+1. `01-requirement.md` defines acceptance criteria (AC-N IDs and text) as the seed — this is the only place AC prose is authored.
+2. The `.feature` file is generated from `01-requirement.md` and becomes the **canonical AC source** from that point forward.
+3. All subsequent gate artifacts (`02-prd.md`, `05-architecture.md`, `06-tasks.md`) must reference AC IDs only (e.g., `AC-19`, `AC-20`) and link to the feature file:
+   ```md
+   **Acceptance Criteria:** canonical source is [`features/<slice>.feature`](../../../features/<slice>.feature)
+   ```
+4. AC prose must NOT be copied into any gate artifact other than `01-requirement.md`.
+5. Rationale: duplicated AC text drifts independently across artifacts and generates spurious review noise on every PR that touches those files.

--- a/.github/skills/requirement-gate-orchestration/SKILL.md
+++ b/.github/skills/requirement-gate-orchestration/SKILL.md
@@ -55,7 +55,7 @@ At Gate 1 freeze:
 2. The `.feature` file is generated from `01-requirement.md` and becomes the **canonical AC source** from that point forward.
 3. All subsequent gate artifacts (`02-prd.md`, `05-architecture.md`, `06-tasks.md`) must reference AC IDs only (e.g., `AC-19`, `AC-20`) and link to the feature file:
    ```md
-   **Acceptance Criteria:** canonical source is [`features/<slice>.feature`](../../../features/<slice>.feature)
+   **Acceptance Criteria:** canonical source is [`features/{slice}.feature`](../../../features/{slice}.feature)
    ```
 4. AC prose must NOT be copied into any gate artifact other than `01-requirement.md`.
 5. Rationale: duplicated AC text drifts independently across artifacts and generates spurious review noise on every PR that touches those files.

--- a/.github/skills/requirement-prd-alignment/SKILL.md
+++ b/.github/skills/requirement-prd-alignment/SKILL.md
@@ -19,6 +19,11 @@ Use this skill to prevent Gate 1 to Gate 2 drift and to standardize PRD validati
 1. `01-requirement.md` and the `Requirement Context Package` are immutable source contracts for Gate 2.
 2. Requirement statement, in-scope and out-of-scope boundaries, and acceptance-criteria intent (including IDs) carry forward unchanged unless Product Owner explicitly approves a change.
 3. Any owner-approved change must be called out explicitly in PRD outputs and context updates.
+4. **AC prose must not be copied into `02-prd.md`.** The PRD must reference AC IDs (e.g., `AC-19`) and link to the canonical feature file:
+   ```md
+   **Acceptance Criteria:** canonical source is [`features/<slice>.feature`](../../../features/<slice>.feature)
+   ```
+   User stories in the PRD reference AC IDs for traceability but do not restate AC text. This prevents AC drift across artifacts.
 
 ## Mandatory Alignment Evidence
 

--- a/.github/skills/requirement-prd-alignment/SKILL.md
+++ b/.github/skills/requirement-prd-alignment/SKILL.md
@@ -21,7 +21,7 @@ Use this skill to prevent Gate 1 to Gate 2 drift and to standardize PRD validati
 3. Any owner-approved change must be called out explicitly in PRD outputs and context updates.
 4. **AC prose must not be copied into `02-prd.md`.** The PRD must reference AC IDs (e.g., `AC-19`) and link to the canonical feature file:
    ```md
-   **Acceptance Criteria:** canonical source is [`features/<slice>.feature`](../../../features/<slice>.feature)
+   **Acceptance Criteria:** canonical source is [`features/{slice}.feature`](../../../features/{slice}.feature)
    ```
    User stories in the PRD reference AC IDs for traceability but do not restate AC text. This prevents AC drift across artifacts.
 

--- a/.github/skills/stacked-pr-review-loop/SKILL.md
+++ b/.github/skills/stacked-pr-review-loop/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to run stacked pull requests efficiently without sacrificing revi
 
 1. For multi-task dependent chains delegated by orchestrator, run in `Orchestrator-Managed Stacked Review Mode`.
 2. In this mode, orchestrator owns stack sequencing: merge order, base-to-tip progression, and PR retargeting.
-3. Dev agents own their assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return a review-clean handback.
+3. Dev agents own their assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return the `pr-review-loop` section-6 exit status package, where review-clean outcomes include both `REVIEW_CLEAN` and `REVIEW_CLEAN_WITH_ESCALATIONS`.
 4. Dev agents do not advance stack sequencing, trigger merges, or retarget PR bases.
 
 ## Efficient Sequence (Pipeline First)

--- a/.github/skills/stacked-pr-review-loop/SKILL.md
+++ b/.github/skills/stacked-pr-review-loop/SKILL.md
@@ -18,14 +18,14 @@ Use this skill to run stacked pull requests efficiently without sacrificing revi
 
 1. For multi-task dependent chains delegated by orchestrator, run in `Orchestrator-Managed Stacked Review Mode`.
 2. In this mode, orchestrator owns stack sequencing: merge order, base-to-tip progression, and PR retargeting.
-3. Dev agents own their assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return the `pr-review-loop` section-6 exit status package, where review-clean outcomes include both `REVIEW_CLEAN` and `REVIEW_CLEAN_WITH_ESCALATIONS`.
+3. Dev agents own their assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return the `pr-review-loop` section-6 exit status package — either `REVIEW_CLEAN` (zero new comments, no open escalations) or `REVIEW_CLEAN_WITH_ESCALATIONS` (zero new comments but escalations pending).
 4. Dev agents do not advance stack sequencing, trigger merges, or retarget PR bases.
 
 ## Efficient Sequence (Pipeline First)
 
 1. Assigned dev agents open `PR1` (base: `master`), `PR2` (base: `PR1` branch), `PR3` (base: `PR2` branch), and deeper PRs as needed, each running their own review loop in parallel.
 2. Each dev agent requests Copilot review immediately after opening its PR and polls to review-clean independently.
-3. Orchestrator monitors dev handbacks and executes stack sequencing (merge order, retarget) once lower PRs are review-clean.
+3. Orchestrator monitors dev handbacks and executes stack sequencing (merge order, retarget) once lower PRs reach `REVIEW_CLEAN` status. `REVIEW_CLEAN_WITH_ESCALATIONS` does not unblock sequencing — escalations must be resolved first.
 
 ## Disposition And Fix Sequence (Base To Tip)
 

--- a/.github/skills/stacked-pr-review-loop/SKILL.md
+++ b/.github/skills/stacked-pr-review-loop/SKILL.md
@@ -48,7 +48,7 @@ After all dev agents have returned their exit status packages (per `pr-review-lo
 
 ## Merge And Retarget Sequence (Base To Tip)
 
-1. Product Owner merges the lowest ready PR first. While waiting: arm an alarm (300 s interval, alarm skill). On each alarm wake, call `get` on the base PR via GitHub MCP and check `state=closed` + `merged=true`. If merged → proceed to step 2. If not → re-arm.
+1. Product Owner merges the lowest ready PR first. While waiting: arm an alarm (300 s interval, alarm skill). On each alarm wake, call GitHub MCP `pull_request_read` with `method=get` for the base PR; read response fields `state` and `merged`. If `state=closed` and `merged=true` → proceed to step 2. If not → re-arm.
 2. Orchestrator retargets the next PR base to `master`.
 3. Rebase the next PR branch onto current `master`, resolve conflicts during rebase, avoid merge commits in PR head history, and hand back to orchestrator.
 4. Orchestrator requests a fresh Copilot review on the rebased head.

--- a/.github/skills/stacked-pr-review-loop/SKILL.md
+++ b/.github/skills/stacked-pr-review-loop/SKILL.md
@@ -17,28 +17,38 @@ Use this skill to run stacked pull requests efficiently without sacrificing revi
 ## Execution Ownership (Orchestrated Stacks)
 
 1. For multi-task dependent chains delegated by orchestrator, run in `Orchestrator-Managed Stacked Review Mode`.
-2. In this mode, orchestrator owns review-loop control for every PR in the chain: review requests, polling, disposition triage, and base-to-tip progression.
-3. Dev agents are code-only executors for assigned issues: implement changes, push commits, and return handback status.
-4. Dev agents do not independently start or continue review loops in this mode unless orchestrator explicitly delegates a specific review action.
+2. In this mode, orchestrator owns stack sequencing: merge order, base-to-tip progression, and PR retargeting.
+3. Dev agents own their assigned PR's full review loop: implement, push, request Copilot review, poll to review-clean, fix `Accept` comments, escalate `Challenge` / `Needs Product Owner Decision` items to orchestrator, and return a review-clean handback.
+4. Dev agents do not advance stack sequencing, trigger merges, or retarget PR bases.
 
 ## Efficient Sequence (Pipeline First)
 
-1. Assigned dev agents open `PR1` (base: `master`), `PR2` (base: `PR1` branch), `PR3` (base: `PR2` branch), and deeper PRs as needed, then hand back to orchestrator.
-2. Orchestrator requests Copilot review immediately on each opened PR; do not wait for lower PR review completion before requesting upper PR reviews.
-3. Orchestrator polls and triages comments as they arrive, then executes fix progression from base to tip.
+1. Assigned dev agents open `PR1` (base: `master`), `PR2` (base: `PR1` branch), `PR3` (base: `PR2` branch), and deeper PRs as needed, each running their own review loop in parallel.
+2. Each dev agent requests Copilot review immediately after opening its PR and polls to review-clean independently.
+3. Orchestrator monitors dev handbacks and executes stack sequencing (merge order, retarget) once lower PRs are review-clean.
 
 ## Disposition And Fix Sequence (Base To Tip)
 
-1. Orchestrator classifies each comment using `Accept | Challenge | Needs Product Owner Decision` per `pr-review-loop`.
-2. Orchestrator dispatches fix instructions to the owning dev agent on the lowest open PR in the stack first.
-3. Dev agent applies code changes, pushes commits, and hands back without running an independent review loop unless delegated.
-4. After each fix push, orchestrator requests a fresh Copilot review immediately on that PR.
-5. Consider that PR review-clean only when the latest Copilot review body indicates zero new comments.
-6. Move to the next PR in the stack only after the lower PR reaches review-clean state.
+1. Dev agent classifies each Copilot comment using `Accept | Challenge | Needs Product Owner Decision` per `pr-review-loop`.
+2. For `Accept` items: dev agent applies fixes, pushes, and requests a fresh Copilot review on its own PR immediately — no orchestrator involvement required.
+3. For `Challenge` or `Needs Product Owner Decision` items: dev agent sends a disposition report to the orchestrator and waits for resolution before pushing any fix.
+4. Consider a PR review-clean only when the latest Copilot review body indicates zero new comments.
+5. Orchestrator does not dispatch fix instructions for `Accept` items — dev handles them directly.
+6. Orchestrator advances stack sequencing only after the lower PR reaches review-clean state.
+
+## Post-Loop Orchestrator Challenge Consolidation
+
+After all dev agents have returned their exit status packages (per `pr-review-loop` section 6):
+
+1. Orchestrator collects every `REVIEW_CLEAN_WITH_ESCALATIONS` package across all PRs in the stack.
+2. If any escalations exist, orchestrator presents them to the Product Owner as a single consolidated cross-PR challenge list before advancing any stack sequencing. Group items by PR for clarity.
+3. For each escalation the PO resolves (accept / fix), orchestrator dispatches the fix to the owning dev agent. Dev implements, pushes, re-runs its review loop, and returns a new exit status package.
+4. Stack sequencing (merge order, retarget) does not advance until all escalations across all PRs are either resolved by PO or explicitly deferred by PO with a recorded rationale.
+5. If all packages are `REVIEW_CLEAN`, orchestrator proceeds directly to merge sequencing.
 
 ## Merge And Retarget Sequence (Base To Tip)
 
-1. Product Owner merges the lowest ready PR first.
+1. Product Owner merges the lowest ready PR first. While waiting: arm an alarm (300 s interval, alarm skill). On each alarm wake, call `get` on the base PR via GitHub MCP and check `state=closed` + `merged=true`. If merged → proceed to step 2. If not → re-arm.
 2. Orchestrator retargets the next PR base to `master`.
 3. Rebase the next PR branch onto current `master`, resolve conflicts during rebase, avoid merge commits in PR head history, and hand back to orchestrator.
 4. Orchestrator requests a fresh Copilot review on the rebased head.

--- a/.github/skills/stacked-pr-review-loop/SKILL.md
+++ b/.github/skills/stacked-pr-review-loop/SKILL.md
@@ -31,7 +31,7 @@ Use this skill to run stacked pull requests efficiently without sacrificing revi
 
 1. Dev agent classifies each Copilot comment using `Accept | Challenge | Needs Product Owner Decision` per `pr-review-loop`.
 2. For `Accept` items: dev agent applies fixes, pushes, and requests a fresh Copilot review on its own PR immediately — no orchestrator involvement required.
-3. For `Challenge` or `Needs Product Owner Decision` items: dev agent sends a disposition report to the orchestrator and waits for resolution before pushing any fix.
+3. For `Challenge` or `Needs Product Owner Decision` items: dev agent sends a disposition report to the orchestrator and waits for resolution before pushing the challenged change itself. Unrelated `Accept` fixes on the same PR may still be applied, pushed, and re-reviewed immediately — only the challenged change is paused.
 4. Consider a PR review-clean only when the latest Copilot review body indicates zero new comments.
 5. Orchestrator does not dispatch fix instructions for `Accept` items — dev handles them directly.
 6. Orchestrator advances stack sequencing only after the lower PR reaches review-clean state.


### PR DESCRIPTION
## Summary

Protocol and skill quality improvements from the post-retrospective session. No product code changed.

## Changes

### Review Loop Exit Status Taxonomy (new)
- `pr-review-loop/SKILL.md` — Added **Section 6: Review Loop Exit Status** (mandatory on every loop exit):
  - `REVIEW_CLEAN`: 0 Copilot comments, no open challenges → proceed to merge-ready; exit package includes PR link, head SHA, review excerpt
  - `REVIEW_CLEAN_WITH_ESCALATIONS`: 0 Copilot comments but ≥1 open `Challenge` / `Needs PO Decision` → return package with thread link + classification + one-line summary per item
  - Routing rule: standalone mode → PO, stacked mode → orchestrator

### Review Loop Ownership Fix
- `pr-review-loop/SKILL.md` — Fixed stale rules 2 & 3 in "Review Loop Ownership": dev now owns full review loop per-PR; orchestrator owns stack sequencing only (was: orchestrator owns review loop, dev is code-only)

### Stacked PR Challenge Consolidation (new)
- `stacked-pr-review-loop/SKILL.md` — Added **Post-Loop Orchestrator Challenge Consolidation** section between Disposition & Fix and Merge & Retarget: orchestrator collects all `REVIEW_CLEAN_WITH_ESCALATIONS` packages cross-PR, presents consolidated challenge list to PO, gates merge sequencing until all escalations resolved or explicitly deferred

### Alarm skill — situational content stripped
- `alarm/SKILL.md` — On-wake logic is generic only; callers define what to check

### Caller skills — on-wake logic added
- `pr-review-loop/SKILL.md` — rule 9: alarm 180s, on-wake routes by review state
- `build-merge-gate-orchestration/SKILL.md` — alarm 600s; on-wake = review-clean handback from dev
- `stacked-pr-review-loop/SKILL.md` — merge step: alarm 300s, on-wake checks `state=closed + merged=true`

### Dev agent review loop ownership
- `AGENTS.md` + `dev.agent.md` — dev owns full review loop in stacked mode; exit status package is emitted per review loop completion

### Supplementary
- `build-evidence-and-merge-readiness/SKILL.md`, `requirement-gate-orchestration/SKILL.md`, `requirement-prd-alignment/SKILL.md` — quality updates
- `copilot-instructions.md` — updated coding conventions to reference instruction files
- `.github/instructions/` — added `css.instructions.md`, `react.instructions.md`, `tests.instructions.md`
- `.github/skills/coding-standards/SKILL.md` — added coding standards skill