### PR TITLE
feat: podium responsive layout — mobile/tablet/desktop tiers (slice/podium-responsive-layout)

### DIFF
--- a/features/podium-responsive-layout.feature
+++ b/features/podium-responsive-layout.feature
@@ -31,14 +31,14 @@ Feature: Podium responsive layout
     And AC-28 the legend bar 481px comment no longer says tablet and above
     And AC-28 the argument card 481px comment is reclassified as mobile-internal
 
-  Scenario: AC-29 Figma tablet values are wired in responsive CSS
+  Scenario: AC-29 tablet-tier podium layout values match the Figma specification
     Given the podium responsive stylesheet sources are loaded
-    Then AC-29 Figma tablet FAB values are wired in responsive CSS
-    And AC-29 Figma tablet sheet width value is wired in responsive CSS
-    And AC-29 Figma tablet dark scrim value is wired in responsive CSS
+    Then AC-29 tablet-tier podium FAB spacing matches the Figma specification
+    And AC-29 tablet-tier podium sheet width matches the Figma specification
+    And AC-29 tablet-tier podium dark scrim matches the Figma specification
 
-  Scenario: AC-30 Figma desktop values are wired in responsive CSS
+  Scenario: AC-30 desktop-tier podium layout values match the Figma specification
     Given the podium responsive stylesheet sources are loaded
-    Then AC-30 Figma desktop FAB values are wired in responsive CSS
-    And AC-30 Figma desktop sheet width value is wired in responsive CSS
-    And AC-30 Figma desktop scrim values are wired in responsive CSS
+    Then AC-30 desktop-tier podium FAB spacing matches the Figma specification
+    And AC-30 desktop-tier podium sheet width matches the Figma specification
+    And AC-30 desktop-tier podium scrim opacity matches the Figma specification

--- a/features/podium-responsive-layout.feature
+++ b/features/podium-responsive-layout.feature
@@ -5,24 +5,40 @@ Feature: Podium responsive layout
 
   Scenario: AC-25 tablet-tier podium layout values are present
     Given the podium responsive stylesheet sources are loaded
-    Then AC-25 tablet-tier podium layout values are present
+    Then AC-25 tablet-tier podium FAB spacing values are present
+    And AC-25 tablet-tier podium sheet width value is present
+    And AC-25 tablet-tier podium dark scrim values are present
 
   Scenario: AC-26 desktop-tier podium layout values are present
     Given the podium responsive stylesheet sources are loaded
-    Then AC-26 desktop-tier podium layout values are present
+    Then AC-26 desktop-tier podium FAB spacing values are present
+    And AC-26 desktop-tier podium sheet width value is present
+    And AC-26 desktop-tier podium scrim values are present
 
   Scenario: AC-27 mobile-tier podium behavior remains frozen
     Given the podium responsive stylesheet sources are loaded
-    Then AC-27 mobile-tier podium baseline values remain unchanged
+    Then AC-27 mobile-tier podium FAB baseline spacing remains unchanged
+    And AC-27 mobile-tier podium sheet width baseline remains unchanged
+    And AC-27 mobile-tier podium scrim baseline remains unchanged
 
   Scenario: AC-28 481px comments are reclassified as mobile-internal
     Given the podium responsive stylesheet sources are loaded
-    Then AC-28 the 481px comments are reclassified as mobile-internal
+    Then AC-28 the timeline 481px comment is reclassified as mobile-internal
+    And AC-28 the timeline 481px comment no longer uses tablet wording
+    And AC-28 the debate screen 481px comment is reclassified as mobile-internal
+    And AC-28 the debate screen 481px comment no longer uses the tablet divider
+    And AC-28 the legend bar 481px comment is reclassified as mobile-internal
+    And AC-28 the legend bar 481px comment no longer says tablet and above
+    And AC-28 the argument card 481px comment is reclassified as mobile-internal
 
   Scenario: AC-29 Figma tablet values are wired in responsive CSS
     Given the podium responsive stylesheet sources are loaded
-    Then AC-29 Figma tablet values are wired in responsive CSS
+    Then AC-29 Figma tablet FAB values are wired in responsive CSS
+    And AC-29 Figma tablet sheet width value is wired in responsive CSS
+    And AC-29 Figma tablet dark scrim value is wired in responsive CSS
 
   Scenario: AC-30 Figma desktop values are wired in responsive CSS
     Given the podium responsive stylesheet sources are loaded
-    Then AC-30 Figma desktop values are wired in responsive CSS
+    Then AC-30 Figma desktop FAB values are wired in responsive CSS
+    And AC-30 Figma desktop sheet width value is wired in responsive CSS
+    And AC-30 Figma desktop scrim values are wired in responsive CSS

--- a/features/podium-responsive-layout.feature
+++ b/features/podium-responsive-layout.feature
@@ -1,0 +1,28 @@
+Feature: Podium responsive layout
+  As a debate visitor
+  I want podium controls to follow mobile, tablet, and desktop responsive layout values
+  So that posting interactions stay consistent across viewport tiers
+
+  Scenario: AC-25 tablet-tier podium layout values are present
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-25 tablet-tier podium layout values are present
+
+  Scenario: AC-26 desktop-tier podium layout values are present
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-26 desktop-tier podium layout values are present
+
+  Scenario: AC-27 mobile-tier podium behavior remains frozen
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-27 mobile-tier podium baseline values remain unchanged
+
+  Scenario: AC-28 481px comments are reclassified as mobile-internal
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-28 the 481px comments are reclassified as mobile-internal
+
+  Scenario: AC-29 Figma tablet values are wired in responsive CSS
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-29 Figma tablet values are wired in responsive CSS
+
+  Scenario: AC-30 Figma desktop values are wired in responsive CSS
+    Given the podium responsive stylesheet sources are loaded
+    Then AC-30 Figma desktop values are wired in responsive CSS

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -1,0 +1,141 @@
+import { Given, Then } from '@cucumber/cucumber';
+import * as assert from 'assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface PodiumResponsiveStyles {
+  argumentCardCss: string;
+  debateScreenCss: string;
+  legendBarCss: string;
+  podiumBottomSheetCss: string;
+  podiumFabCss: string;
+  timelineCss: string;
+}
+
+let podiumResponsiveStyles: PodiumResponsiveStyles | null = null;
+
+function activeStyles(): PodiumResponsiveStyles {
+  assert.ok(
+    podiumResponsiveStyles,
+    'Expected podium responsive stylesheet sources to be loaded.'
+  );
+  return podiumResponsiveStyles;
+}
+
+function mediaBlock(css: string, mediaQuery: string): string {
+  const startIndex = css.indexOf(mediaQuery);
+  assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" to be present.`);
+  const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
+  return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
+Given('the podium responsive stylesheet sources are loaded', function () {
+  podiumResponsiveStyles = {
+    argumentCardCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/argument-card.css'),
+      'utf-8'
+    ),
+    debateScreenCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/debate-screen.css'),
+      'utf-8'
+    ),
+    legendBarCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/legend-bar.css'),
+      'utf-8'
+    ),
+    podiumBottomSheetCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
+      'utf-8'
+    ),
+    podiumFabCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
+      'utf-8'
+    ),
+    timelineCss: readFileSync(
+      resolve(process.cwd(), 'src/styles/components/timeline.css'),
+      'utf-8'
+    ),
+  };
+});
+
+Then('AC-25 tablet-tier podium layout values are present', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+  const tabletDarkScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 768px) and (max-width: 1023px)'
+  );
+
+  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
+  assert.ok(tabletDarkScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
+  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
+});
+
+Then('AC-26 desktop-tier podium layout values are present', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+  assert.ok(desktopFabBlock.includes('var(--space-12)'));
+  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
+  assert.ok(podiumBottomSheetCss.includes('.podium-sheet-scrim'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+});
+
+Then('AC-27 mobile-tier podium baseline values remain unchanged', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  assert.ok(podiumFabCss.includes('right: var(--space-4);'));
+  assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
+  assert.ok(podiumBottomSheetCss.includes('max-width: 390px;'));
+  assert.ok(podiumBottomSheetCss.includes('background: var(--color-scrim);'));
+});
+
+Then('AC-28 the 481px comments are reclassified as mobile-internal', function () {
+  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles();
+
+  assert.ok(
+    timelineCss.includes('mobile-internal layout adjustment (≥481px) — not a design tier')
+  );
+  assert.equal(timelineCss.includes('Tablet (\u2265481px)'), false);
+
+  assert.ok(debateScreenCss.includes('mobile-internal (≥481px) — not a design tier'));
+  assert.equal(debateScreenCss.includes('/* ── Tablet ── */'), false);
+
+  assert.ok(legendBarCss.includes('mobile-internal (≥481px) — not a design tier'));
+  assert.equal(legendBarCss.includes('Tablet and above'), false);
+
+  assert.ok(argumentCardCss.includes('mobile-internal (≥481px) — not a design tier'));
+});
+
+Then('AC-29 Figma tablet values are wired in responsive CSS', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+  const tabletDarkScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 768px) and (max-width: 1023px)'
+  );
+
+  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
+  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
+});
+
+Then('AC-30 Figma desktop values are wired in responsive CSS', function () {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+
+  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+  assert.ok(desktopFabBlock.includes('var(--space-12)'));
+  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+});

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -1,4 +1,4 @@
-import { Given, Then } from '@cucumber/cucumber';
+import { After, Before, Given, Then, World } from '@cucumber/cucumber';
 import * as assert from 'assert';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -12,25 +12,42 @@ interface PodiumResponsiveStyles {
   timelineCss: string;
 }
 
-let podiumResponsiveStyles: PodiumResponsiveStyles | null = null;
+type PodiumResponsiveLayoutWorld = World & {
+  podiumResponsiveStyles?: PodiumResponsiveStyles;
+};
 
-function activeStyles(): PodiumResponsiveStyles {
+function activeStyles(world: PodiumResponsiveLayoutWorld): PodiumResponsiveStyles {
   assert.ok(
-    podiumResponsiveStyles,
+    world.podiumResponsiveStyles,
     'Expected podium responsive stylesheet sources to be loaded.'
   );
-  return podiumResponsiveStyles;
+  return world.podiumResponsiveStyles;
 }
 
-function mediaBlock(css: string, mediaQuery: string): string {
-  const startIndex = css.indexOf(mediaQuery);
-  assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" to be present.`);
+function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+  let startIndex = -1;
+  let searchFrom = 0;
+
+  for (let count = 0; count < occurrence; count += 1) {
+    startIndex = css.indexOf(mediaQuery, searchFrom);
+    assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" occurrence ${occurrence} to be present.`);
+    searchFrom = startIndex + mediaQuery.length;
+  }
+
   const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
   return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
 }
 
-Given('the podium responsive stylesheet sources are loaded', function () {
-  podiumResponsiveStyles = {
+Before(function (this: PodiumResponsiveLayoutWorld) {
+  this.podiumResponsiveStyles = undefined;
+});
+
+After(function (this: PodiumResponsiveLayoutWorld) {
+  this.podiumResponsiveStyles = undefined;
+});
+
+Given('the podium responsive stylesheet sources are loaded', function (this: PodiumResponsiveLayoutWorld) {
+  this.podiumResponsiveStyles = {
     argumentCardCss: readFileSync(
       resolve(process.cwd(), 'src/styles/components/argument-card.css'),
       'utf-8'
@@ -58,8 +75,8 @@ Given('the podium responsive stylesheet sources are loaded', function () {
   };
 });
 
-Then('AC-25 tablet-tier podium layout values are present', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-25 tablet-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
   const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
@@ -68,27 +85,51 @@ Then('AC-25 tablet-tier podium layout values are present', function () {
     '@media (min-width: 768px) and (max-width: 1023px)'
   );
 
-  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.match(
+    tabletFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
+  assert.match(
+    tabletFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
   assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
   assert.ok(tabletDarkScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
   assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
 });
 
-Then('AC-26 desktop-tier podium layout values are present', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-26 desktop-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+  const desktopSheetWidthBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    1
+  );
+  const desktopScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    2
+  );
 
-  assert.ok(desktopFabBlock.includes('var(--space-12)'));
-  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
-  assert.ok(podiumBottomSheetCss.includes('.podium-sheet-scrim'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+  assert.match(
+    desktopFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.match(
+    desktopFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
+  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
 });
 
-Then('AC-27 mobile-tier podium baseline values remain unchanged', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-27 mobile-tier podium baseline values remain unchanged', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   assert.ok(podiumFabCss.includes('right: var(--space-4);'));
   assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
@@ -96,8 +137,8 @@ Then('AC-27 mobile-tier podium baseline values remain unchanged', function () {
   assert.ok(podiumBottomSheetCss.includes('background: var(--color-scrim);'));
 });
 
-Then('AC-28 the 481px comments are reclassified as mobile-internal', function () {
-  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles();
+Then('AC-28 the 481px comments are reclassified as mobile-internal', function (this: PodiumResponsiveLayoutWorld) {
+  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles(this);
 
   assert.ok(
     timelineCss.includes('mobile-internal layout adjustment (≥481px) — not a design tier')
@@ -113,8 +154,8 @@ Then('AC-28 the 481px comments are reclassified as mobile-internal', function ()
   assert.ok(argumentCardCss.includes('mobile-internal (≥481px) — not a design tier'));
 });
 
-Then('AC-29 Figma tablet values are wired in responsive CSS', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-29 Figma tablet values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
   const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
@@ -123,19 +164,44 @@ Then('AC-29 Figma tablet values are wired in responsive CSS', function () {
     '@media (min-width: 768px) and (max-width: 1023px)'
   );
 
-  assert.ok(tabletFabBlock.includes('var(--space-8)'));
+  assert.match(
+    tabletFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
+  assert.match(
+    tabletFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+  );
   assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
   assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
 });
 
-Then('AC-30 Figma desktop values are wired in responsive CSS', function () {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles();
+Then('AC-30 Figma desktop values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
+  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
 
   const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+  const desktopSheetWidthBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    1
+  );
+  const desktopScrimBlock = mediaBlock(
+    podiumBottomSheetCss,
+    '@media (min-width: 1024px)',
+    2
+  );
 
-  assert.ok(desktopFabBlock.includes('var(--space-12)'));
-  assert.ok(desktopSheetBlock.includes('max-width: 720px;'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(podiumBottomSheetCss.includes('rgba(0, 0, 0, 0.52)'));
+  assert.match(
+    desktopFabBlock,
+    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.match(
+    desktopFabBlock,
+    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+  );
+  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
+  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
+  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
 });

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -162,10 +162,14 @@ Then(
   'AC-26 desktop-tier podium scrim values are present',
   function (this: PodiumResponsiveLayoutWorld) {
     const desktopScrimStyles = desktopScrimBlock(this);
-    assert.ok(desktopScrimStyles.includes('.podium-sheet-scrim'));
-    assert.ok(desktopScrimStyles.includes('[data-theme="dark"] .podium-sheet-scrim'));
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+    assert.match(
+      desktopScrimStyles,
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    assert.match(
+      desktopScrimStyles,
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   }
 );
 
@@ -252,7 +256,7 @@ Then(
 );
 
 Then(
-  'AC-29 Figma tablet FAB values are wired in responsive CSS',
+  'AC-29 tablet-tier podium FAB spacing matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const tabletFabStyles = tabletFabBlock(this);
     assert.match(
@@ -267,14 +271,14 @@ Then(
 );
 
 Then(
-  'AC-29 Figma tablet sheet width value is wired in responsive CSS',
+  'AC-29 tablet-tier podium sheet width matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     assert.ok(tabletSheetWidthBlock(this).includes('max-width: 600px;'));
   }
 );
 
 Then(
-  'AC-29 Figma tablet dark scrim value is wired in responsive CSS',
+  'AC-29 tablet-tier podium dark scrim matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const tabletDarkScrimStyles = tabletDarkScrimBlock(this);
     assert.ok(tabletDarkScrimStyles.includes('rgba(0, 0, 0, 0.48)'));
@@ -282,7 +286,7 @@ Then(
 );
 
 Then(
-  'AC-30 Figma desktop FAB values are wired in responsive CSS',
+  'AC-30 desktop-tier podium FAB spacing matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const desktopFabStyles = desktopFabBlock(this);
     assert.match(
@@ -297,17 +301,23 @@ Then(
 );
 
 Then(
-  'AC-30 Figma desktop sheet width value is wired in responsive CSS',
+  'AC-30 desktop-tier podium sheet width matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     assert.ok(desktopSheetWidthBlock(this).includes('max-width: 720px;'));
   }
 );
 
 Then(
-  'AC-30 Figma desktop scrim values are wired in responsive CSS',
+  'AC-30 desktop-tier podium scrim opacity matches the Figma specification',
   function (this: PodiumResponsiveLayoutWorld) {
     const desktopScrimStyles = desktopScrimBlock(this);
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
-    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+    assert.match(
+      desktopScrimStyles,
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    assert.match(
+      desktopScrimStyles,
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   }
 );

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -2,6 +2,7 @@ import { After, Before, Given, Then, World } from '@cucumber/cucumber';
 import * as assert from 'assert';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { mediaBlock } from '../../tests/lib/css-test-utils';
 
 interface PodiumResponsiveStyles {
   argumentCardCss: string;
@@ -22,23 +23,6 @@ function activeStyles(world: PodiumResponsiveLayoutWorld): PodiumResponsiveStyle
     'Expected podium responsive stylesheet sources to be loaded.'
   );
   return world.podiumResponsiveStyles;
-}
-
-function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
-  let startIndex = -1;
-  let searchFrom = 0;
-
-  for (let count = 0; count < occurrence; count += 1) {
-    startIndex = css.indexOf(mediaQuery, searchFrom);
-    assert.ok(
-      startIndex >= 0,
-      `Expected media query "${mediaQuery}" occurrence ${count + 1} to be present; found ${count} occurrence${count === 1 ? '' : 's'}.`
-    );
-    searchFrom = startIndex + mediaQuery.length;
-  }
-
-  const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
-  return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
 }
 
 function tabletFabBlock(world: PodiumResponsiveLayoutWorld): string {

--- a/features/step-definitions/podium-responsive-layout.steps.ts
+++ b/features/step-definitions/podium-responsive-layout.steps.ts
@@ -30,12 +30,42 @@ function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
 
   for (let count = 0; count < occurrence; count += 1) {
     startIndex = css.indexOf(mediaQuery, searchFrom);
-    assert.ok(startIndex >= 0, `Expected media query "${mediaQuery}" occurrence ${occurrence} to be present.`);
+    assert.ok(
+      startIndex >= 0,
+      `Expected media query "${mediaQuery}" occurrence ${count + 1} to be present; found ${count} occurrence${count === 1 ? '' : 's'}.`
+    );
     searchFrom = startIndex + mediaQuery.length;
   }
 
   const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
   return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
+function tabletFabBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumFabCss, '@media (min-width: 768px)');
+}
+
+function desktopFabBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumFabCss, '@media (min-width: 1024px)');
+}
+
+function tabletSheetWidthBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumBottomSheetCss, '@media (min-width: 768px)', 1);
+}
+
+function desktopSheetWidthBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumBottomSheetCss, '@media (min-width: 1024px)', 1);
+}
+
+function tabletDarkScrimBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(
+    activeStyles(world).podiumBottomSheetCss,
+    '@media (min-width: 768px) and (max-width: 1023px)'
+  );
+}
+
+function desktopScrimBlock(world: PodiumResponsiveLayoutWorld): string {
+  return mediaBlock(activeStyles(world).podiumBottomSheetCss, '@media (min-width: 1024px)', 2);
 }
 
 Before(function (this: PodiumResponsiveLayoutWorld) {
@@ -75,133 +105,209 @@ Given('the podium responsive stylesheet sources are loaded', function (this: Pod
   };
 });
 
-Then('AC-25 tablet-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-25 tablet-tier podium FAB spacing values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletFabStyles = tabletFabBlock(this);
+    assert.match(
+      tabletFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    assert.match(
+      tabletFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+  }
+);
 
-  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
-  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
-  const tabletDarkScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 768px) and (max-width: 1023px)'
-  );
+Then(
+  'AC-25 tablet-tier podium sheet width value is present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(tabletSheetWidthBlock(this).includes('max-width: 600px;'));
+  }
+);
 
-  assert.match(
-    tabletFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.match(
-    tabletFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
-  assert.ok(tabletDarkScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
-  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
-});
+Then(
+  'AC-25 tablet-tier podium dark scrim values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletDarkScrimStyles = tabletDarkScrimBlock(this);
+    assert.ok(tabletDarkScrimStyles.includes('[data-theme="dark"] .podium-sheet-scrim'));
+    assert.ok(tabletDarkScrimStyles.includes('rgba(0, 0, 0, 0.48)'));
+  }
+);
 
-Then('AC-26 desktop-tier podium layout values are present', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-26 desktop-tier podium FAB spacing values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopFabStyles = desktopFabBlock(this);
+    assert.match(
+      desktopFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    assert.match(
+      desktopFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+  }
+);
 
-  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetWidthBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    1
-  );
-  const desktopScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    2
-  );
+Then(
+  'AC-26 desktop-tier podium sheet width value is present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(desktopSheetWidthBlock(this).includes('max-width: 720px;'));
+  }
+);
 
-  assert.match(
-    desktopFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.match(
-    desktopFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
-  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
-});
+Then(
+  'AC-26 desktop-tier podium scrim values are present',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopScrimStyles = desktopScrimBlock(this);
+    assert.ok(desktopScrimStyles.includes('.podium-sheet-scrim'));
+    assert.ok(desktopScrimStyles.includes('[data-theme="dark"] .podium-sheet-scrim'));
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+  }
+);
 
-Then('AC-27 mobile-tier podium baseline values remain unchanged', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-27 mobile-tier podium FAB baseline spacing remains unchanged',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const { podiumFabCss } = activeStyles(this);
+    assert.ok(podiumFabCss.includes('right: var(--space-4);'));
+    assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
+  }
+);
 
-  assert.ok(podiumFabCss.includes('right: var(--space-4);'));
-  assert.ok(podiumFabCss.includes('bottom: var(--space-4);'));
-  assert.ok(podiumBottomSheetCss.includes('max-width: 390px;'));
-  assert.ok(podiumBottomSheetCss.includes('background: var(--color-scrim);'));
-});
+Then(
+  'AC-27 mobile-tier podium sheet width baseline remains unchanged',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(activeStyles(this).podiumBottomSheetCss.includes('max-width: 390px;'));
+  }
+);
 
-Then('AC-28 the 481px comments are reclassified as mobile-internal', function (this: PodiumResponsiveLayoutWorld) {
-  const { argumentCardCss, debateScreenCss, legendBarCss, timelineCss } = activeStyles(this);
+Then(
+  'AC-27 mobile-tier podium scrim baseline remains unchanged',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(activeStyles(this).podiumBottomSheetCss.includes('background: var(--color-scrim);'));
+  }
+);
 
-  assert.ok(
-    timelineCss.includes('mobile-internal layout adjustment (≥481px) — not a design tier')
-  );
-  assert.equal(timelineCss.includes('Tablet (\u2265481px)'), false);
+Then(
+  'AC-28 the timeline 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).timelineCss.includes(
+        'mobile-internal layout adjustment (≥481px) — not a design tier'
+      )
+    );
+  }
+);
 
-  assert.ok(debateScreenCss.includes('mobile-internal (≥481px) — not a design tier'));
-  assert.equal(debateScreenCss.includes('/* ── Tablet ── */'), false);
+Then(
+  'AC-28 the timeline 481px comment no longer uses tablet wording',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.equal(activeStyles(this).timelineCss.includes('Tablet (\u2265481px)'), false);
+  }
+);
 
-  assert.ok(legendBarCss.includes('mobile-internal (≥481px) — not a design tier'));
-  assert.equal(legendBarCss.includes('Tablet and above'), false);
+Then(
+  'AC-28 the debate screen 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).debateScreenCss.includes('mobile-internal (≥481px) — not a design tier')
+    );
+  }
+);
 
-  assert.ok(argumentCardCss.includes('mobile-internal (≥481px) — not a design tier'));
-});
+Then(
+  'AC-28 the debate screen 481px comment no longer uses the tablet divider',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.equal(activeStyles(this).debateScreenCss.includes('/* ── Tablet ── */'), false);
+  }
+);
 
-Then('AC-29 Figma tablet values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-28 the legend bar 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).legendBarCss.includes('mobile-internal (≥481px) — not a design tier')
+    );
+  }
+);
 
-  const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
-  const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
-  const tabletDarkScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 768px) and (max-width: 1023px)'
-  );
+Then(
+  'AC-28 the legend bar 481px comment no longer says tablet and above',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.equal(activeStyles(this).legendBarCss.includes('Tablet and above'), false);
+  }
+);
 
-  assert.match(
-    tabletFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.match(
-    tabletFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-  );
-  assert.ok(tabletSheetBlock.includes('max-width: 600px;'));
-  assert.ok(tabletDarkScrimBlock.includes('rgba(0, 0, 0, 0.48)'));
-});
+Then(
+  'AC-28 the argument card 481px comment is reclassified as mobile-internal',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(
+      activeStyles(this).argumentCardCss.includes('mobile-internal (≥481px) — not a design tier')
+    );
+  }
+);
 
-Then('AC-30 Figma desktop values are wired in responsive CSS', function (this: PodiumResponsiveLayoutWorld) {
-  const { podiumFabCss, podiumBottomSheetCss } = activeStyles(this);
+Then(
+  'AC-29 Figma tablet FAB values are wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletFabStyles = tabletFabBlock(this);
+    assert.match(
+      tabletFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    assert.match(
+      tabletFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+  }
+);
 
-  const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-  const desktopSheetWidthBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    1
-  );
-  const desktopScrimBlock = mediaBlock(
-    podiumBottomSheetCss,
-    '@media (min-width: 1024px)',
-    2
-  );
+Then(
+  'AC-29 Figma tablet sheet width value is wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(tabletSheetWidthBlock(this).includes('max-width: 600px;'));
+  }
+);
 
-  assert.match(
-    desktopFabBlock,
-    /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.match(
-    desktopFabBlock,
-    /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-  );
-  assert.ok(desktopSheetWidthBlock.includes('max-width: 720px;'));
-  assert.ok(desktopScrimBlock.includes('.podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('[data-theme="dark"] .podium-sheet-scrim'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.36)'));
-  assert.ok(desktopScrimBlock.includes('rgba(0, 0, 0, 0.52)'));
-});
+Then(
+  'AC-29 Figma tablet dark scrim value is wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const tabletDarkScrimStyles = tabletDarkScrimBlock(this);
+    assert.ok(tabletDarkScrimStyles.includes('rgba(0, 0, 0, 0.48)'));
+  }
+);
+
+Then(
+  'AC-30 Figma desktop FAB values are wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopFabStyles = desktopFabBlock(this);
+    assert.match(
+      desktopFabStyles,
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    assert.match(
+      desktopFabStyles,
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+  }
+);
+
+Then(
+  'AC-30 Figma desktop sheet width value is wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    assert.ok(desktopSheetWidthBlock(this).includes('max-width: 720px;'));
+  }
+);
+
+Then(
+  'AC-30 Figma desktop scrim values are wired in responsive CSS',
+  function (this: PodiumResponsiveLayoutWorld) {
+    const desktopScrimStyles = desktopScrimBlock(this);
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.36)'));
+    assert.ok(desktopScrimStyles.includes('rgba(0, 0, 0, 0.52)'));
+  }
+);

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -18,20 +18,61 @@ import * as assert from 'assert';
 import { createElement } from 'react';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import { Podium } from '../../src/components/Podium';
-import { DEBATE } from '../../src/data/debate';
+import { DEBATE, type Side } from '../../src/data/debate';
 
 function activeRender(world: PostTarkVitarkWorld): RenderResult {
   assert.ok(world.renderResult, 'Expected an active rendered view.');
   return world.renderResult;
 }
 
+function toSideLabel(side: Side): string {
+  return side === 'tark' ? 'Tark' : 'Vitark';
+}
+
+function ensureBottomSheetOpen(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
+  const view = activeRender(world);
+
+  if (!view.queryByRole('dialog', { name: 'Post composer' })) {
+    fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
+    fireEvent.click(
+      view.getByRole('button', {
+        name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
+      })
+    );
+    return;
+  }
+
+  const sideToggle = view.getByRole('radio', { name: toSideLabel(side) });
+  if (sideToggle.getAttribute('aria-checked') !== 'true') {
+    fireEvent.click(sideToggle);
+  }
+}
+
 function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
+  const view = activeRender(world);
+  const existingComposerInput = view.queryByRole('textbox', {
+    name: 'Post text',
+  });
+  if (existingComposerInput) {
+    return existingComposerInput as HTMLTextAreaElement;
+  }
+
+  ensureBottomSheetOpen(world);
   return activeRender(world).getByRole('textbox', {
     name: 'Post text',
   }) as HTMLTextAreaElement;
 }
 
 function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
+  const view = activeRender(world);
+  const existingPublishButton = view.queryByRole('button', {
+    name: 'Publish post',
+  });
+  if (existingPublishButton) {
+    return existingPublishButton as HTMLButtonElement;
+  }
+
+  ensureBottomSheetOpen(world);
   return activeRender(world).getByRole('button', {
     name: 'Publish post',
   }) as HTMLButtonElement;
@@ -93,31 +134,27 @@ Given('the debate screen is loaded', function (this: PostTarkVitarkWorld) {
 Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
   const view = activeRender(this);
 
-  assert.ok(view.getByRole('switch', { name: 'Post as Tark' }));
-  assert.ok(composerInput(this));
-  assert.ok(publishButton(this));
+  assert.ok(view.getByRole('button', { name: 'Open post composer' }));
   assert.equal(view.queryByRole('button', { name: /sign in|log in/i }), null);
   assert.equal(view.queryByLabelText(/image|media|upload/i), null);
 });
 
 Then('Tark is selected by default', function (this: PostTarkVitarkWorld) {
-  const view = activeRender(this);
+  ensureBottomSheetOpen(this, 'tark');
 
-  const chip = view.getByRole('switch', { name: 'Post as Tark' });
+  const chip = activeRender(this).getByRole('radio', { name: 'Tark' });
   assert.ok(chip);
   assert.equal(chip.getAttribute('aria-checked'), 'true');
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  fireEvent.click(activeRender(this).getByRole('switch', { name: 'Post as Tark' }));
+  ensureBottomSheetOpen(this, 'vitark');
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
-  const view = activeRender(this);
-
-  const chip = view.getByRole('switch', { name: 'Post as Vitark' });
+  const chip = activeRender(this).getByRole('radio', { name: 'Vitark' });
   assert.ok(chip);
-  assert.equal(chip.getAttribute('aria-checked'), 'false');
+  assert.equal(chip.getAttribute('aria-checked'), 'true');
 });
 
 When('the visitor enters whitespace-only post text', function (this: PostTarkVitarkWorld) {

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -159,11 +159,12 @@ Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
 });
 
 Then('Tark is selected by default', async function (this: PostTarkVitarkWorld) {
-  expandComposerOptions(this);
+  await openBottomSheetForSide(this, 'tark');
 
   await waitFor(() => {
-    const tarkOption = activeRender(this).getByRole('button', { name: 'Post as Tark' });
-    assert.equal(document.activeElement, tarkOption);
+    const tarkOption = activeRender(this).getByRole('radio', { name: 'Tark' });
+    assert.ok(tarkOption);
+    assert.equal(tarkOption.getAttribute('aria-checked'), 'true');
   });
 });
 

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -38,11 +38,19 @@ function expandComposerOptions(world: PostTarkVitarkWorld): void {
   fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
 }
 
-function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
+async function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark'): Promise<void> {
   const view = activeRender(world);
 
   if (!view.queryByRole('dialog', { name: 'Post composer' })) {
     expandComposerOptions(world);
+
+    await waitFor(() => {
+      const sideButton = activeRender(world).getByRole('button', {
+        name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
+      }) as HTMLButtonElement;
+      assert.equal(sideButton.disabled, false);
+    });
+
     fireEvent.click(
       activeRender(world).getByRole('button', {
         name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
@@ -57,7 +65,7 @@ function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark')
   }
 }
 
-function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
+async function composerInput(world: PostTarkVitarkWorld): Promise<HTMLTextAreaElement> {
   const view = activeRender(world);
   const existingComposerInput = view.queryByRole('textbox', {
     name: 'Post text',
@@ -66,13 +74,13 @@ function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
     return existingComposerInput as HTMLTextAreaElement;
   }
 
-  openBottomSheetForSide(world);
+  await openBottomSheetForSide(world);
   return activeRender(world).getByRole('textbox', {
     name: 'Post text',
   }) as HTMLTextAreaElement;
 }
 
-function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
+async function publishButton(world: PostTarkVitarkWorld): Promise<HTMLButtonElement> {
   const view = activeRender(world);
   const existingPublishButton = view.queryByRole('button', {
     name: 'Publish post',
@@ -81,7 +89,7 @@ function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
     return existingPublishButton as HTMLButtonElement;
   }
 
-  openBottomSheetForSide(world);
+  await openBottomSheetForSide(world);
   return activeRender(world).getByRole('button', {
     name: 'Publish post',
   }) as HTMLButtonElement;
@@ -96,11 +104,13 @@ function buildText(length: number): string {
 }
 
 async function submitComposer(world: PostTarkVitarkWorld): Promise<void> {
+  const composerPublishButton = await publishButton(world);
+
   await waitFor(() => {
-    assert.equal(publishButton(world).disabled, false);
+    assert.equal(composerPublishButton.disabled, false);
   });
 
-  fireEvent.click(publishButton(world));
+  fireEvent.click(composerPublishButton);
 }
 
 class PostTarkVitarkWorld extends World {
@@ -158,7 +168,7 @@ Then('Tark is selected by default', async function (this: PostTarkVitarkWorld) {
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  openBottomSheetForSide(this, 'vitark');
+  return openBottomSheetForSide(this, 'vitark');
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
@@ -167,18 +177,18 @@ Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {
   assert.equal(chip.getAttribute('aria-checked'), 'true');
 });
 
-When('the visitor enters whitespace-only post text', function (this: PostTarkVitarkWorld) {
-  fireEvent.change(composerInput(this), { target: { value: '      ' } });
+When('the visitor enters whitespace-only post text', async function (this: PostTarkVitarkWorld) {
+  fireEvent.change(await composerInput(this), { target: { value: '      ' } });
 });
 
-When('the visitor enters a post with {int} characters', function (this: PostTarkVitarkWorld, length: number) {
+When('the visitor enters a post with {int} characters', async function (this: PostTarkVitarkWorld, length: number) {
   this.latestPublishedText = buildText(length);
-  fireEvent.change(composerInput(this), { target: { value: this.latestPublishedText } });
+  fireEvent.change(await composerInput(this), { target: { value: this.latestPublishedText } });
 });
 
-When('the visitor enters valid multiline post text', function (this: PostTarkVitarkWorld) {
+When('the visitor enters valid multiline post text', async function (this: PostTarkVitarkWorld) {
   this.latestPublishedText = 'Line one has spaces\nLine two stays valid.';
-  fireEvent.change(composerInput(this), { target: { value: this.latestPublishedText } });
+  fireEvent.change(await composerInput(this), { target: { value: this.latestPublishedText } });
 });
 
 When('the visitor submits the post', async function (this: PostTarkVitarkWorld) {
@@ -187,13 +197,13 @@ When('the visitor submits the post', async function (this: PostTarkVitarkWorld) 
 
 When('the visitor publishes the post text {string}', async function (this: PostTarkVitarkWorld, text: string) {
   this.latestPublishedText = text;
-  fireEvent.change(composerInput(this), { target: { value: text } });
+  fireEvent.change(await composerInput(this), { target: { value: text } });
   await submitComposer(this);
 });
 
-Then('a validation error appears saying {string}', function (this: PostTarkVitarkWorld, message: string) {
+Then('a validation error appears saying {string}', async function (this: PostTarkVitarkWorld, message: string) {
   assert.equal(activeRender(this).getByRole('alert').textContent?.trim(), message);
-  assert.equal(composerInput(this).getAttribute('aria-invalid'), 'true');
+  assert.equal((await composerInput(this)).getAttribute('aria-invalid'), 'true');
 });
 
 Then('no new debate post is added', function (this: PostTarkVitarkWorld) {
@@ -220,8 +230,10 @@ Then('the latest debate post text is {string}', async function (this: PostTarkVi
 });
 
 Then('the composer input is cleared', async function (this: PostTarkVitarkWorld) {
+  const input = await composerInput(this);
+
   await waitFor(() => {
-    assert.equal(composerInput(this).value, '');
+    assert.equal(input.value, '');
   });
 });
 
@@ -239,7 +251,7 @@ Given('a publish is already in progress in the composer', async function (this: 
     })
   );
 
-  fireEvent.change(composerInput(this), { target: { value: 'This text has enough length.' } });
+  fireEvent.change(await composerInput(this), { target: { value: 'This text has enough length.' } });
   await submitComposer(this);
 
   await waitFor(() => {
@@ -247,13 +259,13 @@ Given('a publish is already in progress in the composer', async function (this: 
   });
 });
 
-When('the visitor attempts another publish while busy', function (this: PostTarkVitarkWorld) {
-  fireEvent.click(publishButton(this));
+When('the visitor attempts another publish while busy', async function (this: PostTarkVitarkWorld) {
+  fireEvent.click(await publishButton(this));
 });
 
-Then('the second publish attempt is blocked', function (this: PostTarkVitarkWorld) {
+Then('the second publish attempt is blocked', async function (this: PostTarkVitarkWorld) {
   assert.equal(this.publishCalls, 1);
-  assert.equal(publishButton(this).disabled, true);
+  assert.equal((await publishButton(this)).disabled, true);
 });
 
 When('the page is refreshed', function (this: PostTarkVitarkWorld) {

--- a/features/step-definitions/post-tark-vitark.steps.ts
+++ b/features/step-definitions/post-tark-vitark.steps.ts
@@ -29,13 +29,22 @@ function toSideLabel(side: Side): string {
   return side === 'tark' ? 'Tark' : 'Vitark';
 }
 
-function ensureBottomSheetOpen(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
+function expandComposerOptions(world: PostTarkVitarkWorld): void {
+  const view = activeRender(world);
+  if (view.queryByRole('button', { name: 'Post as Tark' })) {
+    return;
+  }
+
+  fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
+}
+
+function openBottomSheetForSide(world: PostTarkVitarkWorld, side: Side = 'tark'): void {
   const view = activeRender(world);
 
   if (!view.queryByRole('dialog', { name: 'Post composer' })) {
-    fireEvent.click(view.getByRole('button', { name: 'Open post composer' }));
+    expandComposerOptions(world);
     fireEvent.click(
-      view.getByRole('button', {
+      activeRender(world).getByRole('button', {
         name: side === 'tark' ? 'Post as Tark' : 'Post as Vitark',
       })
     );
@@ -57,7 +66,7 @@ function composerInput(world: PostTarkVitarkWorld): HTMLTextAreaElement {
     return existingComposerInput as HTMLTextAreaElement;
   }
 
-  ensureBottomSheetOpen(world);
+  openBottomSheetForSide(world);
   return activeRender(world).getByRole('textbox', {
     name: 'Post text',
   }) as HTMLTextAreaElement;
@@ -72,7 +81,7 @@ function publishButton(world: PostTarkVitarkWorld): HTMLButtonElement {
     return existingPublishButton as HTMLButtonElement;
   }
 
-  ensureBottomSheetOpen(world);
+  openBottomSheetForSide(world);
   return activeRender(world).getByRole('button', {
     name: 'Publish post',
   }) as HTMLButtonElement;
@@ -139,16 +148,17 @@ Then('the composer controls are visible', function (this: PostTarkVitarkWorld) {
   assert.equal(view.queryByLabelText(/image|media|upload/i), null);
 });
 
-Then('Tark is selected by default', function (this: PostTarkVitarkWorld) {
-  ensureBottomSheetOpen(this, 'tark');
+Then('Tark is selected by default', async function (this: PostTarkVitarkWorld) {
+  expandComposerOptions(this);
 
-  const chip = activeRender(this).getByRole('radio', { name: 'Tark' });
-  assert.ok(chip);
-  assert.equal(chip.getAttribute('aria-checked'), 'true');
+  await waitFor(() => {
+    const tarkOption = activeRender(this).getByRole('button', { name: 'Post as Tark' });
+    assert.equal(document.activeElement, tarkOption);
+  });
 });
 
 When('the visitor selects the Vitark side', function (this: PostTarkVitarkWorld) {
-  ensureBottomSheetOpen(this, 'vitark');
+  openBottomSheetForSide(this, 'vitark');
 });
 
 Then('Vitark remains selected', function (this: PostTarkVitarkWorld) {

--- a/features/support/jsdom-setup.mjs
+++ b/features/support/jsdom-setup.mjs
@@ -46,6 +46,20 @@ defineGlobalValue(
 );
 defineGlobalValue('IS_REACT_ACT_ENVIRONMENT', true);
 
+if (!win.requestAnimationFrame) {
+  Object.defineProperty(win, 'requestAnimationFrame', {
+    writable: true,
+    value: globalThis.requestAnimationFrame,
+  });
+}
+
+if (!win.cancelAnimationFrame) {
+  Object.defineProperty(win, 'cancelAnimationFrame', {
+    writable: true,
+    value: globalThis.cancelAnimationFrame,
+  });
+}
+
 if (!win.matchMedia) {
   Object.defineProperty(win, 'matchMedia', {
     writable: true,

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -4,7 +4,6 @@ import { DEBATE } from '../data/debate';
 import { Topic } from './Topic';
 import { LegendBar } from './LegendBar';
 import { Timeline } from './Timeline';
-import { Podium } from './Podium';
 import { PodiumFAB } from './PodiumFAB';
 import { PodiumBottomSheet } from './PodiumBottomSheet';
 import { ThemeToggle } from './ThemeToggle';
@@ -17,26 +16,6 @@ export function DebateScreen() {
     const [isSheetOpen, setIsSheetOpen] = useState(false);
     const ignoreNextSheetCloseRef = useRef(false);
     const clearIgnoreCloseAnimationFrameRef = useRef<number | null>(null);
-    const [isMobile, setIsMobile] = useState(
-        () => window.matchMedia('(max-width: 767px)').matches
-    );
-
-    useEffect(() => {
-        const mediaQuery = window.matchMedia('(max-width: 767px)');
-        const handleViewportChange = (event: MediaQueryListEvent) => {
-            setIsMobile(event.matches);
-
-            if (!event.matches) {
-                setIsFabExpanded(false);
-                setIsSheetOpen(false);
-            }
-        };
-
-        mediaQuery.addEventListener('change', handleViewportChange);
-        return () => {
-            mediaQuery.removeEventListener('change', handleViewportChange);
-        };
-    }, []);
 
     useEffect(() => {
         return () => {
@@ -66,50 +45,40 @@ export function DebateScreen() {
             </header>
             <LegendBar />
             <Timeline arguments={[...DEBATE.arguments, ...localPosts]} />
-            {isMobile ? (
-                <>
-                    <PodiumFAB
-                        isExpanded={isFabExpanded}
-                        onExpand={() => setIsFabExpanded(true)}
-                        onSideSelect={(side) => {
-                            setSelectedSide(side);
-                            setIsFabExpanded(false);
-                            ignoreNextSheetCloseRef.current = true;
+            <PodiumFAB
+                isExpanded={isFabExpanded}
+                onExpand={() => setIsFabExpanded(true)}
+                onSideSelect={(side) => {
+                    setSelectedSide(side);
+                    setIsFabExpanded(false);
+                    ignoreNextSheetCloseRef.current = true;
 
-                            if (clearIgnoreCloseAnimationFrameRef.current !== null) {
-                                window.cancelAnimationFrame(clearIgnoreCloseAnimationFrameRef.current);
-                            }
-                            clearIgnoreCloseAnimationFrameRef.current = window.requestAnimationFrame(() => {
-                                ignoreNextSheetCloseRef.current = false;
-                                clearIgnoreCloseAnimationFrameRef.current = null;
-                            });
+                    if (clearIgnoreCloseAnimationFrameRef.current !== null) {
+                        window.cancelAnimationFrame(clearIgnoreCloseAnimationFrameRef.current);
+                    }
+                    clearIgnoreCloseAnimationFrameRef.current = window.requestAnimationFrame(() => {
+                        ignoreNextSheetCloseRef.current = false;
+                        clearIgnoreCloseAnimationFrameRef.current = null;
+                    });
 
-                            setIsSheetOpen(true);
-                        }}
-                        onCollapse={() => setIsFabExpanded(false)}
-                    />
-                    <PodiumBottomSheet
-                        isOpen={isSheetOpen}
-                        selectedSide={selectedSide}
-                        onSideChange={setSelectedSide}
-                        onPublish={handlePublish}
-                        onClose={() => {
-                            if (ignoreNextSheetCloseRef.current) {
-                                ignoreNextSheetCloseRef.current = false;
-                                return;
-                            }
+                    setIsSheetOpen(true);
+                }}
+                onCollapse={() => setIsFabExpanded(false)}
+            />
+            <PodiumBottomSheet
+                isOpen={isSheetOpen}
+                selectedSide={selectedSide}
+                onSideChange={setSelectedSide}
+                onPublish={handlePublish}
+                onClose={() => {
+                    if (ignoreNextSheetCloseRef.current) {
+                        ignoreNextSheetCloseRef.current = false;
+                        return;
+                    }
 
-                            setIsSheetOpen(false);
-                        }}
-                    />
-                </>
-            ) : (
-                <Podium
-                    selectedSide={selectedSide}
-                    onSideChange={setSelectedSide}
-                    onPublish={handlePublish}
-                />
-            )}
+                    setIsSheetOpen(false);
+                }}
+            />
             <ThemeToggle />
         </main>
     );

--- a/src/components/PodiumBottomSheet.tsx
+++ b/src/components/PodiumBottomSheet.tsx
@@ -190,6 +190,7 @@ export function PodiumBottomSheet({
             }
 
             setText('');
+            onClose();
         } finally {
             setIsBusy(false);
         }

--- a/src/styles/components/argument-card.css
+++ b/src/styles/components/argument-card.css
@@ -15,6 +15,7 @@
     }
 }
 
+/* mobile-internal (≥481px) — not a design tier */
 @media (min-width: 481px) {
     .argument-card__body--clamped {
         display: block;

--- a/src/styles/components/legend-bar.css
+++ b/src/styles/components/legend-bar.css
@@ -50,7 +50,7 @@
     text-align: center;
 }
 
-/* Tablet and above: 3-column grid matching timeline spine alignment */
+/* mobile-internal (≥481px) — not a design tier */
 @media (min-width: 481px) {
     .legend-bar {
         display: grid;

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -1,8 +1,4 @@
 .podium-sheet-scrim {
-    --podium-sheet-scrim-tablet-dark: rgba(0, 0, 0, 0.48);
-    --podium-sheet-scrim-desktop-light: rgba(0, 0, 0, 0.36);
-    --podium-sheet-scrim-desktop-dark: rgba(0, 0, 0, 0.52);
-
     animation: podium-scrim-fade-in 300ms ease-out;
     position: fixed;
     inset: 0;
@@ -169,17 +165,17 @@
 /* ── Scrim opacity: tablet dark theme ── */
 @media (min-width: 768px) and (max-width: 1023px) {
     [data-theme="dark"] .podium-sheet-scrim {
-        background: var(--podium-sheet-scrim-tablet-dark);
+        background: rgb(from var(--color-scrim) r g b / 0.48);
     }
 }
 
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
-        background: var(--podium-sheet-scrim-desktop-light);
+        background: rgb(from var(--color-scrim) r g b / 0.36);
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
-        background: var(--podium-sheet-scrim-desktop-dark);
+        background: rgb(from var(--color-scrim) r g b / 0.52);
     }
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -148,7 +148,7 @@
     to { opacity: 1; }
 }
 
-/* ── Tablet (768–1023 px): BottomSheet max-width ── */
+/* ── Tablet (≥768 px, overridden at ≥1024 px): BottomSheet max-width ── */
 @media (min-width: 768px) {
     .podium-bottom-sheet {
         max-width: 600px;
@@ -165,6 +165,7 @@
 /* ── Scrim opacity: tablet dark theme ── */
 @media (min-width: 768px) and (max-width: 1023px) {
     [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.48);
         background: rgb(from var(--color-scrim) r g b / 0.48);
     }
 }
@@ -172,10 +173,12 @@
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.36);
         background: rgb(from var(--color-scrim) r g b / 0.36);
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.52);
         background: rgb(from var(--color-scrim) r g b / 0.52);
     }
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -147,3 +147,35 @@
     from { opacity: 0; }
     to { opacity: 1; }
 }
+
+/* ── Tablet (768–1023 px): BottomSheet max-width ── */
+@media (min-width: 768px) {
+    .podium-bottom-sheet {
+        max-width: 600px;
+    }
+}
+
+/* ── Desktop (≥1024 px): BottomSheet max-width ── */
+@media (min-width: 1024px) {
+    .podium-bottom-sheet {
+        max-width: 720px;
+    }
+}
+
+/* ── Scrim opacity: tablet dark theme ── */
+@media (min-width: 768px) and (max-width: 1023px) {
+    [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.48);
+    }
+}
+
+/* ── Scrim opacity: desktop (light and dark theme) ── */
+@media (min-width: 1024px) {
+    .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.36);
+    }
+
+    [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.52);
+    }
+}

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -1,4 +1,8 @@
 .podium-sheet-scrim {
+    --podium-sheet-scrim-tablet-dark: rgba(0, 0, 0, 0.48);
+    --podium-sheet-scrim-desktop-light: rgba(0, 0, 0, 0.36);
+    --podium-sheet-scrim-desktop-dark: rgba(0, 0, 0, 0.52);
+
     animation: podium-scrim-fade-in 300ms ease-out;
     position: fixed;
     inset: 0;
@@ -165,17 +169,17 @@
 /* ── Scrim opacity: tablet dark theme ── */
 @media (min-width: 768px) and (max-width: 1023px) {
     [data-theme="dark"] .podium-sheet-scrim {
-        background: rgba(0, 0, 0, 0.48);
+        background: var(--podium-sheet-scrim-tablet-dark);
     }
 }
 
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
-        background: rgba(0, 0, 0, 0.36);
+        background: var(--podium-sheet-scrim-desktop-light);
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
-        background: rgba(0, 0, 0, 0.52);
+        background: var(--podium-sheet-scrim-desktop-dark);
     }
 }

--- a/src/styles/components/podium-bottom-sheet.css
+++ b/src/styles/components/podium-bottom-sheet.css
@@ -170,6 +170,13 @@
     }
 }
 
+@media (prefers-color-scheme: dark) and (min-width: 768px) and (max-width: 1023px) {
+    :root:not([data-theme]) .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.48);
+        background: rgb(from var(--color-scrim) r g b / 0.48);
+    }
+}
+
 /* ── Scrim opacity: desktop (light and dark theme) ── */
 @media (min-width: 1024px) {
     .podium-sheet-scrim {
@@ -178,6 +185,13 @@
     }
 
     [data-theme="dark"] .podium-sheet-scrim {
+        background: rgba(0, 0, 0, 0.52);
+        background: rgb(from var(--color-scrim) r g b / 0.52);
+    }
+}
+
+@media (prefers-color-scheme: dark) and (min-width: 1024px) {
+    :root:not([data-theme]) .podium-sheet-scrim {
         background: rgba(0, 0, 0, 0.52);
         background: rgb(from var(--color-scrim) r g b / 0.52);
     }

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,8 +1,8 @@
 button.podium-fab,
 div.podium-fab[role="group"] {
     position: fixed;
-    right: var(--space-4);
-    bottom: var(--space-4);
+    right: max(var(--space-4), env(safe-area-inset-right, 0px));
+    bottom: max(var(--space-4), env(safe-area-inset-bottom, 0px));
     z-index: 30;
 }
 

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -109,8 +109,8 @@ div.podium-fab[role='group'].podium-fab--expanded {
 @media (min-width: 768px) {
     button.podium-fab,
     div.podium-fab[role="group"] {
-        right: var(--space-8);
-        bottom: var(--space-8);
+        right: max(var(--space-8), env(safe-area-inset-right, 0px));
+        bottom: max(var(--space-8), env(safe-area-inset-bottom, 0px));
     }
 }
 
@@ -118,7 +118,7 @@ div.podium-fab[role='group'].podium-fab--expanded {
 @media (min-width: 1024px) {
     button.podium-fab,
     div.podium-fab[role="group"] {
-        right: var(--space-12);
-        bottom: var(--space-12);
+        right: max(var(--space-12), env(safe-area-inset-right, 0px));
+        bottom: max(var(--space-12), env(safe-area-inset-bottom, 0px));
     }
 }

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -1,8 +1,8 @@
 button.podium-fab,
 div.podium-fab[role="group"] {
     position: fixed;
-    right: max(var(--space-4), env(safe-area-inset-right, 0px));
-    bottom: max(var(--space-4), env(safe-area-inset-bottom, 0px));
+    right: var(--space-4);
+    bottom: var(--space-4);
     z-index: 30;
 }
 

--- a/src/styles/components/podium-fab.css
+++ b/src/styles/components/podium-fab.css
@@ -104,3 +104,21 @@ div.podium-fab[role='group'].podium-fab--expanded {
     outline: 2px solid currentColor;
     outline-offset: 2px;
 }
+
+/* ── Tablet (768–1023 px): FAB margin override ── */
+@media (min-width: 768px) {
+    button.podium-fab,
+    div.podium-fab[role="group"] {
+        right: var(--space-8);
+        bottom: var(--space-8);
+    }
+}
+
+/* ── Desktop (≥1024 px): FAB margin override ── */
+@media (min-width: 1024px) {
+    button.podium-fab,
+    div.podium-fab[role="group"] {
+        right: var(--space-12);
+        bottom: var(--space-12);
+    }
+}

--- a/src/styles/components/timeline.css
+++ b/src/styles/components/timeline.css
@@ -41,7 +41,7 @@
     align-self: flex-end;
 }
 
-/* ── Tablet (≥481px): CSS Grid with center spine ── */
+/* ── mobile-internal layout adjustment (≥481px) — not a design tier ── */
 @media (min-width: 481px) {
     .timeline {
         padding: 0 var(--space-10);

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -18,7 +18,7 @@
     text-align: center;
 }
 
-/* ── Tablet ── */
+/* ── mobile-internal (≥481px) — not a design tier ── */
 @media (min-width: 481px) {
     .debate-header {
         padding: var(--space-12) var(--space-10) var(--space-8);

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -16,10 +16,16 @@ const podiumCss = readFileSync(
 
 async function openComposerForSide(side: 'Post as Tark' | 'Post as Vitark') {
     fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-    const sideOption = screen.getByRole('button', { name: side });
+    let sideOption: HTMLElement | null = null;
     await waitFor(() => {
+        sideOption = screen.getByRole('button', { name: side });
         expect(sideOption).toBeEnabled();
     });
+
+    if (!sideOption) {
+        throw new Error(`Expected composer side option "${side}" to be available.`);
+    }
+
     fireEvent.click(sideOption);
 }
 

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -61,7 +61,7 @@ describe('DebateScreen', () => {
         expect(items).toHaveLength(DEBATE.arguments.length);
     });
 
-    it('defaults selected side to tark on mount', () => {
+    it('renders FAB composer entry on mount', () => {
         render(<DebateScreen />);
 
         expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -14,6 +14,15 @@ const podiumCss = readFileSync(
     'utf-8'
 );
 
+async function openComposerForSide(side: 'Post as Tark' | 'Post as Vitark') {
+    fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+    const sideOption = screen.getByRole('button', { name: side });
+    await waitFor(() => {
+        expect(sideOption).toBeEnabled();
+    });
+    fireEvent.click(sideOption);
+}
+
 describe('DebateScreen', () => {
     afterEach(() => {
         document.documentElement.removeAttribute('data-theme');
@@ -71,8 +80,7 @@ describe('DebateScreen', () => {
     it('appends a valid published post as the last timeline item', async () => {
         render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        await openComposerForSide('Post as Tark');
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'This post has enough length.' },
         });
@@ -88,8 +96,7 @@ describe('DebateScreen', () => {
     it('resets localPosts to empty after remount', async () => {
         const { unmount } = render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
+        await openComposerForSide('Post as Tark');
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'Session-only argument text.' },
         });
@@ -127,12 +134,10 @@ describe('DebateScreen', () => {
         expect(debateScreenCss).toContain('padding-bottom: var(--podium-height, 0px);');
     });
 
-    it('opens bottom sheet immediately with selected side after FAB side selection', () => {
+    it('opens bottom sheet immediately with selected side after FAB side selection', async () => {
         render(<DebateScreen />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        const vitarkAction = screen.getByRole('button', { name: 'Post as Vitark' });
-        fireEvent.click(vitarkAction);
+        await openComposerForSide('Post as Vitark');
 
         expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute('aria-checked', 'true');

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import { DEBATE } from '../../src/data/debate';
@@ -13,88 +13,6 @@ const podiumCss = readFileSync(
     resolve(process.cwd(), 'src/styles/components/podium.css'),
     'utf-8'
 );
-
-type MediaQueryChangeListener = (event: MediaQueryListEvent) => void;
-
-interface MatchMediaController {
-    setIsMobile: (nextValue: boolean) => void;
-}
-
-interface MutableMediaQueryList extends MediaQueryList {
-    updateMatches: (nextValue: boolean) => void;
-}
-
-function createMediaQueryList(
-    media: string,
-    matches: boolean,
-    listeners?: Set<MediaQueryChangeListener>
-): MutableMediaQueryList {
-    let currentMatches = matches;
-
-    return {
-        get matches() {
-            return currentMatches;
-        },
-        set matches(nextValue: boolean) {
-            currentMatches = nextValue;
-        },
-        media,
-        onchange: null,
-        addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
-            if (typeof listener === 'function') {
-                listeners?.add(listener as MediaQueryChangeListener);
-            }
-        },
-        removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
-            if (typeof listener === 'function') {
-                listeners?.delete(listener as MediaQueryChangeListener);
-            }
-        },
-        addListener: (listener: MediaQueryChangeListener) => {
-            listeners?.add(listener);
-        },
-        removeListener: (listener: MediaQueryChangeListener) => {
-            listeners?.delete(listener);
-        },
-        dispatchEvent: () => true,
-        updateMatches(nextValue: boolean) {
-            currentMatches = nextValue;
-        },
-    } as MutableMediaQueryList;
-}
-
-function mockViewportQuery(isMobileAtMount: boolean): MatchMediaController {
-    const viewportListeners = new Set<MediaQueryChangeListener>();
-    const viewportQuery = '(max-width: 767px)';
-    const viewportMediaQueryList = createMediaQueryList(
-        viewportQuery,
-        isMobileAtMount,
-        viewportListeners
-    );
-
-    vi.stubGlobal('matchMedia', (query: string) => {
-        if (query === viewportQuery) {
-            return viewportMediaQueryList;
-        }
-
-        return createMediaQueryList(query, false);
-    });
-
-    return {
-        setIsMobile(nextValue: boolean) {
-            viewportMediaQueryList.updateMatches(nextValue);
-            const event = {
-                matches: nextValue,
-                media: viewportQuery,
-            } as MediaQueryListEvent;
-
-            viewportListeners.forEach((listener) => {
-                listener(event);
-            });
-            viewportMediaQueryList.onchange?.(event);
-        },
-    };
-}
 
 describe('DebateScreen', () => {
     afterEach(() => {
@@ -137,14 +55,6 @@ describe('DebateScreen', () => {
         expect(timeline).toBeInTheDocument();
     });
 
-    it('composes Podium controls', () => {
-        render(<DebateScreen />);
-
-        expect(screen.getByRole('switch', { name: 'Post as Tark' })).toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Publish post' })).toBeInTheDocument();
-    });
-
     it('renders all arguments from DEBATE data', () => {
         render(<DebateScreen />);
         const items = screen.getAllByRole('listitem');
@@ -154,24 +64,15 @@ describe('DebateScreen', () => {
     it('defaults selected side to tark on mount', () => {
         render(<DebateScreen />);
 
-        const chip = screen.getByRole('switch', { name: 'Post as Tark' });
-        expect(chip).toBeInTheDocument();
-        expect(chip).toHaveAttribute('aria-checked', 'true');
-    });
-
-    it('passes side changes to Podium by updating selected side state', () => {
-        render(<DebateScreen />);
-
-        fireEvent.click(screen.getByRole('switch', { name: 'Post as Tark' }));
-
-        const chip = screen.getByRole('switch', { name: 'Post as Vitark' });
-        expect(chip).toBeInTheDocument();
-        expect(chip).toHaveAttribute('aria-checked', 'false');
+        expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();
+        expect(screen.queryByRole('switch', { name: 'Post as Tark' })).not.toBeInTheDocument();
     });
 
     it('appends a valid published post as the last timeline item', async () => {
         render(<DebateScreen />);
 
+        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'This post has enough length.' },
         });
@@ -187,6 +88,8 @@ describe('DebateScreen', () => {
     it('resets localPosts to empty after remount', async () => {
         const { unmount } = render(<DebateScreen />);
 
+        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
         fireEvent.change(screen.getByRole('textbox', { name: 'Post text' }), {
             target: { value: 'Session-only argument text.' },
         });
@@ -205,18 +108,6 @@ describe('DebateScreen', () => {
         expect(screen.queryByText('Session-only argument text.')).not.toBeInTheDocument();
     });
 
-    it('resets selected side to tark after remount', () => {
-        const { unmount } = render(<DebateScreen />);
-
-        fireEvent.click(screen.getByRole('switch', { name: 'Post as Tark' }));
-        expect(screen.getByRole('switch', { name: 'Post as Vitark' })).toHaveAttribute('aria-checked', 'false');
-
-        unmount();
-        render(<DebateScreen />);
-
-        expect(screen.getByRole('switch', { name: 'Post as Tark' })).toHaveAttribute('aria-checked', 'true');
-    });
-
     it('applies debate-screen CSS class to main element', () => {
         render(<DebateScreen />);
         const main = screen.getByRole('main');
@@ -227,7 +118,7 @@ describe('DebateScreen', () => {
         render(<DebateScreen />);
 
         expect(screen.getByRole('switch', { name: /dark mode/i })).toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();
     });
 
     it('uses shared podium height variable for debate screen clearance', () => {
@@ -236,17 +127,7 @@ describe('DebateScreen', () => {
         expect(debateScreenCss).toContain('padding-bottom: var(--podium-height, 0px);');
     });
 
-    it('renders mobile compose flow only when matchMedia reports mobile', () => {
-        mockViewportQuery(true);
-        render(<DebateScreen />);
-
-        expect(screen.getByRole('button', { name: 'Open post composer' })).toBeInTheDocument();
-        expect(screen.queryByRole('switch', { name: 'Post as Tark' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
-    });
-
-    it('opens bottom sheet immediately with selected side after mobile FAB side selection', () => {
-        mockViewportQuery(true);
+    it('opens bottom sheet immediately with selected side after FAB side selection', () => {
         render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
@@ -255,23 +136,6 @@ describe('DebateScreen', () => {
 
         expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: 'Vitark' })).toHaveAttribute('aria-checked', 'true');
-    });
-
-    it('resets FAB and sheet state on resize from mobile to desktop', () => {
-        const mediaController = mockViewportQuery(true);
-        render(<DebateScreen />);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Open post composer' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Post as Tark' }));
-        expect(screen.getByRole('dialog', { name: 'Post composer' })).toBeInTheDocument();
-
-        act(() => {
-            mediaController.setIsMobile(false);
-        });
-
-        expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Post text' })).toBeInTheDocument();
     });
 
     it('scopes --podium-height to desktop media query and keeps mobile default at zero', () => {

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -192,7 +192,7 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
 
-    it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
+    it('applies tablet-tier and desktop-tier podium sheet width and scrim rules for the expanded podium composer', () => {
         // BDD traceability note: responsive podium sheet AC-25/26/29/30 are covered by
         // features/podium-responsive-layout.feature and its linked step definitions.
         const tabletWidthBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -192,7 +192,7 @@ describe('PodiumBottomSheet', () => {
     });
 
     it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
-        // Traceability source for AC-29/AC-30: GitHub issue #179 (task-level acceptance criteria).
+        // Traceability source for AC-25, AC-26, AC-29, and AC-30: GitHub issue #179.
         expect(podiumBottomSheetCss).toMatch(
             /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );
@@ -203,7 +203,7 @@ describe('PodiumBottomSheet', () => {
             /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
+            /\/\*\s*──\s*Scrim opacity:\s*desktop\s*\(light and dark theme\)\s*──\s*\*\/[\s\S]*?@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
         );
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -191,18 +191,29 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
 
-    it('applies tablet and desktop podium sheet width and scrim breakpoints from AC-25, AC-26, AC-29, and AC-30', () => {
-        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) {');
-        expect(podiumBottomSheetCss).toContain('max-width: 600px;');
+    it('applies tablet and desktop podium sheet width and scrim breakpoints from issue #179 AC-25, AC-26, AC-29, and AC-30', () => {
+        // Traceability source for AC-29/AC-30: GitHub issue #179 (task-level acceptance criteria).
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}/
+        );
 
-        expect(podiumBottomSheetCss).toContain('@media (min-width: 1024px) {');
-        expect(podiumBottomSheetCss).toContain('max-width: 720px;');
-
-        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) and (max-width: 1023px) {');
-        expect(podiumBottomSheetCss).toContain('[data-theme="dark"] .podium-sheet-scrim {');
-        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.48);');
-
-        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.36);');
-        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.52);');
+        expect(podiumBottomSheetCss).toMatch(
+            /--podium-sheet-scrim-tablet-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /--podium-sheet-scrim-desktop-light:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /--podium-sheet-scrim-desktop-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-tablet-dark\);[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-light\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-dark\);[\s\S]*?\}/
+        );
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -192,7 +192,8 @@ describe('PodiumBottomSheet', () => {
     });
 
     it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
-        // Traceability source for AC-25, AC-26, AC-29, and AC-30: GitHub issue #179.
+        // BDD traceability note: responsive podium sheet AC-25/26/29/30 are currently
+        // sourced from issue #179; add linked feature-scenario coverage in features/*.feature.
         expect(podiumBottomSheetCss).toMatch(
             /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -191,29 +191,19 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
 
-    it('applies tablet and desktop podium sheet width and scrim breakpoints from issue #179 AC-25, AC-26, AC-29, and AC-30', () => {
+    it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
         // Traceability source for AC-29/AC-30: GitHub issue #179 (task-level acceptance criteria).
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}/
+            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}/
-        );
-
-        expect(podiumBottomSheetCss).toMatch(
-            /--podium-sheet-scrim-tablet-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);/
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /--podium-sheet-scrim-desktop-light:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);/
+            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /--podium-sheet-scrim-desktop-dark:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-tablet-dark\);[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-light\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*var\(--podium-sheet-scrim-desktop-dark\);[\s\S]*?\}/
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
         );
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -5,20 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
 import type { Side } from '../../src/data/debate';
-
-function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
-    let startIndex = -1;
-    let searchFrom = 0;
-
-    for (let count = 0; count < occurrence; count += 1) {
-        startIndex = css.indexOf(mediaQuery, searchFrom);
-        expect(startIndex).toBeGreaterThan(-1);
-        searchFrom = startIndex + mediaQuery.length;
-    }
-
-    const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
-    return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
-}
+import { mediaBlock } from '../lib/css-test-utils';
 
 const podiumBottomSheetCss = readFileSync(
     resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -6,6 +6,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PodiumBottomSheet } from '../../src/components/PodiumBottomSheet';
 import type { Side } from '../../src/data/debate';
 
+function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+    let startIndex = -1;
+    let searchFrom = 0;
+
+    for (let count = 0; count < occurrence; count += 1) {
+        startIndex = css.indexOf(mediaQuery, searchFrom);
+        expect(startIndex).toBeGreaterThan(-1);
+        searchFrom = startIndex + mediaQuery.length;
+    }
+
+    const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
+    return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
 const podiumBottomSheetCss = readFileSync(
     resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
     'utf-8'
@@ -194,23 +208,33 @@ describe('PodiumBottomSheet', () => {
     it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
         // BDD traceability note: responsive podium sheet AC-25/26/29/30 are covered by
         // features/podium-responsive-layout.feature and its linked step definitions.
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(prefers-color-scheme:\s*dark\)\s*and\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?:root:not\(\[data-theme\]\)\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /\/\*\s*──\s*Scrim opacity:\s*desktop\s*\(light and dark theme\)\s*──\s*\*\/[\s\S]*?@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
-        );
-        expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(prefers-color-scheme:\s*dark\)\s*and\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?:root:not\(\[data-theme\]\)\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
-        );
+        const tabletWidthBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+        const desktopWidthBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+        const tabletDarkScrimBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px) and (max-width: 1023px)');
+        const tabletSystemDarkScrimBlock = mediaBlock(podiumBottomSheetCss, '@media (prefers-color-scheme: dark) and (min-width: 768px) and (max-width: 1023px)');
+        const desktopScrimBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)', 2);
+        const desktopSystemDarkScrimBlock = mediaBlock(podiumBottomSheetCss, '@media (prefers-color-scheme: dark) and (min-width: 1024px)');
+
+        expect(tabletWidthBlock).toContain('max-width: 600px;');
+        expect(desktopWidthBlock).toContain('max-width: 720px;');
+
+        expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+        expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+        expect(tabletDarkScrimBlock).toContain('rgb(from var(--color-scrim) r g b / 0.48)');
+
+        expect(tabletSystemDarkScrimBlock).toContain(':root:not([data-theme]) .podium-sheet-scrim');
+        expect(tabletSystemDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+        expect(tabletSystemDarkScrimBlock).toContain('rgb(from var(--color-scrim) r g b / 0.48)');
+
+        expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
+        expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
+        expect(desktopScrimBlock).toContain('rgb(from var(--color-scrim) r g b / 0.36)');
+        expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+        expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
+        expect(desktopScrimBlock).toContain('rgb(from var(--color-scrim) r g b / 0.52)');
+
+        expect(desktopSystemDarkScrimBlock).toContain(':root:not([data-theme]) .podium-sheet-scrim');
+        expect(desktopSystemDarkScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
+        expect(desktopSystemDarkScrimBlock).toContain('rgb(from var(--color-scrim) r g b / 0.52)');
     });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -192,8 +192,8 @@ describe('PodiumBottomSheet', () => {
     });
 
     it('applies tablet and desktop podium sheet width and scrim breakpoint rules for the expanded podium composer', () => {
-        // BDD traceability note: responsive podium sheet AC-25/26/29/30 are currently
-        // sourced from issue #179; add linked feature-scenario coverage in features/*.feature.
+        // BDD traceability note: responsive podium sheet AC-25/26/29/30 are covered by
+        // features/podium-responsive-layout.feature and its linked step definitions.
         expect(podiumBottomSheetCss).toMatch(
             /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*600px;[\s\S]*?\}[\s\S]*?\}/
         );

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -190,4 +190,19 @@ describe('PodiumBottomSheet', () => {
         expect(podiumBottomSheetCss).toContain('touch-action: pan-y;');
         expect(podiumBottomSheetCss).toContain('env(safe-area-inset-bottom, 0px)');
     });
+
+    it('applies tablet and desktop podium sheet width and scrim breakpoints from AC-25, AC-26, AC-29, and AC-30', () => {
+        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) {');
+        expect(podiumBottomSheetCss).toContain('max-width: 600px;');
+
+        expect(podiumBottomSheetCss).toContain('@media (min-width: 1024px) {');
+        expect(podiumBottomSheetCss).toContain('max-width: 720px;');
+
+        expect(podiumBottomSheetCss).toContain('@media (min-width: 768px) and (max-width: 1023px) {');
+        expect(podiumBottomSheetCss).toContain('[data-theme="dark"] .podium-sheet-scrim {');
+        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.48);');
+
+        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.36);');
+        expect(podiumBottomSheetCss).toContain('background: rgba(0, 0, 0, 0.52);');
+    });
 });

--- a/tests/components/PodiumBottomSheet.test.tsx
+++ b/tests/components/PodiumBottomSheet.test.tsx
@@ -200,10 +200,16 @@ describe('PodiumBottomSheet', () => {
             /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-bottom-sheet\s*\{[\s\S]*?max-width:\s*720px;[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
+            /@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(prefers-color-scheme:\s*dark\)\s*and\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)\s*\{[\s\S]*?:root:not\(\[data-theme\]\)\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.48\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.48\);[\s\S]*?\}[\s\S]*?\}/
         );
         expect(podiumBottomSheetCss).toMatch(
             /\/\*\s*──\s*Scrim opacity:\s*desktop\s*\(light and dark theme\)\s*──\s*\*\/[\s\S]*?@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.36\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.36\);[\s\S]*?\}[\s\S]*?\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
+        );
+        expect(podiumBottomSheetCss).toMatch(
+            /@media\s*\(prefers-color-scheme:\s*dark\)\s*and\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?:root:not\(\[data-theme\]\)\s+\.podium-sheet-scrim\s*\{[\s\S]*?background:\s*rgba\(0,\s*0,\s*0,\s*0\.52\);[\s\S]*?background:\s*rgb\(from\s+var\(--color-scrim\)\s+r\s+g\s+b\s*\/\s*0\.52\);[\s\S]*?\}[\s\S]*?\}/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -210,6 +210,9 @@ describe('PodiumFAB', () => {
         const desktopMediaMatch = /@media\s*\(min-width:\s*1024px\)/.exec(podiumFabCss);
         const tabletBreakpointIndex = tabletMediaMatch?.index ?? -1;
         const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
+
+        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
+        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
         const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
         const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
         const tabletRule = tabletBlock.match(
@@ -220,9 +223,6 @@ describe('PodiumFAB', () => {
         );
         const tabletDeclarations = tabletRule?.[2] ?? '';
         const desktopDeclarations = desktopRule?.[2] ?? '';
-
-        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
-        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
         expect(tabletRule).not.toBeNull();
         expect(desktopRule).not.toBeNull();
         expect(tabletDeclarations).toMatch(

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -204,4 +204,18 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).not.toMatch(/\brgba?\s*\(/i);
         expect(podiumFabCss).not.toMatch(/\bhsla?\s*\(/i);
     });
+
+    it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
+        const tabletBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 768px)');
+        const desktopBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 1024px)');
+
+        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
+        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
+        expect(podiumFabCss).toMatch(
+            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-8\);[\s\S]*bottom:\s*var\(--space-8\);/
+        );
+        expect(podiumFabCss).toMatch(
+            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-12\);[\s\S]*bottom:\s*var\(--space-12\);/
+        );
+    });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -197,6 +197,12 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-vitark-surface\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-ambient\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-key\)/);
+        expect(podiumFabCss).toMatch(
+            /right:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+        );
+        expect(podiumFabCss).toMatch(
+            /bottom:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+        );
         expect(podiumFabCss).toMatch(/transition:\s*opacity\s+300ms\s+ease-out,\s*transform\s+300ms\s+ease-out/);
         expect(podiumFabCss).toMatch(/transform:\s*scale\(0\.8\)/);
         expect(podiumFabCss).toMatch(/\.podium-fab--expanded\s*\{[\s\S]*pointer-events:\s*auto;/);

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { PodiumFAB } from '../../src/components/PodiumFAB';
+import { mediaBlock } from '../lib/css-test-utils';
 
 const podiumFabCss = readFileSync(
     resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
@@ -206,15 +207,8 @@ describe('PodiumFAB', () => {
     });
 
     it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
-        const tabletMediaMatch = /@media\s*\(min-width:\s*768px\)/.exec(podiumFabCss);
-        const desktopMediaMatch = /@media\s*\(min-width:\s*1024px\)/.exec(podiumFabCss);
-        const tabletBreakpointIndex = tabletMediaMatch?.index ?? -1;
-        const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
-
-        expect(tabletBreakpointIndex).toBeGreaterThan(-1);
-        expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
-        const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
+        const tabletBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+        const desktopBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
         const tabletRule = tabletBlock.match(
             /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{([^}]*)\}/
         );

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -216,10 +216,10 @@ describe('PodiumFAB', () => {
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
         expect(tabletBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
         );
         expect(desktopBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -206,26 +206,20 @@ describe('PodiumFAB', () => {
     });
 
     it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
-        const tabletBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 768px)');
-        const desktopBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 1024px)');
+        const tabletMediaMatch = /@media\s*\(min-width:\s*768px\)/.exec(podiumFabCss);
+        const desktopMediaMatch = /@media\s*\(min-width:\s*1024px\)/.exec(podiumFabCss);
+        const tabletBreakpointIndex = tabletMediaMatch?.index ?? -1;
+        const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
         const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
         const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
 
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        expect(tabletBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
         expect(tabletBlock).toMatch(
-            /right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);/
-        );
-        expect(tabletBlock).toMatch(
-            /bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
-        );
-        expect(desktopBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
-        expect(desktopBlock).toMatch(
-            /right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
         );
         expect(desktopBlock).toMatch(
-            /bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+            /button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[\s\S]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[\s\S]*\}/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -197,12 +197,6 @@ describe('PodiumFAB', () => {
         expect(podiumFabCss).toMatch(/background-color:\s*var\(--color-vitark-surface\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-ambient\)/);
         expect(podiumFabCss).toMatch(/var\(--color-elevation-shadow-key\)/);
-        expect(podiumFabCss).toMatch(
-            /right:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-right,\s*0px\)\);/
-        );
-        expect(podiumFabCss).toMatch(
-            /bottom:\s*max\(var\(--space-4\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
-        );
         expect(podiumFabCss).toMatch(/transition:\s*opacity\s+300ms\s+ease-out,\s*transform\s+300ms\s+ease-out/);
         expect(podiumFabCss).toMatch(/transform:\s*scale\(0\.8\)/);
         expect(podiumFabCss).toMatch(/\.podium-fab--expanded\s*\{[\s\S]*pointer-events:\s*auto;/);
@@ -218,14 +212,30 @@ describe('PodiumFAB', () => {
         const desktopBreakpointIndex = desktopMediaMatch?.index ?? -1;
         const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
         const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
+        const tabletRule = tabletBlock.match(
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{([^}]*)\}/
+        );
+        const desktopRule = desktopBlock.match(
+            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{([^}]*)\}/
+        );
+        const tabletDeclarations = tabletRule?.[2] ?? '';
+        const desktopDeclarations = desktopRule?.[2] ?? '';
 
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        expect(tabletBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
+        expect(tabletRule).not.toBeNull();
+        expect(desktopRule).not.toBeNull();
+        expect(tabletDeclarations).toMatch(
+            /right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);/
         );
-        expect(desktopBlock).toMatch(
-            /button\.podium-fab,\s*div\.podium-fab\[role=(['"])group\1\]\s*\{[^}]*right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);[^}]*bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);[^}]*\}/
+        expect(tabletDeclarations).toMatch(
+            /bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+        );
+        expect(desktopDeclarations).toMatch(
+            /right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+        );
+        expect(desktopDeclarations).toMatch(
+            /bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
         );
     });
 });

--- a/tests/components/PodiumFAB.test.tsx
+++ b/tests/components/PodiumFAB.test.tsx
@@ -208,14 +208,24 @@ describe('PodiumFAB', () => {
     it('maps AC-25 AC-26 AC-29 and AC-30 to tokenized tablet and desktop FAB margins', () => {
         const tabletBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 768px)');
         const desktopBreakpointIndex = podiumFabCss.indexOf('@media (min-width: 1024px)');
+        const tabletBlock = podiumFabCss.slice(tabletBreakpointIndex, desktopBreakpointIndex);
+        const desktopBlock = podiumFabCss.slice(desktopBreakpointIndex);
 
         expect(tabletBreakpointIndex).toBeGreaterThan(-1);
         expect(desktopBreakpointIndex).toBeGreaterThan(tabletBreakpointIndex);
-        expect(podiumFabCss).toMatch(
-            /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-8\);[\s\S]*bottom:\s*var\(--space-8\);/
+        expect(tabletBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
+        expect(tabletBlock).toMatch(
+            /right:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-right,\s*0px\)\);/
         );
-        expect(podiumFabCss).toMatch(
-            /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*button\.podium-fab,\s*div\.podium-fab\[role="group"\]\s*\{[\s\S]*right:\s*var\(--space-12\);[\s\S]*bottom:\s*var\(--space-12\);/
+        expect(tabletBlock).toMatch(
+            /bottom:\s*max\(var\(--space-8\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
+        );
+        expect(desktopBlock).toMatch(/button\.podium-fab,\s*div\.podium-fab\[role="group"\]/);
+        expect(desktopBlock).toMatch(
+            /right:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-right,\s*0px\)\);/
+        );
+        expect(desktopBlock).toMatch(
+            /bottom:\s*max\(var\(--space-12\),\s*env\(safe-area-inset-bottom,\s*0px\)\);/
         );
     });
 });

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -29,7 +29,7 @@ const argumentCardCss = readFileSync(
 );
 
 describe('podium responsive layout', () => {
-    it('AC-25 Scenario: tablet-tier podium layout values are present', () => {
+    it('AC-25: tablet-tier podium layout values are present', () => {
         const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
         const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
         const tabletDarkScrimBlock = mediaBlock(
@@ -48,7 +48,7 @@ describe('podium responsive layout', () => {
         expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
     });
 
-    it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
+    it('AC-26: desktop-tier podium layout values are present', () => {
         const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
         const desktopSheetWidthBlock = mediaBlock(
             podiumBottomSheetCss,
@@ -76,14 +76,14 @@ describe('podium responsive layout', () => {
         );
     });
 
-    it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
+    it('AC-27: mobile-tier podium behavior remains frozen', () => {
         expect(podiumFabCss).toContain('right: var(--space-4);');
         expect(podiumFabCss).toContain('bottom: var(--space-4);');
         expect(podiumBottomSheetCss).toContain('max-width: 390px;');
         expect(podiumBottomSheetCss).toContain('background: var(--color-scrim);');
     });
 
-    it('AC-28 Scenario: 481px comments are reclassified as mobile-internal', () => {
+    it('AC-28: 481px comments are reclassified as mobile-internal', () => {
         expect(timelineCss).toContain('mobile-internal layout adjustment (≥481px) — not a design tier');
         expect(timelineCss).not.toContain('Tablet (≥481px)');
 
@@ -96,7 +96,7 @@ describe('podium responsive layout', () => {
         expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
     });
 
-    it('AC-29 Scenario: tablet-tier podium layout values match the Figma specification', () => {
+    it('AC-29: tablet-tier podium layout values match the Figma specification', () => {
         const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
         const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
         const tabletDarkScrimBlock = mediaBlock(
@@ -114,7 +114,7 @@ describe('podium responsive layout', () => {
         expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
     });
 
-    it('AC-30 Scenario: desktop-tier podium layout values match the Figma specification', () => {
+    it('AC-30: desktop-tier podium layout values match the Figma specification', () => {
         const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
         const desktopSheetWidthBlock = mediaBlock(
             podiumBottomSheetCss,

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -27,9 +27,16 @@ const argumentCardCss = readFileSync(
   'utf-8'
 );
 
-function mediaBlock(css: string, mediaQuery: string): string {
-  const startIndex = css.indexOf(mediaQuery);
-  expect(startIndex).toBeGreaterThan(-1);
+function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+  let startIndex = -1;
+  let searchFrom = 0;
+
+  for (let count = 0; count < occurrence; count += 1) {
+    startIndex = css.indexOf(mediaQuery, searchFrom);
+    expect(startIndex).toBeGreaterThan(-1);
+    searchFrom = startIndex + mediaQuery.length;
+  }
+
   const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
   return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
 }
@@ -43,7 +50,12 @@ describe('podium responsive layout', () => {
       '@media (min-width: 768px) and (max-width: 1023px)'
     );
 
-    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    expect(tabletFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
     expect(tabletSheetBlock).toContain('max-width: 600px;');
     expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
     expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
@@ -51,13 +63,28 @@ describe('podium responsive layout', () => {
 
   it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
     const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+    const desktopSheetWidthBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      1
+    );
+    const desktopScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      2
+    );
 
-    expect(desktopFabBlock).toContain('var(--space-12)');
-    expect(desktopSheetBlock).toContain('max-width: 720px;');
-    expect(podiumBottomSheetCss).toContain('.podium-sheet-scrim');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
+    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
   });
 
   it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
@@ -88,18 +115,39 @@ describe('podium responsive layout', () => {
       '@media (min-width: 768px) and (max-width: 1023px)'
     );
 
-    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
+    expect(tabletFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+    );
     expect(tabletSheetBlock).toContain('max-width: 600px;');
     expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
   });
 
   it('AC-30 Scenario: Figma desktop values are wired in responsive CSS', () => {
     const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+    const desktopSheetWidthBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      1
+    );
+    const desktopScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 1024px)',
+      2
+    );
 
-    expect(desktopFabBlock).toContain('var(--space-12)');
-    expect(desktopSheetBlock).toContain('max-width: 720px;');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
-    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopFabBlock).toMatch(
+      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopFabBlock).toMatch(
+      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+    );
+    expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
+    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
+    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
   });
 });

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -1,157 +1,144 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { mediaBlock } from '../lib/css-test-utils';
 
 const podiumFabCss = readFileSync(
-  resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
-  'utf-8'
+    resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
+    'utf-8'
 );
 const podiumBottomSheetCss = readFileSync(
-  resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
-  'utf-8'
+    resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
+    'utf-8'
 );
 const timelineCss = readFileSync(
-  resolve(process.cwd(), 'src/styles/components/timeline.css'),
-  'utf-8'
+    resolve(process.cwd(), 'src/styles/components/timeline.css'),
+    'utf-8'
 );
 const debateScreenCss = readFileSync(
-  resolve(process.cwd(), 'src/styles/debate-screen.css'),
-  'utf-8'
+    resolve(process.cwd(), 'src/styles/debate-screen.css'),
+    'utf-8'
 );
 const legendBarCss = readFileSync(
-  resolve(process.cwd(), 'src/styles/components/legend-bar.css'),
-  'utf-8'
+    resolve(process.cwd(), 'src/styles/components/legend-bar.css'),
+    'utf-8'
 );
 const argumentCardCss = readFileSync(
-  resolve(process.cwd(), 'src/styles/components/argument-card.css'),
-  'utf-8'
+    resolve(process.cwd(), 'src/styles/components/argument-card.css'),
+    'utf-8'
 );
 
-function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
-  let startIndex = -1;
-  let searchFrom = 0;
-
-  for (let count = 0; count < occurrence; count += 1) {
-    startIndex = css.indexOf(mediaQuery, searchFrom);
-    expect(startIndex).toBeGreaterThan(-1);
-    searchFrom = startIndex + mediaQuery.length;
-  }
-
-  const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
-  return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
-}
-
 describe('podium responsive layout', () => {
-  it('AC-25 Scenario: tablet-tier podium layout values are present', () => {
-    const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
-    const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
-    const tabletDarkScrimBlock = mediaBlock(
-      podiumBottomSheetCss,
-      '@media (min-width: 768px) and (max-width: 1023px)'
-    );
+    it('AC-25 Scenario: tablet-tier podium layout values are present', () => {
+        const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+        const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+        const tabletDarkScrimBlock = mediaBlock(
+            podiumBottomSheetCss,
+            '@media (min-width: 768px) and (max-width: 1023px)'
+        );
 
-    expect(tabletFabBlock).toMatch(
-      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-    );
-    expect(tabletFabBlock).toMatch(
-      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-    );
-    expect(tabletSheetBlock).toContain('max-width: 600px;');
-    expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
-    expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
-  });
+        expect(tabletFabBlock).toMatch(
+            /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+        );
+        expect(tabletFabBlock).toMatch(
+            /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+        );
+        expect(tabletSheetBlock).toContain('max-width: 600px;');
+        expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+        expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+    });
 
-  it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
-    const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-    const desktopSheetWidthBlock = mediaBlock(
-      podiumBottomSheetCss,
-      '@media (min-width: 1024px)',
-      1
-    );
-    const desktopScrimBlock = mediaBlock(
-      podiumBottomSheetCss,
-      '@media (min-width: 1024px)',
-      2
-    );
+    it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
+        const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+        const desktopSheetWidthBlock = mediaBlock(
+            podiumBottomSheetCss,
+            '@media (min-width: 1024px)',
+            1
+        );
+        const desktopScrimBlock = mediaBlock(
+            podiumBottomSheetCss,
+            '@media (min-width: 1024px)',
+            2
+        );
 
-    expect(desktopFabBlock).toMatch(
-      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-    );
-    expect(desktopFabBlock).toMatch(
-      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-    );
-    expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
-    expect(desktopScrimBlock).toMatch(
-      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
-    );
-    expect(desktopScrimBlock).toMatch(
-      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
-    );
-  });
+        expect(desktopFabBlock).toMatch(
+            /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+        );
+        expect(desktopFabBlock).toMatch(
+            /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+        );
+        expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
+        expect(desktopScrimBlock).toMatch(
+            /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+        );
+        expect(desktopScrimBlock).toMatch(
+            /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+        );
+    });
 
-  it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
-    expect(podiumFabCss).toContain('right: var(--space-4);');
-    expect(podiumFabCss).toContain('bottom: var(--space-4);');
-    expect(podiumBottomSheetCss).toContain('max-width: 390px;');
-    expect(podiumBottomSheetCss).toContain('background: var(--color-scrim);');
-  });
+    it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
+        expect(podiumFabCss).toContain('right: var(--space-4);');
+        expect(podiumFabCss).toContain('bottom: var(--space-4);');
+        expect(podiumBottomSheetCss).toContain('max-width: 390px;');
+        expect(podiumBottomSheetCss).toContain('background: var(--color-scrim);');
+    });
 
-  it('AC-28 Scenario: 481px comments are reclassified as mobile-internal', () => {
-    expect(timelineCss).toContain('mobile-internal layout adjustment (≥481px) — not a design tier');
-    expect(timelineCss).not.toContain('Tablet (\u2265481px)');
+    it('AC-28 Scenario: 481px comments are reclassified as mobile-internal', () => {
+        expect(timelineCss).toContain('mobile-internal layout adjustment (≥481px) — not a design tier');
+        expect(timelineCss).not.toContain('Tablet (≥481px)');
 
-    expect(debateScreenCss).toContain('mobile-internal (≥481px) — not a design tier');
-    expect(debateScreenCss).not.toContain('/* ── Tablet ── */');
+        expect(debateScreenCss).toContain('mobile-internal (≥481px) — not a design tier');
+        expect(debateScreenCss).not.toContain('/* ── Tablet ── */');
 
-    expect(legendBarCss).toContain('mobile-internal (≥481px) — not a design tier');
-    expect(legendBarCss).not.toContain('Tablet and above');
+        expect(legendBarCss).toContain('mobile-internal (≥481px) — not a design tier');
+        expect(legendBarCss).not.toContain('Tablet and above');
 
-    expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
-  });
+        expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
+    });
 
-  it('AC-29 Scenario: tablet-tier podium layout values match the Figma specification', () => {
-    const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
-    const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
-    const tabletDarkScrimBlock = mediaBlock(
-      podiumBottomSheetCss,
-      '@media (min-width: 768px) and (max-width: 1023px)'
-    );
+    it('AC-29 Scenario: tablet-tier podium layout values match the Figma specification', () => {
+        const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+        const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+        const tabletDarkScrimBlock = mediaBlock(
+            podiumBottomSheetCss,
+            '@media (min-width: 768px) and (max-width: 1023px)'
+        );
 
-    expect(tabletFabBlock).toMatch(
-      /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-    );
-    expect(tabletFabBlock).toMatch(
-      /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
-    );
-    expect(tabletSheetBlock).toContain('max-width: 600px;');
-    expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
-  });
+        expect(tabletFabBlock).toMatch(
+            /right:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+        );
+        expect(tabletFabBlock).toMatch(
+            /bottom:\s*(?:max\([^;]*var\(--space-8\)[^;]*\)|var\(--space-8\))\s*;/
+        );
+        expect(tabletSheetBlock).toContain('max-width: 600px;');
+        expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+    });
 
-  it('AC-30 Scenario: desktop-tier podium layout values match the Figma specification', () => {
-    const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
-    const desktopSheetWidthBlock = mediaBlock(
-      podiumBottomSheetCss,
-      '@media (min-width: 1024px)',
-      1
-    );
-    const desktopScrimBlock = mediaBlock(
-      podiumBottomSheetCss,
-      '@media (min-width: 1024px)',
-      2
-    );
+    it('AC-30 Scenario: desktop-tier podium layout values match the Figma specification', () => {
+        const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+        const desktopSheetWidthBlock = mediaBlock(
+            podiumBottomSheetCss,
+            '@media (min-width: 1024px)',
+            1
+        );
+        const desktopScrimBlock = mediaBlock(
+            podiumBottomSheetCss,
+            '@media (min-width: 1024px)',
+            2
+        );
 
-    expect(desktopFabBlock).toMatch(
-      /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-    );
-    expect(desktopFabBlock).toMatch(
-      /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
-    );
-    expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
-    expect(desktopScrimBlock).toMatch(
-      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
-    );
-    expect(desktopScrimBlock).toMatch(
-      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
-    );
-  });
+        expect(desktopFabBlock).toMatch(
+            /right:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+        );
+        expect(desktopFabBlock).toMatch(
+            /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
+        );
+        expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
+        expect(desktopScrimBlock).toMatch(
+            /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+        );
+        expect(desktopScrimBlock).toMatch(
+            /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+        );
+    });
 });

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -81,10 +81,12 @@ describe('podium responsive layout', () => {
       /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
     );
     expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
-    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopScrimBlock).toMatch(
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    expect(desktopScrimBlock).toMatch(
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   });
 
   it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
@@ -107,7 +109,7 @@ describe('podium responsive layout', () => {
     expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
   });
 
-  it('AC-29 Scenario: Figma tablet values are wired in responsive CSS', () => {
+  it('AC-29 Scenario: tablet-tier podium layout values match the Figma specification', () => {
     const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
     const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
     const tabletDarkScrimBlock = mediaBlock(
@@ -125,7 +127,7 @@ describe('podium responsive layout', () => {
     expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
   });
 
-  it('AC-30 Scenario: Figma desktop values are wired in responsive CSS', () => {
+  it('AC-30 Scenario: desktop-tier podium layout values match the Figma specification', () => {
     const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
     const desktopSheetWidthBlock = mediaBlock(
       podiumBottomSheetCss,
@@ -145,9 +147,11 @@ describe('podium responsive layout', () => {
       /bottom:\s*(?:max\([^;]*var\(--space-12\)[^;]*\)|var\(--space-12\))\s*;/
     );
     expect(desktopSheetWidthBlock).toContain('max-width: 720px;');
-    expect(desktopScrimBlock).toContain('.podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.36)');
-    expect(desktopScrimBlock).toContain('rgba(0, 0, 0, 0.52)');
+    expect(desktopScrimBlock).toMatch(
+      /\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.36\)[^}]*\}/
+    );
+    expect(desktopScrimBlock).toMatch(
+      /\[data-theme="dark"\]\s+\.podium-sheet-scrim\s*\{[^}]*rgba\(0,\s*0,\s*0,\s*0\.52\)[^}]*\}/
+    );
   });
 });

--- a/tests/components/podium-responsive-layout.test.ts
+++ b/tests/components/podium-responsive-layout.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const podiumFabCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/podium-fab.css'),
+  'utf-8'
+);
+const podiumBottomSheetCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/podium-bottom-sheet.css'),
+  'utf-8'
+);
+const timelineCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/timeline.css'),
+  'utf-8'
+);
+const debateScreenCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/debate-screen.css'),
+  'utf-8'
+);
+const legendBarCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/legend-bar.css'),
+  'utf-8'
+);
+const argumentCardCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/argument-card.css'),
+  'utf-8'
+);
+
+function mediaBlock(css: string, mediaQuery: string): string {
+  const startIndex = css.indexOf(mediaQuery);
+  expect(startIndex).toBeGreaterThan(-1);
+  const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
+  return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}
+
+describe('podium responsive layout', () => {
+  it('AC-25 Scenario: tablet-tier podium layout values are present', () => {
+    const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+    const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+    const tabletDarkScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 768px) and (max-width: 1023px)'
+    );
+
+    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletSheetBlock).toContain('max-width: 600px;');
+    expect(tabletDarkScrimBlock).toContain('[data-theme="dark"] .podium-sheet-scrim');
+    expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+  });
+
+  it('AC-26 Scenario: desktop-tier podium layout values are present', () => {
+    const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+    expect(desktopFabBlock).toContain('var(--space-12)');
+    expect(desktopSheetBlock).toContain('max-width: 720px;');
+    expect(podiumBottomSheetCss).toContain('.podium-sheet-scrim');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+  });
+
+  it('AC-27 Scenario: mobile-tier podium behavior remains frozen', () => {
+    expect(podiumFabCss).toContain('right: var(--space-4);');
+    expect(podiumFabCss).toContain('bottom: var(--space-4);');
+    expect(podiumBottomSheetCss).toContain('max-width: 390px;');
+    expect(podiumBottomSheetCss).toContain('background: var(--color-scrim);');
+  });
+
+  it('AC-28 Scenario: 481px comments are reclassified as mobile-internal', () => {
+    expect(timelineCss).toContain('mobile-internal layout adjustment (≥481px) — not a design tier');
+    expect(timelineCss).not.toContain('Tablet (\u2265481px)');
+
+    expect(debateScreenCss).toContain('mobile-internal (≥481px) — not a design tier');
+    expect(debateScreenCss).not.toContain('/* ── Tablet ── */');
+
+    expect(legendBarCss).toContain('mobile-internal (≥481px) — not a design tier');
+    expect(legendBarCss).not.toContain('Tablet and above');
+
+    expect(argumentCardCss).toContain('mobile-internal (≥481px) — not a design tier');
+  });
+
+  it('AC-29 Scenario: Figma tablet values are wired in responsive CSS', () => {
+    const tabletFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 768px)');
+    const tabletSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 768px)');
+    const tabletDarkScrimBlock = mediaBlock(
+      podiumBottomSheetCss,
+      '@media (min-width: 768px) and (max-width: 1023px)'
+    );
+
+    expect(tabletFabBlock).toContain('var(--space-8)');
+    expect(tabletSheetBlock).toContain('max-width: 600px;');
+    expect(tabletDarkScrimBlock).toContain('rgba(0, 0, 0, 0.48)');
+  });
+
+  it('AC-30 Scenario: Figma desktop values are wired in responsive CSS', () => {
+    const desktopFabBlock = mediaBlock(podiumFabCss, '@media (min-width: 1024px)');
+    const desktopSheetBlock = mediaBlock(podiumBottomSheetCss, '@media (min-width: 1024px)');
+
+    expect(desktopFabBlock).toContain('var(--space-12)');
+    expect(desktopSheetBlock).toContain('max-width: 720px;');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.36)');
+    expect(podiumBottomSheetCss).toContain('rgba(0, 0, 0, 0.52)');
+  });
+});

--- a/tests/lib/css-test-utils.ts
+++ b/tests/lib/css-test-utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns the substring of `css` that starts at the nth occurrence of `mediaQuery`
+ * and ends just before the next `@media` rule (or at the end of the string).
+ *
+ * Throws an Error — compatible with both Vitest and Cucumber — when the requested
+ * occurrence is not found.
+ */
+export function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+    let startIndex = -1;
+    let searchFrom = 0;
+
+    for (let count = 0; count < occurrence; count += 1) {
+        startIndex = css.indexOf(mediaQuery, searchFrom);
+        if (startIndex < 0) {
+            throw new Error(
+                `Expected media query "${mediaQuery}" occurrence ${count + 1} to be present; found ${count} occurrence${count === 1 ? '' : 's'}.`
+            );
+        }
+        searchFrom = startIndex + mediaQuery.length;
+    }
+
+    const nextMediaIndex = css.indexOf('@media', startIndex + mediaQuery.length);
+    return nextMediaIndex === -1 ? css.slice(startIndex) : css.slice(startIndex, nextMediaIndex);
+}

--- a/tests/lib/css-test-utils.ts
+++ b/tests/lib/css-test-utils.ts
@@ -6,6 +6,12 @@
  * occurrence is not found.
  */
 export function mediaBlock(css: string, mediaQuery: string, occurrence = 1): string {
+    if (!Number.isInteger(occurrence) || occurrence < 1) {
+        throw new Error(
+            `mediaBlock: "occurrence" must be a positive integer; received ${occurrence}.`
+        );
+    }
+
     let startIndex = -1;
     let searchFrom = 0;
 


### PR DESCRIPTION
## Slice: `podium-responsive-layout`

Delivers responsive layout for the Podium FAB and bottom-sheet across mobile, tablet, and desktop viewport tiers, plus BDD and Vitest acceptance coverage.

### Acceptance Criteria Delivered

| AC | Description | Status |
|---|---|---|
| AC-25 | Tablet-tier FAB spacing (`--space-8`), sheet max-width (600px), dark scrim (rgba 0.48) | ✅ |
| AC-26 | Desktop-tier FAB spacing (`--space-12`), sheet max-width (720px), scrim 0.36/0.52 | ✅ |
| AC-27 | Mobile-tier baseline values frozen (--space-4, 390px, var(--color-scrim)) | ✅ |
| AC-28 | 481px @media comments reclassified as mobile-internal across 4 stylesheets | ✅ |
| AC-29 | Figma tablet spec values wired and verified | ✅ |
| AC-30 | Figma desktop spec values wired and verified | ✅ |

### PRs Merged into Slice

| PR | Task | Description |
|---|---|---|
| #183 | A | Podium FAB responsive spacing |
| #184 | B | Podium bottom-sheet max-width |
| #185 | C | Desktop scrim opacity |
| #186 | D | Tablet-bounded dark scrim |
| #187 | E | 481px comment reclassification |
| #189 | F | BDD + Vitest AC coverage |
| #188 | — | Protocol hardening |

### Test Evidence

- Unit tests: **311 passed** (24 files)
- BDD: **28 scenarios, 101 steps passed**
- Runtime QA: **REVISED PASS** (Gate 5.5)

### Rollback Note

Each feature CSS file change is isolated to responsive `@media` blocks. Rolling back this PR restores the pre-slice baseline with no impact to other slices.

---

Closes #182