### PR TITLE
chore: reclassify 481px mobile-internal breakpoint comments

### DIFF
--- a/src/styles/components/argument-card.css
+++ b/src/styles/components/argument-card.css
@@ -15,6 +15,7 @@
     }
 }
 
+/* mobile-internal (≥481px) — not a design tier */
 @media (min-width: 481px) {
     .argument-card__body--clamped {
         display: block;

--- a/src/styles/components/legend-bar.css
+++ b/src/styles/components/legend-bar.css
@@ -50,7 +50,7 @@
     text-align: center;
 }
 
-/* Tablet and above: 3-column grid matching timeline spine alignment */
+/* mobile-internal (≥481px) — not a design tier */
 @media (min-width: 481px) {
     .legend-bar {
         display: grid;

--- a/src/styles/components/timeline.css
+++ b/src/styles/components/timeline.css
@@ -41,7 +41,7 @@
     align-self: flex-end;
 }
 
-/* ── Tablet (≥481px): CSS Grid with center spine ── */
+/* ── mobile-internal layout adjustment (≥481px) — not a design tier ── */
 @media (min-width: 481px) {
     .timeline {
         padding: 0 var(--space-10);

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -18,7 +18,7 @@
     text-align: center;
 }
 
-/* ── Tablet ── */
+/* ── mobile-internal (≥481px) — not a design tier ── */
 @media (min-width: 481px) {
     .debate-header {
         padding: var(--space-12) var(--space-10) var(--space-8);


### PR DESCRIPTION
## Summary
- Reclassified the `@media (min-width: 481px)` comments in four CSS files to explicitly mark them as mobile-internal implementation details.
- Preserved all selectors and CSS declarations; this change is comment text only.

## Files Changed
- `src/styles/components/argument-card.css` — added `mobile-internal (≥481px)` comment above the existing 481px media query.
- `src/styles/components/legend-bar.css` — replaced the `Tablet and above` comment with `mobile-internal (≥481px) — not a design tier`.
- `src/styles/components/timeline.css` — replaced the `Tablet (≥481px)` comment with `mobile-internal layout adjustment (≥481px) — not a design tier`.
- `src/styles/debate-screen.css` — replaced the `Tablet` comment with `mobile-internal (≥481px) — not a design tier`.

## Verification
- `CI=1 npm test`
- Result: pass (23 test files, 308 tests)

Closes #180

## Agent Provenance
run-id: 606d3fa0-b7e7-4eac-9031-a440f4d8d634
task-id: #180
role: dev
dispatched: 2026-04-21T04:26:32.352Z
model: gpt-5.3-codex