### PR TITLE
[podium-responsive-layout] Task A — remove DebateScreen isMobile conditional

### DIFF
--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -18,20 +18,61 @@ import * as assert from 'assert';
 import { createElement } from 'react';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import { Podium } from '../../src/components/Podium';
-import { DEBATE } from '../../src/data/debate';
+import { DEBATE, type Side } from '../../src/data/debate';
 
 function activeRender(world: PostTarkVitarkWorld): RenderResult {
   assert.ok(world.renderResult, 'Expected an active rendered view.');
   return world.renderResult;
 }
 
+function toSideLabel(side: Side): string {
+  return side === 'tark' ? 'Tark' : 'Vitark';
+}
+
+function ensureBottomSheetOpen(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
+  const view = activeRender(world);
+
+  if (!view.queryByRole('dialog', { name: 'Post composer' })) {
+    fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
+    fireEvent.click(
+      view.getByRole('button', {
+        name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
+      })
+    );
+    return;
+  }
+
+  const sideToggle = view.getByRole('radio', { name: toSideLabel(side) });
+  if (sideToggle.getAttribute('aria-checked') !== 'true') {
+    fireEvent.click(sideToggle);
+  }
+}
+
 function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
+  const view = activeRender(world);
+  const existingComposerInput = view.queryByRole('textbox', {
+    name: 'Post text',
+  });
+  if (existingComposerInput) {
+    return existingComposerInput as HTMLTextAreaElement;
+  }
+
+  ensureBottomSheetOpen(world);
   return activeRender(world).getByRole('textbox', {
     name: 'Post text',
   }) as HTMLTextAreaElement;
 }
 
 function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
+  const view = activeRender(world);
+  const existingPublishButton = view.queryByRole('button', {
+    name: 'Publish post',
+  });
+  if (existingPublishButton) {
+    return existingPublishButton as HTMLButtonElement;
+  }
+
+  ensureBottomSheetOpen(world);
   return activeRender(world).getByRole('button', {
     name: 'Publish post',
   }) as HTMLButtonElement;
@@ -93,31 +134,27 @@ Given('the debate screen is loaded', function (this: PostTarkVitarkWorld) {
 Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
   const view = activeRender(this);
 
-  assert.ok(view.getByRole('switch', { name: 'Post as Tark' }));
-  assert.ok(composerInput(this));
-  assert.ok(publishButton(this));
+  assert.ok(view.getByRole('button', { name: 'Open post composer' }));
   assert.equal(view.queryByRole('button', { name: /sign in|log in/i }), null);
   assert.equal(view.queryByLabelText(/image|media|upload/i), null);
 });
 
 Then('Tark is selected by default', function (this: PostTarkVitarkWorld) {
-  const view = activeRender(this);
+  ensureBottomSheetOpen(this, 'tark');
 
-  const chip = view.getByRole('switch', { name: 'Post as Tark' });
+  const chip = activeRender(this).getByRole('radio', { name: 'Tark' });
   assert.ok(chip);
   assert.equal(chip.getAttribute('aria-checked'), 'true');
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  fireEvent.click(activeRender(this).getByRole('switch', { name: 'Post as Tark' }));
+  ensureBottomSheetOpen(this, 'vitark');
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
-  const view = activeRender(this);
-
-  const chip = view.getByRole('switch', { name: 'Post as Vitark' });
+  const chip = activeRender(this).getByRole('radio', { name: 'Vitark' });
   assert.ok(chip);
-  assert.equal(chip.getAttribute('aria-checked'), 'false');
+  assert.equal(chip.getAttribute('aria-checked'), 'true');
 });
 
 When('the visitor enters whitespace-only post text', function (this: PostTarkVitarkWorld) {

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -38,11 +38,19 @@ function expandComposerOptions(world: PostTarkVitarkWorld): void {
   fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
 }
 
-function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
+async function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark'): Promise<void> {
   const view = activeRender(world);
 
   if (!view.queryByRole('dialog', { name: 'Post composer' })) {
     expandComposerOptions(world);
+
+    await waitFor(() => {
+      const sideButton = activeRender(world).getByRole('button', {
+        name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
+      }) as HTMLButtonElement;
+      assert.equal(sideButton.disabled, false);
+    });
+
     fireEvent.click(
       activeRender(world).getByRole('button', {
         name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
@@ -57,7 +65,7 @@ function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark')
   }
 }
 
-function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
+async function composerInput(world: PostTarkVitarkWorld): Promise<HTMLTextAreaElement> {
   const view = activeRender(world);
   const existingComposerInput = view.queryByRole('textbox', {
     name: 'Post text',
@@ -66,13 +74,13 @@ function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
     return existingComposerInput as HTMLTextAreaElement;
   }
 
-  openBottomSheetForSide(world);
+  await openBottomSheetForSide(world);
   return activeRender(world).getByRole('textbox', {
     name: 'Post text',
   }) as HTMLTextAreaElement;
 }
 
-function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
+async function publishButton(world: PostTarkVitarkWorld): Promise<HTMLButtonElement> {
   const view = activeRender(world);
   const existingPublishButton = view.queryByRole('button', {
     name: 'Publish post',
@@ -81,7 +89,7 @@ function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
     return existingPublishButton as HTMLButtonElement;
   }
 
-  openBottomSheetForSide(world);
+  await openBottomSheetForSide(world);
   return activeRender(world).getByRole('button', {
     name: 'Publish post',
   }) as HTMLButtonElement;
@@ -96,11 +104,13 @@ function buildText(length: number): string {
 }
 
 async function submitComposer(world: PostTarkVitarkWorld): Promise<void> {
+  const composerPublishButton = await publishButton(world);
+
   await waitFor(() => {
-    assert.equal(publishButton(world).disabled, false);
+    assert.equal(composerPublishButton.disabled, false);
   });
 
-  fireEvent.click(publishButton(world));
+  fireEvent.click(composerPublishButton);
 }
 
 class PostTarkVitarkWorld extends World {
@@ -158,7 +168,7 @@ Then('Tark is selected by default', async function (this: PostTarkVitarkWorld) {
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  openBottomSheetForSide(this, 'vitark');
+  return openBottomSheetForSide(this, 'vitark');
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
@@ -167,18 +177,18 @@ Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
   assert.equal(chip.getAttribute('aria-checked'), 'true');
 });
 
-When('the visitor enters whitespace-only post text', function (this: PostTarkVitarkWorld) {
-  fireEvent.change(composerInput(this), { target: { value: '      ' } });
+When('the visitor enters whitespace-only post text', async function (this: PostTarkVitarkWorld) {
+  fireEvent.change(await composerInput(this), { target: { value: '      ' } });
 });
 
-When('the visitor enters a post with {int} characters', function (this: PostTarkVitarkWorld, length: number) {
+When('the visitor enters a post with {int} characters', async function (this: PostTarkVitarkWorld, length: number) {
   this.latestPublishedText = buildText(length);
-  fireEvent.change(composerInput(this), { target: { value: this.latestPublishedText } });
+  fireEvent.change(await composerInput(this), { target: { value: this.latestPublishedText } });
 });
 
-When('the visitor enters valid multiline post text', function (this: PostTarkVitarkWorld) {
+When('the visitor enters valid multiline post text', async function (this: PostTarkVitarkWorld) {
   this.latestPublishedText = 'Line one has spaces\nLine two stays valid.';
-  fireEvent.change(composerInput(this), { target: { value: this.latestPublishedText } });
+  fireEvent.change(await composerInput(this), { target: { value: this.latestPublishedText } });
 });
 
 When('the visitor submits the post', async function (this: PostTarkVitarkWorld) {
@@ -187,13 +197,13 @@ When('the visitor submits the post', async function (this: PostTarkVitarkWorld) 
 
 When('the visitor publishes the post text {string}', async function (this: PostTarkVitarkWorld, text: string) {
   this.latestPublishedText = text;
-  fireEvent.change(composerInput(this), { target: { value: text } });
+  fireEvent.change(await composerInput(this), { target: { value: text } });
   await submitComposer(this);
 });
 
-Then('a validation error appears saying {string}', function (this: PostTarkVitarkWorld, message: string) {
+Then('a validation error appears saying {string}', async function (this: PostTarkVitarkWorld, message: string) {
   assert.equal(activeRender(this).getByRole('alert').textContent?.trim(), message);
-  assert.equal(composerInput(this).getAttribute('aria-invalid'), 'true');
+  assert.equal((await composerInput(this)).getAttribute('aria-invalid'), 'true');
 });
 
 Then('no new debate post is added', function (this: PostTarkVitarkWorld) {
@@ -220,8 +230,10 @@ Then('the latest debate post text is {string}', async function (this: PostTarkVi
 });
 
 Then('the composer input is cleared', async function (this: PostTarkVitarkWorld) {
+  const input = await composerInput(this);
+
   await waitFor(() => {
-    assert.equal(composerInput(this).value, '');
+    assert.equal(input.value, '');
   });
 });
 
@@ -239,7 +251,7 @@ Given('a publish is already in progress in the composer', async function (this: 
     })
   );
 
-  fireEvent.change(composerInput(this), { target: { value: 'This text has enough length.' } });
+  fireEvent.change(await composerInput(this), { target: { value: 'This text has enough length.' } });
   await submitComposer(this);
 
   await waitFor(() => {
@@ -247,13 +259,13 @@ Given('a publish is already in progress in the composer', async function (this: 
   });
 });
 
-When('the visitor attempts another publish while busy', function (this: PostTarkVitarkWorld) {
-  fireEvent.click(publishButton(this));
+When('the visitor attempts another publish while busy', async function (this: PostTarkVitarkWorld) {
+  fireEvent.click(await publishButton(this));
 });
 
-Then('the second publish attempt is blocked', function (this: PostTarkVitarkWorld) {
+Then('the second publish attempt is blocked', async function (this: PostTarkVitarkWorld) {
   assert.equal(this.publishCalls, 1);
-  assert.equal(publishButton(this).disabled, true);
+  assert.equal((await publishButton(this)).disabled, true);
 });
 
 When('the page is refreshed', function (this: PostTarkVitarkWorld) {

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -29,13 +29,22 @@ function toSideLabel(side: Side): string {
   return side === 'tark' ? 'Tark' : 'Vitark';
 }
 
-function ensureBottomSheetOpen(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
+function expandComposerOptions(world: PostTarkVitarkWorld): void {
+  const view = activeRender(world);
+  if (view.queryByRole('button', { name: 'Post as Tark' })) {
+    return;
+  }
+
+  fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
+}
+
+function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
   const view = activeRender(world);
 
   if (!view.queryByRole('dialog', { name: 'Post composer' })) {
-    fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
+    expandComposerOptions(world);
     fireEvent.click(
-      view.getByRole('button', {
+      activeRender(world).getByRole('button', {
         name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
       })
     );
@@ -57,7 +66,7 @@ function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
     return existingComposerInput as HTMLTextAreaElement;
   }
 
-  ensureBottomSheetOpen(world);
+  openBottomSheetForSide(world);
   return activeRender(world).getByRole('textbox', {
     name: 'Post text',
   }) as HTMLTextAreaElement;
@@ -72,7 +81,7 @@ function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
     return existingPublishButton as HTMLButtonElement;
   }
 
-  ensureBottomSheetOpen(world);
+  openBottomSheetForSide(world);
   return activeRender(world).getByRole('button', {
     name: 'Publish post',
   }) as HTMLButtonElement;
@@ -139,16 +148,17 @@ Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
   assert.equal(view.queryByLabelText(/image|media|upload/i), null);
 });
 
-Then('Tark is selected by default', function (this: PostTarkVitarkWorld) {
-  ensureBottomSheetOpen(this, 'tark');
+Then('Tark is selected by default', async function (this: PostTarkVitarkWorld) {
+  expandComposerOptions(this);
 
-  const chip = activeRender(this).getByRole('radio', { name: 'Tark' });
-  assert.ok(chip);
-  assert.equal(chip.getAttribute('aria-checked'), 'true');
+  await waitFor(() => {
+    const tarkOption = activeRender(this).getByRole('button', { name: 'Post as Tark' });
+    assert.equal(document.activeElement, tarkOption);
+  });
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  ensureBottomSheetOpen(this, 'vitark');
+  openBottomSheetForSide(this, 'vitark');
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {

--- a/features/support/jsdom-setup.mjs
+++ b/features/support/jsdom-setup.mjs
@@ -46,6 +46,20 @@ defineGlobalValue(
 );
 defineGlobalValue('IS_REACT_ACT_ENVIRONMENT', true);
 
+if (!win.requestAnimationFrame) {
+  Object.defineProperty(win, 'requestAnimationFrame', {
+    writable: true,
+    value: globalThis.requestAnimationFrame,
+  });
+}
+
+if (!win.cancelAnimationFrame) {
+  Object.defineProperty(win, 'cancelAnimationFrame', {
+    writable: true,
+    value: globalThis.cancelAnimationFrame,
+  });
+}
+
 if (!win.matchMedia) {
   Object.defineProperty(win, 'matchMedia', {
     writable: true,

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -4,7 +4,6 @@ import { DEBATE } from '../data/debate';
 import { Topic } from './Topic';
 import { LegendBar } from './LegendBar';
 import { Timeline } from './Timeline';
-import { Podium } from './Podium';
 import { PodiumFAB } from './PodiumFAB';
 import { PodiumBottomSheet } from './PodiumBottomSheet';
 import { ThemeToggle } from './ThemeToggle';
@@ -17,26 +16,6 @@ export function DebateScreen() {
     const [isSheetOpen, setIsSheetOpen] = useState(false);
     const ignoreNextSheetCloseRef = useRef(false);
     const clearIgnoreCloseAnimationFrameRef = useRef<number | null>(null);
-    const [isMobile, setIsMobile] = useState(
-        () => window.matchMedia('(max-width: 767px)').matches
-    );
-
-    useEffect(() => {
-        const mediaQuery = window.matchMedia('(max-width: 767px)');
-        const handleViewportChange = (event: MediaQueryListEvent) => {
-            setIsMobile(event.matches);
-
-            if (!event.matches) {
-                setIsFabExpanded(false);
-                setIsSheetOpen(false);
-            }
-        };
-
-        mediaQuery.addEventListener('change', handleViewportChange);
-        return () => {
-            mediaQuery.removeEventListener('change', handleViewportChange);
-        };
-    }, []);
 
     useEffect(() => {
         return () => {
@@ -66,50 +45,40 @@ export function DebateScreen() {
             </header>
             <LegendBar />
             <Timeline arguments={[...DEBATE.arguments, ...localPosts]} />
-            {isMobile ? (
-                <>
-                    <PodiumFAB
-                        isExpanded={isFabExpanded}
-                        onExpand={() => setIsFabExpanded(true)}
-                        onSideSelect={(side) => {
-                            setSelectedSide(side);
-                            setIsFabExpanded(false);
-                            ignoreNextSheetCloseRef.current = true;
+            <PodiumFAB
+                isExpanded={isFabExpanded}
+                onExpand={() => setIsFabExpanded(true)}
+                onSideSelect={(side) => {
+                    setSelectedSide(side);
+                    setIsFabExpanded(false);
+                    ignoreNextSheetCloseRef.current = true;
 
-                            if (clearIgnoreCloseAnimationFrameRef.current !== null) {
-                                window.cancelAnimationFrame(clearIgnoreCloseAnimationFrameRef.current);
-                            }
-                            clearIgnoreCloseAnimationFrameRef.current = window.requestAnimationFrame(() => {
-                                ignoreNextSheetCloseRef.current = false;
-                                clearIgnoreCloseAnimationFrameRef.current = null;
-                            });
+                    if (clearIgnoreCloseAnimationFrameRef.current !== null) {
+                        window.cancelAnimationFrame(clearIgnoreCloseAnimationFrameRef.current);
+                    }
+                    clearIgnoreCloseAnimationFrameRef.current = window.requestAnimationFrame(() => {
+                        ignoreNextSheetCloseRef.current = false;
+                        clearIgnoreCloseAnimationFrameRef.current = null;
+                    });
 
-                            setIsSheetOpen(true);
-                        }}
-                        onCollapse={() => setIsFabExpanded(false)}
-                    />
-                    <PodiumBottomSheet
-                        isOpen={isSheetOpen}
-                        selectedSide={selectedSide}
-                        onSideChange={setSelectedSide}
-                        onPublish={handlePublish}
-                        onClose={() => {
-                            if (ignoreNextSheetCloseRef.current) {
-                                ignoreNextSheetCloseRef.current = false;
-                                return;
-                            }
+                    setIsSheetOpen(true);
+                }}
+                onCollapse={() => setIsFabExpanded(false)}
+            />
+            <PodiumBottomSheet
+                isOpen={isSheetOpen}
+                selectedSide={selectedSide}
+                onSideChange={setSelectedSide}
+                onPublish={handlePublish}
+                onClose={() => {
+                    if (ignoreNextSheetCloseRef.current) {
+                        ignoreNextSheetCloseRef.current = false;
+                        return;
+                    }
 
-                            setIsSheetOpen(false);
-                        }}
-                    />
-                </>
-            ) : (
-                <Podium
-                    selectedSide={selectedSide}
-                    onSideChange={setSelectedSide}
-                    onPublish={handlePublish}
-                />
-            )}
+                    setIsSheetOpen(false);
+                }}
+            />
             <ThemeToggle />
         </main>
     );

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -16,10 +16,16 @@ const podiumCss = readFileSync(
 
 async function openComposerForSide(side: 'Post as Tark' | 'Post as Vitark') {
     fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-    const sideOption = screen.getByRole('button', { name: side });
+    let sideOption: HTMLElement | null = null;
     await waitFor(() => {
+        sideOption = screen.getByRole('button', { name: side });
         expect(sideOption).toBeEnabled();
     });
+
+    if (!sideOption) {
+        throw new Error(`Expected composer side option "${side}" to be available.`);
+    }
+
     fireEvent.click(sideOption);
 }
 

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -61,7 +61,7 @@ describe('DebateScreen', () => {
         expect(items).toHaveLength(DEBATE.arguments.length);
     });
 
-    it('defaults selected side to tark on mount', () => {
+    it('renders FAB composer entry on mount', () => {
         render(<DebateScreen />);
 
         expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -14,6 +14,15 @@ const podiumCss = readFileSync(
     'utf-8'
 );
 
+async function openComposerForSide(side: 'Post as Tark' | 'Post as Vitark') {
+    fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+    const sideOption = screen.getByRole('button', { name: side });
+    await waitFor(() => {
+        expect(sideOption).toBeEnabled();
+    });
+    fireEvent.click(sideOption);
+}
+
 describe('DebateScreen', () => {
     afterEach(() => {
         document.documentElement.removeAttribute('data-theme');
@@ -71,8 +80,7 @@ describe('DebateScreen', () => {
     it('appends a valid published post as the last timeline item', async () => {
         render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        await openComposerForSide('Post as Tark');
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'This post has enough length.' },
         });
@@ -88,8 +96,7 @@ describe('DebateScreen', () => {
     it('resets localPosts to empty after remount', async () => {
         const { unmount } = render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        await openComposerForSide('Post as Tark');
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'Session-only argument text.' },
         });
@@ -127,12 +134,10 @@ describe('DebateScreen', () => {
         expect(debateScreenCss).toContain('padding-bottom: var(--podium-height, 0px);');
     });
 
-    it('opens bottom sheet immediately with selected side after FAB side selection', () => {
+    it('opens bottom sheet immediately with selected side after FAB side selection', async () => {
         render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        const vitarkAction = screen.getByRole('button', { name: 'Post as Vitark' });
-        fireEvent.click(vitarkAction);
+        await openComposerForSide('Post as Vitark');
 
         expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute('aria-checked', 'true');

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import { DEBATE } from '../../src/data/debate';
@@ -13,88 +13,6 @@ const podiumCss = readFileSync(
     resolve(process.cwd(), 'src/styles/components/podium.css'),
     'utf-8'
 );
-
-type MediaQueryChangeListener = (event: MediaQueryListEvent) => void;
-
-interface MatchMediaController {
-    setIsMobile: (nextValue: boolean) => void;
-}
-
-interface MutableMediaQueryList extends MediaQueryList {
-    updateMatches: (nextValue: boolean) => void;
-}
-
-function createMediaQueryList(
-    media: string,
-    matches: boolean,
-    listeners?: Set<MediaQueryChangeListener>
-): MutableMediaQueryList {
-    let currentMatches = matches;
-
-    return {
-        get matches() {
-            return currentMatches;
-        },
-        set matches(nextValue: boolean) {
-            currentMatches = nextValue;
-        },
-        media,
-        onchange: null,
-        addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
-            if (typeof listener === 'function') {
-                listeners?.add(listener as MediaQueryChangeListener);
-            }
-        },
-        removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
-            if (typeof listener === 'function') {
-                listeners?.delete(listener as MediaQueryChangeListener);
-            }
-        },
-        addListener: (listener: MediaQueryChangeListener) => {
-            listeners?.add(listener);
-        },
-        removeListener: (listener: MediaQueryChangeListener) => {
-            listeners?.delete(listener);
-        },
-        dispatchEvent: () => true,
-        updateMatches(nextValue: boolean) {
-            currentMatches = nextValue;
-        },
-    } as MutableMediaQueryList;
-}
-
-function mockViewportQuery(isMobileAtMount: boolean): MatchMediaController {
-    const viewportListeners = new Set<MediaQueryChangeListener>();
-    const viewportQuery = '(max-width: 767px)';
-    const viewportMediaQueryList = createMediaQueryList(
-        viewportQuery,
-        isMobileAtMount,
-        viewportListeners
-    );
-
-    vi.stubGlobal('matchMedia', (query: string) => {
-        if (query === viewportQuery) {
-            return viewportMediaQueryList;
-        }
-
-        return createMediaQueryList(query, false);
-    });
-
-    return {
-        setIsMobile(nextValue: boolean) {
-            viewportMediaQueryList.updateMatches(nextValue);
-            const event = {
-                matches: nextValue,
-                media: viewportQuery,
-            } as MediaQueryListEvent;
-
-            viewportListeners.forEach((listener) => {
-                listener(event);
-            });
-            viewportMediaQueryList.onchange?.(event);
-        },
-    };
-}
 
 describe('DebateScreen', () => {
     afterEach(() => {
@@ -137,14 +55,6 @@ describe('DebateScreen', () => {
         expect(timeline).toBeInTheDocument();
     });
 
-    it('composes Podium controls', () => {
-        render(<DebateScreen />);
-
-        expect(screen.getByRole('switch', { name: 'Post as Tark' })).toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
-    });
-
     it('renders all arguments from DEBATE data', () => {
         render(<DebateScreen />);
         const items = screen.getAllByRole('listitem');
@@ -154,24 +64,15 @@ describe('DebateScreen', () => {
     it('defaults selected side to tark on mount', () => {
         render(<DebateScreen />);
 
-        const chip = screen.getByRole('switch', { name: 'Post as Tark' });
-        expect(chip).toBeInTheDocument();
-        expect(chip).toHaveAttribute('aria-checked', 'true');
-    });
-
-    it('passes side changes to Podium by updating selected side state', () => {
-        render(<DebateScreen />);
-
-        fireEvent.click(screen.getByRole('switch', { name: 'Post as Tark' }));
-
-        const chip = screen.getByRole('switch', { name: 'Post as Vitark' });
-        expect(chip).toBeInTheDocument();
-        expect(chip).toHaveAttribute('aria-checked', 'false');
+        expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();
+        expect(screen.queryByRole('switch', { name: 'Post as Tark' })).not.toBeInTheDocument();
     });
 
     it('appends a valid published post as the last timeline item', async () => {
         render(<DebateScreen />);
 
+        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'This post has enough length.' },
         });
@@ -187,6 +88,8 @@ describe('DebateScreen', () => {
     it('resets localPosts to empty after remount', async () => {
         const { unmount } = render(<DebateScreen />);
 
+        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'Session-only argument text.' },
         });
@@ -205,18 +108,6 @@ describe('DebateScreen', () => {
         expect(screen.queryByText('Session-only argument text.')).not.toBeInTheDocument();
     });
 
-    it('resets selected side to tark after remount', () => {
-        const { unmount } = render(<DebateScreen />);
-
-        fireEvent.click(screen.getByRole('switch', { name: 'Post as Tark' }));
-        expect(screen.getByRole('switch', { name: 'Post as Vitark' })).toHaveAttribute('aria-checked', 'false');
-
-        unmount();
-        render(<DebateScreen />);
-
-        expect(screen.getByRole('switch', { name: 'Post as Tark' })).toHaveAttribute('aria-checked', 'true');
-    });
-
     it('applies debate-screen CSS class to main element', () => {
         render(<DebateScreen />);
         const main = screen.getByRole('main');
@@ -227,7 +118,7 @@ describe('DebateScreen', () => {
         render(<DebateScreen />);
 
         expect(screen.getByRole('switch', { name: /dark mode/i })).toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();
     });
 
     it('uses shared podium height variable for debate screen clearance', () => {
@@ -236,17 +127,7 @@ describe('DebateScreen', () => {
         expect(debateScreenCss).toContain('padding-bottom: var(--podium-height, 0px);');
     });
 
-    it('renders mobile compose flow only when matchMedia reports mobile', () => {
-        mockViewportQuery(true);
-        render(<DebateScreen />);
-
-        expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();
-        expect(screen.queryByRole('switch', { name: 'Post as Tark' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
-    });
-
-    it('opens bottom sheet immediately with selected side after mobile FAB side selection', () => {
-        mockViewportQuery(true);
+    it('opens bottom sheet immediately with selected side after FAB side selection', () => {
         render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
@@ -255,23 +136,6 @@ describe('DebateScreen', () => {
 
         expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute('aria-checked', 'true');
-    });
-
-    it('resets FAB and sheet state on resize from mobile to desktop', () => {
-        const mediaController = mockViewportQuery(true);
-        render(<DebateScreen />);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
-        expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
-
-        act(() => {
-            mediaController.setIsMobile(false);
-        });
-
-        expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
     });
 
     it('scopes --podium-height to desktop media query and keeps mobile default at zero', () => {


### PR DESCRIPTION
Closes #177

## Implementation Summary
- Removed `isMobile` state and the viewport listener effect from `DebateScreen`.
- Removed `Podium` composition from `DebateScreen` and rendered `PodiumFAB` + `PodiumBottomSheet` unconditionally across viewports.
- Reworked `DebateScreen` unit tests to the FAB + BottomSheet flow and removed viewport mocking scaffold/types tied to `isMobile`.
- Updated post-publish BDD step definitions to drive FAB-first composer interactions safely (including requestAnimationFrame-gated option readiness).
- Updated cucumber jsdom setup so `window.requestAnimationFrame` / `window.cancelAnimationFrame` are always available.

## Files Changed
- `src/components/DebateScreen.tsx` — removed `isMobile` conditional path and viewport listener; always render FAB + BottomSheet.
- `tests/components/DebateScreen.test.tsx` — deleted/reworked tests listed in issue #177, removed viewport helper scaffold, and hardened FAB-side selection timing in helper flow.
- `features/step-definitions/post-tark-vitark.steps.ts` — aligned compose/publish BDD interactions with FAB → BottomSheet flow and awaited side-option readiness.
- `features/support/jsdom-setup.mjs` — ensured `window.requestAnimationFrame` and `window.cancelAnimationFrame` exist in cucumber jsdom runtime.

## Verification Evidence
- `npm test` ✅
- `npm run test:bdd` ✅
- `npm run build` ✅

### Figma Traceability
| Frame / Node | Extracted requirement | Code location | Status |
|---|---|---|---|
| `801:459` (Mobile Light) | FAB entry point present in mobile layout | `src/components/DebateScreen.tsx` | exact |
| `786:427` (Tablet Light) | FAB entry point present in tablet layout | `src/components/DebateScreen.tsx` | exact |
| `786:811` (Desktop Light) | FAB entry point present in desktop layout | `src/components/DebateScreen.tsx` | exact |

### Visual Validation Evidence
- Browser checks were run at mobile (390x844), tablet (768x1024), and desktop (1280x800) in both Light and Dark themes.
- Figma references reviewed via node screenshots: `801:459`, `801:500`, `786:427`, `786:715`, `786:811`, `786:1099`.
- Parity verdict for this task scope (FAB presence + compose entry flow): **exact match**.

## BDD Evidence
### Scenario Catalog (Issue #177 AC mapping)
- AC-27: Existing mobile debate behavior preserved with FAB composer entry.
- AC-29: Tablet FAB + BottomSheet render path available.
- AC-30: Desktop FAB + BottomSheet render path available.

### Scenario-to-Test Mapping
- `tests/components/DebateScreen.test.tsx`
  - `renders FAB composer entry on mount` → AC-27/29/30
  - `appends a valid published post as the last timeline item` → AC-27/29/30
  - `resets localPosts to empty after remount` → AC-27/29/30
  - `opens bottom sheet immediately with selected side after FAB side selection` → AC-29/30
- `features/post-tark-vitark.feature` + `features/step-definitions/post-tark-vitark.steps.ts`
  - Existing post/publish acceptance journeys remain green with FAB + BottomSheet interaction model.

## Runtime QA Handoff Package
- **Journey map:** Debate screen load → open composer FAB → pick side → publish post → verify timeline append/reset behavior.
- **Routes:** `/` (Debate Screen).
- **Setup / test data:** Existing `DEBATE` seed data; no additional fixtures.
- **Expected states:** FAB visible in all breakpoints; bottom sheet opens on side select; publish writes to timeline.
- **Known-risk notes:** Cucumber runtime emits non-blocking React `act(...)` warnings during asynchronous state updates in bottom-sheet interactions.

## Residual Risk and Rollback
- Residual risk: low; main behavior change is intentionally removing desktop/tablet inline Podium path.
- Rollback: revert commits on this PR branch (latest `080bb6b`).

## Agent Provenance
run-id: e1c8e3c0-9f6f-4f0c-bfa4-3ad9f9a69ebd
task-id: #177
role: dev
dispatched: 2026-04-21T04:25:51.203Z
model: gpt-5.3-codex