### PR TITLE
fix: align bottom-sheet open height with Figma 244px spec

### DIFF
--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -138,7 +138,7 @@
     line-height: 1rem;
 }
 
-.podium-bottom-sheet__error:not(:empty) {
+.podium-bottom-sheet__textarea[aria-invalid='true'] ~ .podium-bottom-sheet__error {
     display: block;
     min-height: 1rem;
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -131,11 +131,16 @@
 }
 
 .podium-bottom-sheet__error {
+    display: none;
     margin: 0;
-    min-height: 1rem;
     color: var(--color-error);
     font-size: 0.75rem;
     line-height: 1rem;
+}
+
+.podium-bottom-sheet__error:not(:empty) {
+    display: block;
+    min-height: 1rem;
 }
 
 @keyframes podium-scrim-fade-in {


### PR DESCRIPTION
Closes #173

## Summary
- fixed open-state bottom sheet height inflation by removing layout space for the empty error row
- kept validation error messaging intact when text is present
- limited the implementation diff to `src/styles/components/podium-bottom-sheet.css`

## Implementation
- `display: none` on `.podium-bottom-sheet__error` by default
- `display: block` + `min-height: 1rem` only when `.podium-bottom-sheet__textarea[aria-invalid='true'] ~ .podium-bottom-sheet__error`

This removes the extra 28px consumed in the default open state (16px error line + 12px extra flex gap), matching the 244px Figma frame height.

## Verification Evidence
- `npm run test` ✅ (308/308)
- `npm run test:bdd` ✅ (22/22 scenarios)
- `npm run build` ✅

### Figma Traceability
| Frame / Node | Extracted value | Code location | Status |
|---|---:|---|---|
| 704:253 (Composer-Open-Tark/Light/Mobile) | Podium/BottomSheet height = 244px | `src/styles/components/podium-bottom-sheet.css` | applied |
| 709:276 (Composer-Open-Vitark/Light/Mobile) | Podium/BottomSheet height = 244px | `src/styles/components/podium-bottom-sheet.css` | applied |
| 714:408 (Composer-Open-Tark/Dark/Mobile) | Podium/BottomSheet height = 244px | `src/styles/components/podium-bottom-sheet.css` | applied |
| 714:471 (Composer-Open-Vitark/Dark/Mobile) | Podium/BottomSheet height = 244px | `src/styles/components/podium-bottom-sheet.css` | applied |
| 714:284 (FAB-Collapsed/Dark/Mobile) | baseline frame includes no open sheet | reference-only | n/a |
| 714:346 (FAB-Expanded/Dark/Mobile) | baseline frame includes no open sheet | reference-only | n/a |

### Visual Validation Evidence
- **Blocked:** Chrome DevTools MCP could not open a browser session in this environment (`chrome-profile` already running/locked), so in-agent runtime screenshot capture could not complete.

## Runtime QA Handoff Package
- **Journey:** Debate screen → tap FAB open → composer bottom sheet opens → verify visible rows (handle, segmented control, textarea, publish action)
- **Route:** `/`
- **Viewport/Theme matrix:** mobile 360x800 in Light and Dark
- **Expected state:** open sheet visual height matches 244px Figma open-state frame
- **Setup/Test data:** no auth/setup required; static debate seed content
- **Known risk note:** screenshot capture in this run was blocked by shared Chrome MCP profile lock

## Residual Risk
- When an error message is displayed, the sheet can exceed 244px due to intentional error line rendering.

## Rollback
- Revert commit `f408d97`.

## Agent Provenance
run-id: d7420be8-a929-43d6-9c1b-31ca1b09fdb9
task-id: #173
role: dev
dispatched: 2026-04-20T07:17:31.191Z
model: gpt-5.3-codex