### PR TITLE
[podium-responsive-layout] Task F — BDD feature file + unit tests

### DIFF
--- a/features/podium-responsive-layout.feature
+++ b/features/podium-responsive-layout.feature
@@ -31,14 +31,14 @@ Feature: Podium responsive layout
     And AC-28 the legend bar 481px comment no longer says tablet and above
     And AC-28 the argument card 481px comment is reclassified as mobile-internal
 
-  Scenario: AC-29 Figma tablet values are wired in responsive CSS
+  Scenario: AC-29 tablet-tier podium layout values match the Figma specification
     Given the podium responsive stylesheet sources are loaded
-    Then AC-29 Figma tablet FAB values are wired in responsive CSS
-    And AC-29 Figma tablet sheet width value is wired in responsive CSS
-    And AC-29 Figma tablet dark scrim value is wired in responsive CSS
+    Then AC-29 tablet-tier podium FAB spacing matches the Figma specification
+    And AC-29 tablet-tier podium sheet width matches the Figma specification
+    And AC-29 tablet-tier podium dark scrim matches the Figma specification
 
-  Scenario: AC-30 Figma desktop values are wired in responsive CSS
+  Scenario: AC-30 desktop-tier podium layout values match the Figma specification
     Given the podium responsive stylesheet sources are loaded
-    Then AC-30 Figma desktop FAB values are wired in responsive CSS
-    And AC-30 Figma desktop sheet width value is wired in responsive CSS
-    And AC-30 Figma desktop scrim values are wired in responsive CSS
+    Then AC-30 desktop-tier podium FAB spacing matches the Figma specification
+    And AC-30 desktop-tier podium sheet width matches the Figma specification
+    And AC-30 desktop-tier podium scrim opacity matches the Figma specification

--- a/features/podium-responsive-layout.feature
+++ b/features/podium-responsive-layout.feature
@@ -5,24 +5,40 @@ Feature: Podium responsive layout
 
   Scenario: AC-25 tablet-tier podium layout values are present
     Given the podium responsive stylesheet sources are loaded
-    Then AC-25 tablet-tier podium layout values are present
+    Then AC-25 tablet-tier podium FAB spacing values are present
+    And AC-25 tablet-tier podium sheet width value is present
+    And AC-25 tablet-tier podium dark scrim values are present
 
   Scenario: AC-26 desktop-tier podium layout values are present
     Given the podium responsive stylesheet sources are loaded
-    Then AC-26 desktop-tier podium layout values are present
+    Then AC-26 desktop-tier podium FAB spacing values are present
+    And AC-26 desktop-tier podium sheet width value is present
+    And AC-26 desktop-tier podium scrim values are present
 
   Scenario: AC-27 mobile-tier podium behavior remains frozen
     Given the podium responsive stylesheet sources are loaded
-    Then AC-27 mobile-tier podium baseline values remain unchanged
+    Then AC-27 mobile-tier podium FAB baseline spacing remains unchanged
+    And AC-27 mobile-tier podium sheet width baseline remains unchanged
+    And AC-27 mobile-tier podium scrim baseline remains unchanged
 
   Scenario: AC-28 481px comments are reclassified as mobile-internal
     Given the podium responsive stylesheet sources are loaded
-    Then AC-28 the 481px comments are reclassified as mobile-internal
+    Then AC-28 the timeline 481px comment is reclassified as mobile-internal
+    And AC-28 the timeline 481px comment no longer uses tablet wording
+    And AC-28 the debate screen 481px comment is reclassified as mobile-internal
+    And AC-28 the debate screen 481px comment no longer uses the tablet divider
+    And AC-28 the legend bar 481px comment is reclassified as mobile-internal
+    And AC-28 the legend bar 481px comment no longer says tablet and above
+    And AC-28 the argument card 481px comment is reclassified as mobile-internal
 
   Scenario: AC-29 Figma tablet values are wired in responsive CSS
     Given the podium responsive stylesheet sources are loaded
-    Then AC-29 Figma tablet values are wired in responsive CSS
+    Then AC-29 Figma tablet FAB values are wired in responsive CSS
+    And AC-29 Figma tablet sheet width value is wired in responsive CSS
+    And AC-29 Figma tablet dark scrim value is wired in responsive CSS
 
   Scenario: AC-30 Figma desktop values are wired in responsive CSS
     Given the podium responsive stylesheet sources are loaded
-    Then AC-30 Figma desktop values are wired in responsive CSS
+    Then AC-30 Figma desktop FAB values are wired in responsive CSS
+    And AC-30 Figma desktop sheet width value is wired in responsive CSS
+    And AC-30 Figma desktop scrim values are wired in responsive CSS

--- a/features/podium-responsive-layout.feature
+++ b/features/podium-responsive-layout.feature
@@ -1,0 +1,28 @@
+Feature: Podium responsive layout
+  As a debate visitor
+  I want podium controls to follow mobile, tablet, and desktop responsive layout values
+  So that posting interactions stay consistent across viewport tiers
+
+  Scenario: AC-25 tablet-tier podium layout values are present
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-25 tablet-tier podium layout values are present
+
+  Scenario: AC-26 desktop-tier podium layout values are present
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-26 desktop-tier podium layout values are present
+
+  Scenario: AC-27 mobile-tier podium behavior remains frozen
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-27 mobile-tier podium baseline values remain unchanged
+
+  Scenario: AC-28 481px comments are reclassified as mobile-internal
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-28 the 481px comments are reclassified as mobile-internal
+
+  Scenario: AC-29 Figma tablet values are wired in responsive CSS
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-29 Figma tablet values are wired in responsive CSS
+
+  Scenario: AC-30 Figma desktop values are wired in responsive CSS
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-30 Figma desktop values are wired in responsive CSS

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -1,0 +1,141 @@
+import { Given, Then } from '@cucumber/cucumber';
+import * as assert from 'assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface PodiumResponsiveStyles {
+  argumentCardCss: string;
+  debateScreenCss: string;
+  legendBarCss: string;
+  podiumBottomSheetCss: string;
+  podiumFabCss: string;
+  timelineCss: string;
+}
+
+let podiumResponsiveStyles: PodiumResponsiveStyles | null = null;
+
+function activeStyles(): PodiumResponsiveStyles {
+  assert.ok(
+    podiumResponsiveStyles,
+    'Expected podium responsive stylesheet sources to be loaded.'
+  );
+  return podiumResponsiveStyles;
+}
+
+function mediaBlock(css: string, mediaQuery: string): string {
+  const startIndex = css.indexOf(mediaQuery);
+  assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" to be present.`);
+  const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
+  return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
+Given('the podium responsive stylesheet sources are loaded', function () {
+  podiumResponsiveStyles = {
+    argumentCardCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/argument-card.css'),
+      'utf-8'
+    ),
+    debateScreenCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/debate-screen.css'),
+      'utf-8'
+    ),
+    legendBarCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/legend-bar.css'),
+      'utf-8'
+    ),
+    podiumBottomSheetCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
+      'utf-8'
+    ),
+    podiumFabCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
+      'utf-8'
+    ),
+    timelineCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/timeline.css'),
+      'utf-8'
+    ),
+  };
+});
+
+Then('AC-25 tablet-tier podium layout values are present', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+  const tabletDarkScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 768px) and (max-width: 1023px)'
+  );
+
+  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
+  assert.ok(tabletDarkScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
+  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
+});
+
+Then('AC-26 desktop-tier podium layout values are present', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+  assert.ok(desktopFabBlock.includes('var(--space-12)'));
+  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
+  assert.ok(podiumBottomSheetCss.includes('.podium-sheet-scrim'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+});
+
+Then('AC-27 mobile-tier podium baseline values remain unchanged', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  assert.ok(podiumFabCss.includes('right: var(--space-4);'));
+  assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
+  assert.ok(podiumBottomSheetCss.includes('max-width: 390px;'));
+  assert.ok(podiumBottomSheetCss.includes('background: var(--color-scrim);'));
+});
+
+Then('AC-28 the 481px comments are reclassified as mobile-internal', function () {
+  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles();
+
+  assert.ok(
+    timelineCss.includes('mobile-internal layout adjustment (≥481px) — not a design tier')
+  );
+  assert.equal(timelineCss.includes('Tablet (\u2265481px)'), false);
+
+  assert.ok(debateScreenCss.includes('mobile-internal (≥481px) — not a design tier'));
+  assert.equal(debateScreenCss.includes('/* ── Tablet ── */'), false);
+
+  assert.ok(legendBarCss.includes('mobile-internal (≥481px) — not a design tier'));
+  assert.equal(legendBarCss.includes('Tablet and above'), false);
+
+  assert.ok(argumentCardCss.includes('mobile-internal (≥481px) — not a design tier'));
+});
+
+Then('AC-29 Figma tablet values are wired in responsive CSS', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+  const tabletDarkScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 768px) and (max-width: 1023px)'
+  );
+
+  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
+  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
+});
+
+Then('AC-30 Figma desktop values are wired in responsive CSS', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+  assert.ok(desktopFabBlock.includes('var(--space-12)'));
+  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+});

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -1,4 +1,4 @@
-import { Given, Then } from '@cucumber/cucumber';
+import { After, Before, Given, Then, World } from '@cucumber/cucumber';
 import * as assert from 'assert';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -12,25 +12,42 @@ interface PodiumResponsiveStyles {
   timelineCss: string;
 }
 
-let podiumResponsiveStyles: PodiumResponsiveStyles | null = null;
+type PodiumResponsiveLayoutWorld = World & {
+  podiumResponsiveStyles?: PodiumResponsiveStyles;
+};
 
-function activeStyles(): PodiumResponsiveStyles {
+function activeStyles(world: PodiumResponsiveLayoutWorld): PodiumResponsiveStyles {
   assert.ok(
-    podiumResponsiveStyles,
+    world.podiumResponsiveStyles,
     'Expected podium responsive stylesheet sources to be loaded.'
   );
-  return podiumResponsiveStyles;
+  return world.podiumResponsiveStyles;
 }
 
-function mediaBlock(css: string, mediaQuery: string): string {
-  const startIndex = css.indexOf(mediaQuery);
-  assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" to be present.`);
+function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+  let startIndex = -1;
+  let searchFrom = 0;
+
+  for (let count = 0; count < occurrence; count += 1) {
+    startIndex = css.indexOf(mediaQuery, searchFrom);
+    assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" occurrence ${occurrence} to be present.`);
+    searchFrom = startIndex + mediaQuery.length;
+  }
+
   const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
   return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
 }
 
-Given('the podium responsive stylesheet sources are loaded', function () {
-  podiumResponsiveStyles = {
+Before(function (this: PodiumResponsiveLayoutWorld) {
+  this.podiumResponsiveStyles = undefined;
+});
+
+After(function (this: PodiumResponsiveLayoutWorld) {
+  this.podiumResponsiveStyles = undefined;
+});
+
+Given('the podium responsive stylesheet sources are loaded', function (this: PodiumResponsiveLayoutWorld) {
+  this.podiumResponsiveStyles = {
     argumentCardCss: readFileSync(
       resolve(process.cwd(), 'src/styles/components/argument-card.css'),
       'utf-8'
@@ -58,8 +75,8 @@ Given('the podium responsive stylesheet sources are loaded', function () {
   };
 });
 
-Then('AC-25 tablet-tier podium layout values are present', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-25 tablet-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
   const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
@@ -68,27 +85,51 @@ Then('AC-25 tablet-tier podium layout values are present', function () {
     '@media (min-width: 768px) and (max-width: 1023px)'
   );
 
-  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.match(
+    tabletFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
+  assert.match(
+    tabletFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
   assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
   assert.ok(tabletDarkScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
   assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
 });
 
-Then('AC-26 desktop-tier podium layout values are present', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-26 desktop-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+  const desktopSheetWidthBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    1
+  );
+  const desktopScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    2
+  );
 
-  assert.ok(desktopFabBlock.includes('var(--space-12)'));
-  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
-  assert.ok(podiumBottomSheetCss.includes('.podium-sheet-scrim'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+  assert.match(
+    desktopFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.match(
+    desktopFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
+  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
 });
 
-Then('AC-27 mobile-tier podium baseline values remain unchanged', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-27 mobile-tier podium baseline values remain unchanged', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   assert.ok(podiumFabCss.includes('right: var(--space-4);'));
   assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
@@ -96,8 +137,8 @@ Then('AC-27 mobile-tier podium baseline values remain unchanged', function () {
   assert.ok(podiumBottomSheetCss.includes('background: var(--color-scrim);'));
 });
 
-Then('AC-28 the 481px comments are reclassified as mobile-internal', function () {
-  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles();
+Then('AC-28 the 481px comments are reclassified as mobile-internal', function (this: PodiumResponsiveLayoutWorld) {
+  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles(this);
 
   assert.ok(
     timelineCss.includes('mobile-internal layout adjustment (≥481px) — not a design tier')
@@ -113,8 +154,8 @@ Then('AC-28 the 481px comments are reclassified as mobile-internal', function ()
   assert.ok(argumentCardCss.includes('mobile-internal (≥481px) — not a design tier'));
 });
 
-Then('AC-29 Figma tablet values are wired in responsive CSS', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-29 Figma tablet values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
   const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
@@ -123,19 +164,44 @@ Then('AC-29 Figma tablet values are wired in responsive CSS', function () {
     '@media (min-width: 768px) and (max-width: 1023px)'
   );
 
-  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.match(
+    tabletFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
+  assert.match(
+    tabletFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
   assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
   assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
 });
 
-Then('AC-30 Figma desktop values are wired in responsive CSS', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-30 Figma desktop values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+  const desktopSheetWidthBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    1
+  );
+  const desktopScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    2
+  );
 
-  assert.ok(desktopFabBlock.includes('var(--space-12)'));
-  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+  assert.match(
+    desktopFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.match(
+    desktopFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
+  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
 });

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -162,10 +162,14 @@ Then(
   'AC-26 desktop-tier podium scrim values are present',
   function (this: PodiumResponsiveLayoutWorld) {
     const desktopScrimStyles = desktopScrimBlock(this);
-    assert.ok(desktopScrimStyles.includes('.podium-sheet-scrim'));
-    assert.ok(desktopScrimStyles.includes('[data-theme="dark"] .podium-sheet-scrim'));
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+    assert.match(
+      desktopScrimStyles,
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    assert.match(
+      desktopScrimStyles,
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   }
 );
 
@@ -252,7 +256,7 @@ Then(
 );
 
 Then(
-  'AC-29 Figma tablet FAB values are wired in responsive CSS',
+  'AC-29 tablet-tier podium FAB spacing matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const tabletFabStyles = tabletFabBlock(this);
     assert.match(
@@ -267,14 +271,14 @@ Then(
 );
 
 Then(
-  'AC-29 Figma tablet sheet width value is wired in responsive CSS',
+  'AC-29 tablet-tier podium sheet width matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     assert.ok(tabletSheetWidthBlock(this).includes('max-width: 600px;'));
   }
 );
 
 Then(
-  'AC-29 Figma tablet dark scrim value is wired in responsive CSS',
+  'AC-29 tablet-tier podium dark scrim matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const tabletDarkScrimStyles = tabletDarkScrimBlock(this);
     assert.ok(tabletDarkScrimStyles.includes('rgba(0, 0, 0, 0.48)'));
@@ -282,7 +286,7 @@ Then(
 );
 
 Then(
-  'AC-30 Figma desktop FAB values are wired in responsive CSS',
+  'AC-30 desktop-tier podium FAB spacing matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const desktopFabStyles = desktopFabBlock(this);
     assert.match(
@@ -297,17 +301,23 @@ Then(
 );
 
 Then(
-  'AC-30 Figma desktop sheet width value is wired in responsive CSS',
+  'AC-30 desktop-tier podium sheet width matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     assert.ok(desktopSheetWidthBlock(this).includes('max-width: 720px;'));
   }
 );
 
 Then(
-  'AC-30 Figma desktop scrim values are wired in responsive CSS',
+  'AC-30 desktop-tier podium scrim opacity matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const desktopScrimStyles = desktopScrimBlock(this);
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+    assert.match(
+      desktopScrimStyles,
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    assert.match(
+      desktopScrimStyles,
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   }
 );

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -30,12 +30,42 @@ function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
 
   for (let count = 0; count < occurrence; count += 1) {
     startIndex = css.indexOf(mediaQuery, searchFrom);
-    assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" occurrence ${occurrence} to be present.`);
+    assert.ok(
+      startIndex >= 0,
+      `Expected media query "${mediaQuery}" occurrence ${count + 1} to be present; found ${count} occurrence${count === 1 ? '' : 's'}.`
+    );
     searchFrom = startIndex + mediaQuery.length;
   }
 
   const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
   return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
+function tabletFabBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumFabCss, '@media (min-width: 768px)');
+}
+
+function desktopFabBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumFabCss, '@media (min-width: 1024px)');
+}
+
+function tabletSheetWidthBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumBottomSheetCss, '@media (min-width: 768px)', 1);
+}
+
+function desktopSheetWidthBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumBottomSheetCss, '@media (min-width: 1024px)', 1);
+}
+
+function tabletDarkScrimBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(
+    activeStyles(world).podiumBottomSheetCss,
+    '@media (min-width: 768px) and (max-width: 1023px)'
+  );
+}
+
+function desktopScrimBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumBottomSheetCss, '@media (min-width: 1024px)', 2);
 }
 
 Before(function (this: PodiumResponsiveLayoutWorld) {
@@ -75,133 +105,209 @@ Given('the podium responsive stylesheet sources are loaded', function (this: Pod
   };
 });
 
-Then('AC-25 tablet-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-25 tablet-tier podium FAB spacing values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletFabStyles = tabletFabBlock(this);
+    assert.match(
+      tabletFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    assert.match(
+      tabletFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+  }
+);
 
-  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
-  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
-  const tabletDarkScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 768px) and (max-width: 1023px)'
-  );
+Then(
+  'AC-25 tablet-tier podium sheet width value is present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(tabletSheetWidthBlock(this).includes('max-width: 600px;'));
+  }
+);
 
-  assert.match(
-    tabletFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.match(
-    tabletFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
-  assert.ok(tabletDarkScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
-  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
-});
+Then(
+  'AC-25 tablet-tier podium dark scrim values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletDarkScrimStyles = tabletDarkScrimBlock(this);
+    assert.ok(tabletDarkScrimStyles.includes('[data-theme="dark"] .podium-sheet-scrim'));
+    assert.ok(tabletDarkScrimStyles.includes('rgba(0, 0, 0, 0.48)'));
+  }
+);
 
-Then('AC-26 desktop-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-26 desktop-tier podium FAB spacing values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopFabStyles = desktopFabBlock(this);
+    assert.match(
+      desktopFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    assert.match(
+      desktopFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+  }
+);
 
-  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetWidthBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    1
-  );
-  const desktopScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    2
-  );
+Then(
+  'AC-26 desktop-tier podium sheet width value is present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(desktopSheetWidthBlock(this).includes('max-width: 720px;'));
+  }
+);
 
-  assert.match(
-    desktopFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.match(
-    desktopFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
-  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
-});
+Then(
+  'AC-26 desktop-tier podium scrim values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopScrimStyles = desktopScrimBlock(this);
+    assert.ok(desktopScrimStyles.includes('.podium-sheet-scrim'));
+    assert.ok(desktopScrimStyles.includes('[data-theme="dark"] .podium-sheet-scrim'));
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+  }
+);
 
-Then('AC-27 mobile-tier podium baseline values remain unchanged', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-27 mobile-tier podium FAB baseline spacing remains unchanged',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const { podiumFabCss } = activeStyles(this);
+    assert.ok(podiumFabCss.includes('right: var(--space-4);'));
+    assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
+  }
+);
 
-  assert.ok(podiumFabCss.includes('right: var(--space-4);'));
-  assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
-  assert.ok(podiumBottomSheetCss.includes('max-width: 390px;'));
-  assert.ok(podiumBottomSheetCss.includes('background: var(--color-scrim);'));
-});
+Then(
+  'AC-27 mobile-tier podium sheet width baseline remains unchanged',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(activeStyles(this).podiumBottomSheetCss.includes('max-width: 390px;'));
+  }
+);
 
-Then('AC-28 the 481px comments are reclassified as mobile-internal', function (this: PodiumResponsiveLayoutWorld) {
-  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles(this);
+Then(
+  'AC-27 mobile-tier podium scrim baseline remains unchanged',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(activeStyles(this).podiumBottomSheetCss.includes('background: var(--color-scrim);'));
+  }
+);
 
-  assert.ok(
-    timelineCss.includes('mobile-internal layout adjustment (≥481px) — not a design tier')
-  );
-  assert.equal(timelineCss.includes('Tablet (\u2265481px)'), false);
+Then(
+  'AC-28 the timeline 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).timelineCss.includes(
+        'mobile-internal layout adjustment (≥481px) — not a design tier'
+      )
+    );
+  }
+);
 
-  assert.ok(debateScreenCss.includes('mobile-internal (≥481px) — not a design tier'));
-  assert.equal(debateScreenCss.includes('/* ── Tablet ── */'), false);
+Then(
+  'AC-28 the timeline 481px comment no longer uses tablet wording',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.equal(activeStyles(this).timelineCss.includes('Tablet (\u2265481px)'), false);
+  }
+);
 
-  assert.ok(legendBarCss.includes('mobile-internal (≥481px) — not a design tier'));
-  assert.equal(legendBarCss.includes('Tablet and above'), false);
+Then(
+  'AC-28 the debate screen 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).debateScreenCss.includes('mobile-internal (≥481px) — not a design tier')
+    );
+  }
+);
 
-  assert.ok(argumentCardCss.includes('mobile-internal (≥481px) — not a design tier'));
-});
+Then(
+  'AC-28 the debate screen 481px comment no longer uses the tablet divider',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.equal(activeStyles(this).debateScreenCss.includes('/* ── Tablet ── */'), false);
+  }
+);
 
-Then('AC-29 Figma tablet values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-28 the legend bar 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).legendBarCss.includes('mobile-internal (≥481px) — not a design tier')
+    );
+  }
+);
 
-  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
-  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
-  const tabletDarkScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 768px) and (max-width: 1023px)'
-  );
+Then(
+  'AC-28 the legend bar 481px comment no longer says tablet and above',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.equal(activeStyles(this).legendBarCss.includes('Tablet and above'), false);
+  }
+);
 
-  assert.match(
-    tabletFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.match(
-    tabletFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
-  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
-});
+Then(
+  'AC-28 the argument card 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).argumentCardCss.includes('mobile-internal (≥481px) — not a design tier')
+    );
+  }
+);
 
-Then('AC-30 Figma desktop values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-29 Figma tablet FAB values are wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletFabStyles = tabletFabBlock(this);
+    assert.match(
+      tabletFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    assert.match(
+      tabletFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+  }
+);
 
-  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetWidthBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    1
-  );
-  const desktopScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    2
-  );
+Then(
+  'AC-29 Figma tablet sheet width value is wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(tabletSheetWidthBlock(this).includes('max-width: 600px;'));
+  }
+);
 
-  assert.match(
-    desktopFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.match(
-    desktopFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
-  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
-});
+Then(
+  'AC-29 Figma tablet dark scrim value is wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletDarkScrimStyles = tabletDarkScrimBlock(this);
+    assert.ok(tabletDarkScrimStyles.includes('rgba(0, 0, 0, 0.48)'));
+  }
+);
+
+Then(
+  'AC-30 Figma desktop FAB values are wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopFabStyles = desktopFabBlock(this);
+    assert.match(
+      desktopFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    assert.match(
+      desktopFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+  }
+);
+
+Then(
+  'AC-30 Figma desktop sheet width value is wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(desktopSheetWidthBlock(this).includes('max-width: 720px;'));
+  }
+);
+
+Then(
+  'AC-30 Figma desktop scrim values are wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopScrimStyles = desktopScrimBlock(this);
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+  }
+);

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -27,9 +27,16 @@ const argumentCardCss = readFileSync(
   'utf-8'
 );
 
-function mediaBlock(css: string, mediaQuery: string): string {
-  const startIndex = css.indexOf(mediaQuery);
-  expect(startIndex).toBeGreaterThan(-1);
+function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+  let startIndex = -1;
+  let searchFrom = 0;
+
+  for (let count = 0; count < occurrence; count += 1) {
+    startIndex = css.indexOf(mediaQuery, searchFrom);
+    expect(startIndex).toBeGreaterThan(-1);
+    searchFrom = startIndex + mediaQuery.length;
+  }
+
   const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
   return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
 }
@@ -43,7 +50,12 @@ describe('podium responsive layout', () => {
       '@media (min-width: 768px) and (max-width: 1023px)'
     );
 
-    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    expect(tabletFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
     expect(tabletSheetBlock).toContain('max-width: 600px;');
     expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
     expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
@@ -51,13 +63,28 @@ describe('podium responsive layout', () => {
 
   it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
     const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+    const desktopSheetWidthBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      1
+    );
+    const desktopScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      2
+    );
 
-    expect(desktopFabBlock).toContain('var(--space-12)');
-    expect(desktopSheetBlock).toContain('max-width: 720px;');
-    expect(podiumBottomSheetCss).toContain('.podium-sheet-scrim');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
+    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
   });
 
   it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
@@ -88,18 +115,39 @@ describe('podium responsive layout', () => {
       '@media (min-width: 768px) and (max-width: 1023px)'
     );
 
-    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    expect(tabletFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
     expect(tabletSheetBlock).toContain('max-width: 600px;');
     expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
   });
 
   it('AC-30 Scenario: Figma desktop values are wired in responsive CSS', () => {
     const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+    const desktopSheetWidthBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      1
+    );
+    const desktopScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      2
+    );
 
-    expect(desktopFabBlock).toContain('var(--space-12)');
-    expect(desktopSheetBlock).toContain('max-width: 720px;');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
+    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
   });
 });

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -81,10 +81,12 @@ describe('podium responsive layout', () => {
       /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
     );
     expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
-    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopScrimBlock).toMatch(
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    expect(desktopScrimBlock).toMatch(
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   });
 
   it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
@@ -107,7 +109,7 @@ describe('podium responsive layout', () => {
     expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
   });
 
-  it('AC-29 Scenario: Figma tablet values are wired in responsive CSS', () => {
+  it('AC-29 Scenario: tablet-tier podium layout values match the Figma specification', () => {
     const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
     const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
     const tabletDarkScrimBlock = mediaBlock(
@@ -125,7 +127,7 @@ describe('podium responsive layout', () => {
     expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
   });
 
-  it('AC-30 Scenario: Figma desktop values are wired in responsive CSS', () => {
+  it('AC-30 Scenario: desktop-tier podium layout values match the Figma specification', () => {
     const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
     const desktopSheetWidthBlock = mediaBlock(
       podiumBottomSheetCss,
@@ -145,9 +147,11 @@ describe('podium responsive layout', () => {
       /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
     );
     expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
-    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopScrimBlock).toMatch(
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    expect(desktopScrimBlock).toMatch(
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   });
 });

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const podiumFabCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
+  'utf-8'
+);
+const podiumBottomSheetCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
+  'utf-8'
+);
+const timelineCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/timeline.css'),
+  'utf-8'
+);
+const debateScreenCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/debate-screen.css'),
+  'utf-8'
+);
+const legendBarCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/legend-bar.css'),
+  'utf-8'
+);
+const argumentCardCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/argument-card.css'),
+  'utf-8'
+);
+
+function mediaBlock(css: string, mediaQuery: string): string {
+  const startIndex = css.indexOf(mediaQuery);
+  expect(startIndex).toBeGreaterThan(-1);
+  const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
+  return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
+describe('podium responsive layout', () => {
+  it('AC-25 Scenario: tablet-tier podium layout values are present', () => {
+    const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+    const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+    const tabletDarkScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 768px) and (max-width: 1023px)'
+    );
+
+    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletSheetBlock).toContain('max-width: 600px;');
+    expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+    expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+  });
+
+  it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
+    const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+    expect(desktopFabBlock).toContain('var(--space-12)');
+    expect(desktopSheetBlock).toContain('max-width: 720px;');
+    expect(podiumBottomSheetCss).toContain('.podium-sheet-scrim');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+  });
+
+  it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
+    expect(podiumFabCss).toContain('right: var(--space-4);');
+    expect(podiumFabCss).toContain('bottom: var(--space-4);');
+    expect(podiumBottomSheetCss).toContain('max-width: 390px;');
+    expect(podiumBottomSheetCss).toContain('background: var(--color-scrim);');
+  });
+
+  it('AC-28 Scenario: 481px comments are reclassified as mobile-internal', () => {
+    expect(timelineCss).toContain('mobile-internal layout adjustment (≥481px) — not a design tier');
+    expect(timelineCss).not.toContain('Tablet (\u2265481px)');
+
+    expect(debateScreenCss).toContain('mobile-internal (≥481px) — not a design tier');
+    expect(debateScreenCss).not.toContain('/* ── Tablet ── */');
+
+    expect(legendBarCss).toContain('mobile-internal (≥481px) — not a design tier');
+    expect(legendBarCss).not.toContain('Tablet and above');
+
+    expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
+  });
+
+  it('AC-29 Scenario: Figma tablet values are wired in responsive CSS', () => {
+    const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+    const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+    const tabletDarkScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 768px) and (max-width: 1023px)'
+    );
+
+    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletSheetBlock).toContain('max-width: 600px;');
+    expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+  });
+
+  it('AC-30 Scenario: Figma desktop values are wired in responsive CSS', () => {
+    const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+    expect(desktopFabBlock).toContain('var(--space-12)');
+    expect(desktopSheetBlock).toContain('max-width: 720px;');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #182 by adding dedicated BDD and vitest coverage for AC-25 through AC-30 in the podium responsive layout slice.

Closes #182.

## Files Changed
- `features/podium-responsive-layout.feature` — adds six scenarios, one per AC (AC-25..AC-30).
- `features/step-definitions/podium-responsive-layout.steps.ts` — adds step definitions that assert responsive CSS source values for tablet, desktop, mobile freeze, and 481px comment reclassification.
- `tests/components/podium-responsive-layout.test.ts` — adds six unit tests with file-content assertions mapped to AC-25..AC-30.

## Verification
- `npm test`
- `npm run test:bdd`
- `npm run build`

## BDD Traceability
| AC | Scenario | Unit test |
|---|---|---|
| AC-25 | `AC-25 tablet-tier podium layout values are present` | `AC-25 Scenario: tablet-tier podium layout values are present` |
| AC-26 | `AC-26 desktop-tier podium layout values are present` | `AC-26 Scenario: desktop-tier podium layout values are present` |
| AC-27 | `AC-27 mobile-tier podium behavior remains frozen` | `AC-27 Scenario: mobile-tier podium behavior remains frozen` |
| AC-28 | `AC-28 481px comments are reclassified as mobile-internal` | `AC-28 Scenario: 481px comments are reclassified as mobile-internal` |
| AC-29 | `AC-29 Figma tablet values are wired in responsive CSS` | `AC-29 Scenario: Figma tablet values are wired in responsive CSS` |
| AC-30 | `AC-30 Figma desktop values are wired in responsive CSS` | `AC-30 Scenario: Figma desktop values are wired in responsive CSS` |

## Residual Risk
- Issue metadata references `docs/slices/podium-responsive-layout/05-architecture.md`, which is not present on this branch; implementation is aligned to explicit AC/test directives in issue #182.

## Rollback
- Revert commit `f852fb7` from branch `task/182-podium-bdd-tests`.

## Agent Provenance
run-id: 50aa246f-254f-46ea-9908-2065394bee26
task-id: #182
role: dev
dispatched: 2026-04-21T08:49:17.195Z
model: gpt-5.3-codex