### PR TITLE
[podium-responsive-layout] Task C: bottom-sheet width and scrim breakpoints

### DIFF
--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -1,8 +1,4 @@
 .podium-sheet-scrim {
-    --podium-sheet-scrim-tablet-dark: rgba(0, 0, 0, 0.48);
-    --podium-sheet-scrim-desktop-light: rgba(0, 0, 0, 0.36);
-    --podium-sheet-scrim-desktop-dark: rgba(0, 0, 0, 0.52);
-
     animation: podium-scrim-fade-in 300ms ease-out;
     position: fixed;
     inset: 0;
@@ -169,17 +165,17 @@
 /* ── Scrim opacity: tablet dark theme ── */
 @media (min-width: 768px) and (max-width: 1023px) {
     [data-theme="dark"] .podium-sheet-scrim {
-        background: var(--podium-sheet-scrim-tablet-dark);
+        background: rgb(from var(--color-scrim) r g b / 0.48);
     }
 }
 
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
-        background: var(--podium-sheet-scrim-desktop-light);
+        background: rgb(from var(--color-scrim) r g b / 0.36);
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
-        background: var(--podium-sheet-scrim-desktop-dark);
+        background: rgb(from var(--color-scrim) r g b / 0.52);
     }
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -148,7 +148,7 @@
     to { opacity: 1; }
 }
 
-/* ── Tablet (768–1023 px): BottomSheet max-width ── */
+/* ── Tablet (≥768 px, overridden at ≥1024 px): BottomSheet max-width ── */
 @media (min-width: 768px) {
     .podium-bottom-sheet {
         max-width: 600px;
@@ -165,6 +165,7 @@
 /* ── Scrim opacity: tablet dark theme ── */
 @media (min-width: 768px) and (max-width: 1023px) {
     [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.48);
         background: rgb(from var(--color-scrim) r g b / 0.48);
     }
 }
@@ -172,10 +173,12 @@
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.36);
         background: rgb(from var(--color-scrim) r g b / 0.36);
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.52);
         background: rgb(from var(--color-scrim) r g b / 0.52);
     }
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -147,3 +147,35 @@
     from { opacity: 0; }
     to { opacity: 1; }
 }
+
+/* ── Tablet (768–1023 px): BottomSheet max-width ── */
+@media (min-width: 768px) {
+    .podium-bottom-sheet {
+        max-width: 600px;
+    }
+}
+
+/* ── Desktop (≥1024 px): BottomSheet max-width ── */
+@media (min-width: 1024px) {
+    .podium-bottom-sheet {
+        max-width: 720px;
+    }
+}
+
+/* ── Scrim opacity: tablet dark theme ── */
+@media (min-width: 768px) and (max-width: 1023px) {
+    [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.48);
+    }
+}
+
+/* ── Scrim opacity: desktop (light and dark theme) ── */
+@media (min-width: 1024px) {
+    .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.36);
+    }
+
+    [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.52);
+    }
+}

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -1,4 +1,8 @@
 .podium-sheet-scrim {
+    --podium-sheet-scrim-tablet-dark: rgba(0, 0, 0, 0.48);
+    --podium-sheet-scrim-desktop-light: rgba(0, 0, 0, 0.36);
+    --podium-sheet-scrim-desktop-dark: rgba(0, 0, 0, 0.52);
+
     animation: podium-scrim-fade-in 300ms ease-out;
     position: fixed;
     inset: 0;
@@ -165,17 +169,17 @@
 /* ── Scrim opacity: tablet dark theme ── */
 @media (min-width: 768px) and (max-width: 1023px) {
     [data-theme="dark"] .podium-sheet-scrim {
-        background: rgba(0, 0, 0, 0.48);
+        background: var(--podium-sheet-scrim-tablet-dark);
     }
 }
 
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
-        background: rgba(0, 0, 0, 0.36);
+        background: var(--podium-sheet-scrim-desktop-light);
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
-        background: rgba(0, 0, 0, 0.52);
+        background: var(--podium-sheet-scrim-desktop-dark);
     }
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -170,6 +170,13 @@
     }
 }
 
+@media (prefers-color-scheme: dark) and (min-width: 768px) and (max-width: 1023px) {
+    :root:not([data-theme]) .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.48);
+        background: rgb(from var(--color-scrim) r g b / 0.48);
+    }
+}
+
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
@@ -178,6 +185,13 @@
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.52);
+        background: rgb(from var(--color-scrim) r g b / 0.52);
+    }
+}
+
+@media (prefers-color-scheme: dark) and (min-width: 1024px) {
+    :root:not([data-theme]) .podium-sheet-scrim {
         background: rgba(0, 0, 0, 0.52);
         background: rgb(from var(--color-scrim) r g b / 0.52);
     }

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -192,7 +192,7 @@ describe('PodiumBottomSheet', () => {
     });
 
     it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
-        // Traceability source for AC-29/AC-30: GitHub issue #179 (task-level acceptance criteria).
+        // Traceability source for AC-25, AC-26, AC-29, and AC-30: GitHub issue #179.
         expect(podiumBottomSheetCss).toMatch(
             /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );
@@ -203,7 +203,7 @@ describe('PodiumBottomSheet', () => {
             /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
+            /\/\*\s*──\s*Scrim opacity:\s*desktop\s*\(light and dark theme\)\s*──\s*\*\/[\s\S]*?@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
         );
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -191,18 +191,29 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
 
-    it('applies tablet and desktop podium sheet width and scrim breakpoints from AC-25, AC-26, AC-29, and AC-30', () => {
-        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) {');
-        expect(podiumBottomSheetCss).toContain('max-width: 600px;');
+    it('applies tablet and desktop podium sheet width and scrim breakpoints from issue #179 AC-25, AC-26, AC-29, and AC-30', () => {
+        // Traceability source for AC-29/AC-30: GitHub issue #179 (task-level acceptance criteria).
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}/
+        );
 
-        expect(podiumBottomSheetCss).toContain('@media (min-width: 1024px) {');
-        expect(podiumBottomSheetCss).toContain('max-width: 720px;');
-
-        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) and (max-width: 1023px) {');
-        expect(podiumBottomSheetCss).toContain('[data-theme="dark"] .podium-sheet-scrim {');
-        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.48);');
-
-        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.36);');
-        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.52);');
+        expect(podiumBottomSheetCss).toMatch(
+            /--podium-sheet-scrim-tablet-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /--podium-sheet-scrim-desktop-light:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /--podium-sheet-scrim-desktop-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-tablet-dark\);[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-light\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-dark\);[\s\S]*?\}/
+        );
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -192,7 +192,8 @@ describe('PodiumBottomSheet', () => {
     });
 
     it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
-        // Traceability source for AC-25, AC-26, AC-29, and AC-30: GitHub issue #179.
+        // BDD traceability note: responsive podium sheet AC-25/26/29/30 are currently
+        // sourced from issue #179; add linked feature-scenario coverage in features/*.feature.
         expect(podiumBottomSheetCss).toMatch(
             /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -191,29 +191,19 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
 
-    it('applies tablet and desktop podium sheet width and scrim breakpoints from issue #179 AC-25, AC-26, AC-29, and AC-30', () => {
+    it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
         // Traceability source for AC-29/AC-30: GitHub issue #179 (task-level acceptance criteria).
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}/
+            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}/
-        );
-
-        expect(podiumBottomSheetCss).toMatch(
-            /--podium-sheet-scrim-tablet-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);/
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /--podium-sheet-scrim-desktop-light:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);/
+            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /--podium-sheet-scrim-desktop-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-tablet-dark\);[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-light\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-dark\);[\s\S]*?\}/
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
         );
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -190,4 +190,19 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('touch-action: pan-y;');
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
+
+    it('applies tablet and desktop podium sheet width and scrim breakpoints from AC-25, AC-26, AC-29, and AC-30', () => {
+        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) {');
+        expect(podiumBottomSheetCss).toContain('max-width: 600px;');
+
+        expect(podiumBottomSheetCss).toContain('@media (min-width: 1024px) {');
+        expect(podiumBottomSheetCss).toContain('max-width: 720px;');
+
+        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) and (max-width: 1023px) {');
+        expect(podiumBottomSheetCss).toContain('[data-theme="dark"] .podium-sheet-scrim {');
+        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.48);');
+
+        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.36);');
+        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.52);');
+    });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -200,10 +200,16 @@ describe('PodiumBottomSheet', () => {
             /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
+            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(prefers-color-scheme:\s*dark\)\s*and\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?:root:not\(\[data-theme\]\)\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
             /\/\*\s*──\s*Scrim opacity:\s*desktop\s*\(light and dark theme\)\s*──\s*\*\/[\s\S]*?@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(prefers-color-scheme:\s*dark\)\s*and\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?:root:not\(\[data-theme\]\)\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
         );
     });
 });


### PR DESCRIPTION
Closes #179

## Implementation Summary
Implemented Task C for `podium-bottom-sheet.css` with responsive width and scrim breakpoints for tablet/desktop, including explicit system-dark fallback handling when `data-theme` is not set.

## Files Changed
- `src/styles/components/podium-bottom-sheet.css`
  - Added tablet width rule (`@media (min-width: 768px)` → `max-width: 600px`)
  - Added desktop width rule (`@media (min-width: 1024px)` → `max-width: 720px`)
  - Added tablet dark scrim override for explicit dark theme
  - Added desktop light/dark scrim overrides for explicit theme
  - Added tablet and desktop `prefers-color-scheme: dark` fallbacks for `:root:not([data-theme])` parity
  - Added `rgba(...)` fallbacks before `rgb(from var(--color-scrim) ...)` for cross-browser compatibility
- `tests/components/PodiumBottomSheet.test.tsx`
  - Added scoped CSS assertions covering breakpoint width rules, scrim fallback+relative declarations, and system-dark fallback blocks.

## Verification Evidence
- `npm test -- tests/components/PodiumBottomSheet.test.tsx` ✅
- `npm test` ✅
- `npm run test:bdd` ✅
- `npm run build` ✅

## BDD Evidence
- Acceptance criteria covered in unit assertions: AC-25, AC-26, AC-29, AC-30.
- Current traceability source: issue #179 for this atomic task; follow-up feature-file linkage note is included in the test for BDD artifact alignment.

## Runtime QA Handoff Package
- Journey map: Open Debate Screen → open Podium bottom sheet → verify tablet/desktop width + scrim opacity by theme mode.
- Route list: `/`.
- Setup notes: validate at 768–1023 and >=1024, with explicit `[data-theme]` and system dark mode without `[data-theme]`.
- Expected states:
  - Tablet: max-width 600px; dark scrim alpha 0.48.
  - Desktop: max-width 720px; light scrim alpha 0.36; dark scrim alpha 0.52.

## Residual Risk and Rollback
- Residual risk: low; scoped to bottom-sheet stylesheet and focused CSS-source assertions.
- Rollback: revert branch commits for PR #184 to restore prior behavior.

## Agent Provenance
run-id: de0b85a1-fc9e-45ff-b821-4943c943893a
task-id: #179
role: dev
dispatched: 2026-04-21T04:26:18.614Z
model: gpt-5.3-codex