### PR TITLE
[podium-responsive-layout] Task B: add tablet and desktop FAB breakpoints

### DIFF
--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,8 +1,8 @@
 button.podium-fab,
 div.podium-fab[role="group"] {
     position: fixed;
-    right: var(--space-4);
-    bottom: var(--space-4);
+    right: max(var(--space-4), env(safe-area-inset-right, 0px));
+    bottom: max(var(--space-4), env(safe-area-inset-bottom, 0px));
     z-index: 30;
 }
 

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -109,8 +109,8 @@ div.podium-fab[role='group'].podium-fab--expanded {
 @media (min-width: 768px) {
     button.podium-fab,
     div.podium-fab[role="group"] {
-        right: var(--space-8);
-        bottom: var(--space-8);
+        right: max(var(--space-8), env(safe-area-inset-right, 0px));
+        bottom: max(var(--space-8), env(safe-area-inset-bottom, 0px));
     }
 }
 
@@ -118,7 +118,7 @@ div.podium-fab[role='group'].podium-fab--expanded {
 @media (min-width: 1024px) {
     button.podium-fab,
     div.podium-fab[role="group"] {
-        right: var(--space-12);
-        bottom: var(--space-12);
+        right: max(var(--space-12), env(safe-area-inset-right, 0px));
+        bottom: max(var(--space-12), env(safe-area-inset-bottom, 0px));
     }
 }

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,8 +1,8 @@
 button.podium-fab,
 div.podium-fab[role="group"] {
     position: fixed;
-    right: max(var(--space-4), env(safe-area-inset-right, 0px));
-    bottom: max(var(--space-4), env(safe-area-inset-bottom, 0px));
+    right: var(--space-4);
+    bottom: var(--space-4);
     z-index: 30;
 }
 

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -104,3 +104,21 @@ div.podium-fab[role='group'].podium-fab--expanded {
     outline: 2px solid currentColor;
     outline-offset: 2px;
 }
+
+/* ── Tablet (768–1023 px): FAB margin override ── */
+@media (min-width: 768px) {
+    button.podium-fab,
+    div.podium-fab[role="group"] {
+        right: var(--space-8);
+        bottom: var(--space-8);
+    }
+}
+
+/* ── Desktop (≥1024 px): FAB margin override ── */
+@media (min-width: 1024px) {
+    button.podium-fab,
+    div.podium-fab[role="group"] {
+        right: var(--space-12);
+        bottom: var(--space-12);
+    }
+}

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -210,6 +210,9 @@ describe('PodiumFAB', () => {
         const desktopMediaMatch = /@media\s*\(min-width:\s*1024px\)/.exec(podiumFabCss);
         const tabletBreakpointIndex = tabletMediaMatch?.index ?? -1;
         const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
+
+        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
+        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
         const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
         const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
         const tabletRule = tabletBlock.match(
@@ -220,9 +223,6 @@ describe('PodiumFAB', () => {
         );
         const tabletDeclarations = tabletRule?.[2] ?? '';
         const desktopDeclarations = desktopRule?.[2] ?? '';
-
-        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
-        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
         expect(tabletRule).not.toBeNull();
         expect(desktopRule).not.toBeNull();
         expect(tabletDeclarations).toMatch(

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -204,4 +204,18 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).not.toMatch(/\brgba?\s*\(/i);
         expect(podiumFabCss).not.toMatch(/\bhsla?\s*\(/i);
     });
+
+    it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
+        const tabletBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 768px)');
+        const desktopBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 1024px)');
+
+        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
+        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
+        expect(podiumFabCss).toMatch(
+            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-8\);[\s\S]*bottom:\s*var\(--space-8\);/
+        );
+        expect(podiumFabCss).toMatch(
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-12\);[\s\S]*bottom:\s*var\(--space-12\);/
+        );
+    });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -197,6 +197,12 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-vitark-surface\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-ambient\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-key\)/);
+        expect(podiumFabCss).toMatch(
+            /right:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+        );
+        expect(podiumFabCss).toMatch(
+            /bottom:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+        );
         expect(podiumFabCss).toMatch(/transition:\s*opacity\s+300ms\s+ease-out,\s*transform\s+300ms\s+ease-out/);
         expect(podiumFabCss).toMatch(/transform:\s*scale\(0\.8\)/);
         expect(podiumFabCss).toMatch(/\.podium-fab--expanded\s*\{[\s\S]*pointer-events:\s*auto;/);

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -216,10 +216,10 @@ describe('PodiumFAB', () => {
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
         expect(tabletBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
         );
         expect(desktopBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -206,26 +206,20 @@ describe('PodiumFAB', () => {
     });
 
     it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
-        const tabletBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 768px)');
-        const desktopBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 1024px)');
+        const tabletMediaMatch = /@media\s*\(min-width:\s*768px\)/.exec(podiumFabCss);
+        const desktopMediaMatch = /@media\s*\(min-width:\s*1024px\)/.exec(podiumFabCss);
+        const tabletBreakpointIndex = tabletMediaMatch?.index ?? -1;
+        const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
         const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
         const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
 
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        expect(tabletBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
         expect(tabletBlock).toMatch(
-            /right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);/
-        );
-        expect(tabletBlock).toMatch(
-            /bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
-        );
-        expect(desktopBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
-        expect(desktopBlock).toMatch(
-            /right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
         );
         expect(desktopBlock).toMatch(
-            /bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -197,12 +197,6 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-vitark-surface\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-ambient\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-key\)/);
-        expect(podiumFabCss).toMatch(
-            /right:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-right,\s*0px\)\);/
-        );
-        expect(podiumFabCss).toMatch(
-            /bottom:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
-        );
         expect(podiumFabCss).toMatch(/transition:\s*opacity\s+300ms\s+ease-out,\s*transform\s+300ms\s+ease-out/);
         expect(podiumFabCss).toMatch(/transform:\s*scale\(0\.8\)/);
         expect(podiumFabCss).toMatch(/\.podium-fab--expanded\s*\{[\s\S]*pointer-events:\s*auto;/);
@@ -218,14 +212,30 @@ describe('PodiumFAB', () => {
         const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
         const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
         const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
+        const tabletRule = tabletBlock.match(
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{([^}]*)\}/
+        );
+        const desktopRule = desktopBlock.match(
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{([^}]*)\}/
+        );
+        const tabletDeclarations = tabletRule?.[2] ?? '';
+        const desktopDeclarations = desktopRule?.[2] ?? '';
 
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        expect(tabletBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
+        expect(tabletRule).not.toBeNull();
+        expect(desktopRule).not.toBeNull();
+        expect(tabletDeclarations).toMatch(
+            /right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);/
         );
-        expect(desktopBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
+        expect(tabletDeclarations).toMatch(
+            /bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+        );
+        expect(desktopDeclarations).toMatch(
+            /right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+        );
+        expect(desktopDeclarations).toMatch(
+            /bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -208,14 +208,24 @@ describe('PodiumFAB', () => {
     it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
         const tabletBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 768px)');
         const desktopBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 1024px)');
+        const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
+        const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
 
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        expect(podiumFabCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-8\);[\s\S]*bottom:\s*var\(--space-8\);/
+        expect(tabletBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
+        expect(tabletBlock).toMatch(
+            /right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);/
         );
-        expect(podiumFabCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-12\);[\s\S]*bottom:\s*var\(--space-12\);/
+        expect(tabletBlock).toMatch(
+            /bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+        );
+        expect(desktopBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
+        expect(desktopBlock).toMatch(
+            /right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+        );
+        expect(desktopBlock).toMatch(
+            /bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
         );
     });
 });


### PR DESCRIPTION
## Summary
- append tablet (`min-width: 768px`) and desktop (`min-width: 1024px`) FAB margin overrides using token floors (`--space-8`, `--space-12`) with safe-area inset support
- keep existing mobile baseline declarations unchanged (`right: var(--space-4); bottom: var(--space-4);`) to stay within issue #178 scope
- harden AC-traceable CSS-source assertions in `PodiumFAB.test.tsx` for AC-25, AC-26, AC-29, and AC-30 with resilient media/rule matching

## Issue
Closes #178

## Files Changed
- `src/styles/components/podium-fab.css` — appended tablet and desktop media-query overrides for `button.podium-fab` and `div.podium-fab[role="group"]` with safe-area-aware token floors
- `tests/components/PodiumFAB.test.tsx` — acceptance-criteria traceability assertions for breakpoint token rules and scoped selector-block validation

## Verification Evidence
- `npm test -- tests/components/PodiumFAB.test.tsx` (fail-first observed before initial CSS implementation)
- `npm test` (pass)
- `npm run build` (pass)

## BDD Evidence
- Scenario mapping from issue acceptance criteria:
  - AC-25 + AC-29 → `@media (min-width: 768px)` keeps minimum 32px FAB offsets via `max(var(--space-8), env(...))`
  - AC-26 + AC-30 → `@media (min-width: 1024px)` keeps minimum 48px FAB offsets via `max(var(--space-12), env(...))`
- Test traceability: `tests/components/PodiumFAB.test.tsx` test `maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins`

## Residual Risk
- Low: scope is limited to appended breakpoint declarations plus CSS-source assertions; mobile baseline remains untouched.

## Rollback
- Revert PR commits `7f1bc8c`, `ac962e7`, `60f8c02`, `29f61be`, `b3e5ce8`, `a2fb1de`, and `1053c9c`.

## Agent Provenance
run-id: 49a13a22-6ce9-4c87-917d-017f3dc0ae44
task-id: #178
role: dev
dispatched: 2026-04-21T04:26:05.894Z
model: gpt-5.3-codex