### PR TITLE
chore: harden agent model routing

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- Protocol-Version: 3.19 -->
-<!-- Last-Updated: 2026-04-11 -->
+<!-- Protocol-Version: 3.20 -->
+<!-- Last-Updated: 2026-04-21 -->
 
 # Shared Agent Protocol
 
@@ -94,6 +94,25 @@ The full Gate 5, Gate 5.5 Runtime QA, and Gate 6 orchestration workflow - issue-
 2. Product Owner may opt a specific gate invocation into cloud mode by explicitly requesting cloud execution.
 3. Gate 3 design work is always local-only.
 4. Final verification and merge readiness decisions are always local.
+
+## Model Routing Policy
+
+1. Repository-standard role defaults are:
+
+| Role | Default model | Default use |
+|---|---|---|
+| `architect-orchestrator` | `gpt-5.4` | coordination, gate decisions, merge-readiness reasoning |
+| `requirement-challenger` | `claude-sonnet-4.6` | requirement challenge and ambiguity reduction |
+| `prd-agent` | `claude-sonnet-4.6` | PRD drafting and acceptance-criteria quality checks |
+| `design-qa-agent` | `claude-sonnet-4.6` | design coverage and UX/design critique |
+| `architecture-agent` | `gpt-5.4` | architecture planning and dependency/risk reasoning |
+| `dev` | `gpt-5.3-codex` | issue-scoped implementation and code editing |
+| `runtime-qa` | `gpt-5.4` | browser-verdict synthesis and runtime triage |
+
+2. For sync handoffs via `runSubagent`, orchestrator must pass an explicit `model` argument for Gate 1, Gate 2, Gate 3B, Gate 4, and Gate 5.5. Do not rely on platform default selection.
+3. For terminal-dispatched agents via `scripts/run-agent.ts` and parallel async runs via `scripts/mcp-dev-orchestrator.ts`, omit `--model` unless deliberately overriding; both scripts resolve the role default automatically from `scripts/agent-model-routing.ts`.
+4. Any override must be deliberate, called out in the handoff or dispatch note, and used only when the task clearly needs a non-default reasoning lane.
+5. Before a new role is used in live orchestration, add its default model to `scripts/agent-model-routing.ts` and document it in `.github/skills/async-agent-dispatch/SKILL.md` in the same change.
 
 ## Terminal Mutation Override Policy
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -64,6 +64,15 @@ Orchestrator-specific rule:
 2. Allowed secondary: Cloud for non-Gate-3 analysis drafts and alternatives.
 3. Final signoff decisions and merge readiness checks must be made in Local context.
 
+## Model Routing Policy
+
+Follow the shared Model Routing Policy in `.github/AGENTS.md` and the operational details in `.github/skills/async-agent-dispatch/SKILL.md`.
+
+1. Sync `runSubagent` handoffs must set an explicit model for specialist roles.
+2. Gate 1, Gate 2, and Gate 3B use `claude-sonnet-4.6` for `requirement-challenger`, `prd-agent`, and `design-qa-agent`.
+3. Gate 4 and Gate 5.5 use `gpt-5.4` for `architecture-agent` and `runtime-qa`.
+4. Async terminal dispatch should rely on the scripted role defaults unless there is a deliberate, documented override.
+
 ## Required Inputs
 
 1. Minimum kickoff input: requirement statement.

--- a/.github/orchestrator-context.md
+++ b/.github/orchestrator-context.md
@@ -153,6 +153,7 @@ Project-specific Figma identifiers live in `.figma-config.local` (gitignored). U
 80. PRD Amendment Protocol (adopted 2026-04-16): When the Product Owner approves a scope change after Gate 2 is closed, all three conditions must be met before Gate 3 closure: (1) a dated `## Amendments` entry appended in `02-prd.md` (amendment number, date, scope narrative, supersession clause if applicable), (2) delta markers in `03-ux.md` and `04-design-qa.md` citing the amendment number, and (3) no downstream artifact may remain with stale scope that conflicts with the amendment. Gate 3 is blocked until all three are satisfied. Cross-ref: `.github/skills/requirement-prd-alignment/SKILL.md` §PRD Amendment Protocol, `.github/skills/prd-gate-orchestration/SKILL.md` §PRD Amendment trigger rule.
 81. Gate 5.5 skip enforcement (adopted 2026-04-17): "Explicitly accept residual runtime risk" is only satisfied when the orchestrator has invoked `vscode_askQuestions` presenting the specific skip risk to Product Owner and received an explicit in-session confirmation. An orchestrator unilaterally declaring "PO accepted residual runtime risk" in a gate closure summary — without a `vscode_askQuestions` call in that session — is a workflow failure and an invalid Gate 5.5 skip path. Gate 5.5 remains blocking for UI-impacting issues until either a `Runtime QA Verdict: Pass` or a confirmed `vscode_askQuestions` risk acceptance is on record. Cross-ref: `build-merge-gate-orchestration` skill Explicit PO Acceptance Enforcement rule, `build-evidence-and-merge-readiness` skill Runtime QA lock and Merge Recommendation Checklist #6.
 82. Global AC numbering (adopted 2026-04-20, PO decision): AC IDs are globally unique across all slices. The last AC assigned is **AC-28** (`podium-responsive-layout`, 2026-04-20). The next slice must seed its first AC at **AC-29**. Orchestrator must update this rule (last assigned AC + slice + date) at Gate 1 freeze for every new slice. If a slice is expected to add ACs after Gate 1 (e.g., deferred OQs formalized at Gate 3), the orchestrator must either (a) reserve those AC IDs at Gate 1 freeze — recording them here with status "reserved, prose deferred to Gate N" — even though their prose is not yet written, or (b) update this rule immediately at the gate where each new AC ID is first assigned, before any subsequent slice may seed IDs. If option (b) is used and Gate 3 assigns new IDs for this slice, update this rule at Gate 3 closure with the new last assigned AC + slice + date. Per-slice feature files remain self-contained, but global uniqueness must be preserved for AC IDs created at any gate.
+83. Model routing policy (adopted 2026-04-21, PO decision): `architect-orchestrator`, `architecture-agent`, and `runtime-qa` use `gpt-5.4`; `requirement-challenger`, `prd-agent`, and `design-qa-agent` use `claude-sonnet-4.6`; `dev` uses `gpt-5.3-codex`. Gates 1, 2, 3B, 4, and 5.5 sync handoffs must pass an explicit `model` argument. Terminal dispatch via `scripts/run-agent.ts` and `scripts/mcp-dev-orchestrator.ts` resolves the role default automatically unless a deliberate override is specified. Any new live role must be added to `scripts/agent-model-routing.ts` and `.github/skills/async-agent-dispatch/SKILL.md` before use. Cross-ref: `.github/AGENTS.md` Model Routing Policy.
 
 ## Resume Protocol For Orchestrator
 
@@ -930,3 +931,15 @@ Detailed repo-wide governance history from 2026-03-30 through 2026-04-02 is arch
 - Open questions status: None.
 - Next micro-goal: Start next slice intake or governance task.
 - Known Rules added: #81 (Branch Sync Protocol — context pointer to pr-review-loop Section 4).
+
+### 2026-04-21 (Global — Model Routing Hardening)
+- Gate status: No active slice. Governance hardening task complete.
+- Artifact changes:
+  - `.github/AGENTS.md` — added shared Model Routing Policy and bumped protocol version to 3.20.
+  - `.github/agents/architect-orchestrator.agent.md` — made explicit-model sync handoffs mandatory for specialist roles.
+  - `.github/skills/async-agent-dispatch/SKILL.md` — added role-to-model table and shared routing-helper rule.
+  - Gate 4 skill updated: `architecture-gate-orchestration` now requires `gpt-5.4` in the sync handoff.
+  - Added `scripts/agent-model-routing.ts` and updated `scripts/run-agent.ts` + `scripts/mcp-dev-orchestrator.ts` to resolve role defaults automatically.
+- Open questions status: None.
+- Next micro-goal: Use the hardened routing defaults on the next slice intake and the next async build dispatch.
+- Blockers/owner decisions: Product Owner approved the role-model map: challenger / PRD / design QA → `claude-sonnet-4.6`; orchestrator / architecture / runtime QA → `gpt-5.4`; dev → `gpt-5.3-codex`.

--- a/.github/skills/architecture-gate-orchestration/SKILL.md
+++ b/.github/skills/architecture-gate-orchestration/SKILL.md
@@ -29,7 +29,7 @@ Orchestrator must include Figma frame URLs with node IDs in the Gate 4 handoff p
 
 ## Architecture Gate Handoff Trigger
 
-When executing Gate 4, invoke `architecture-agent` with slice artifacts (`01-requirement.md`, `02-prd.md`, `03-ux.md`, `04-design-qa.md`) **and Figma frame URLs with node IDs from `04-design-qa.md`** and any explicit Product Owner technical constraints.
+When executing Gate 4, invoke `architecture-agent` with model `gpt-5.4`, slice artifacts (`01-requirement.md`, `02-prd.md`, `03-ux.md`, `04-design-qa.md`) **and Figma frame URLs with node IDs from `04-design-qa.md`** and any explicit Product Owner technical constraints.
 
 ## Execution Rule
 

--- a/.github/skills/async-agent-dispatch/SKILL.md
+++ b/.github/skills/async-agent-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: async-agent-dispatch
-description: "Async agent dispatch workflow: run a single Copilot SDK agent via run-agent.ts, launch parallel async agents for Gate 5 parallel dev dispatch, apply session context prefix for chat traceability, read prompts from files, configure MCP servers via mcp.json, and maintain Figma OAuth token lifecycle. Use when: dispatching any named agent (prd-agent, dev, design-qa-agent, etc.) from the terminal, running Gate 5 parallel dev agents as background processes, tracing async chat sessions back to their originating slice/gate, troubleshooting MCP tool access, or refreshing an expired Figma OAuth token."
+description: "Async agent dispatch workflow: run a single Copilot SDK agent via run-agent.ts, launch parallel async agents for Gate 5 parallel dev dispatch, apply role-based model routing, apply session context prefix for chat traceability, read prompts from files, configure MCP servers via mcp.json, and maintain Figma OAuth token lifecycle. Use when: dispatching any named agent (prd-agent, dev, design-qa-agent, etc.) from the terminal, running Gate 5 parallel dev agents as background processes, tracing async chat sessions back to their originating slice/gate, troubleshooting MCP tool access, or refreshing an expired Figma OAuth token."
 ---
 
 # Async Agent Dispatch
@@ -32,6 +32,28 @@ Before every agent dispatch, classify the expected output:
 
 **Violation pattern to avoid:** using `runSubagent` to dispatch a dev agent to fix review comments. The commit SHA and thread replies are verifiable on GitHub; they do not need to flow into the orchestrator's reasoning context. Using `runSubagent` in this case blocks the chat session for the full agent duration unnecessarily.
 
+## Role-Based Model Routing (Mandatory)
+
+`scripts/agent-model-routing.ts` is the source of truth for terminal and async role defaults.
+
+| Role | Default model | Typical use |
+|---|---|---|
+| `architect-orchestrator` | `gpt-5.4` | coordination and gate decisions |
+| `requirement-challenger` | `claude-sonnet-4.6` | requirement challenge |
+| `prd-agent` | `claude-sonnet-4.6` | PRD drafting |
+| `design-qa-agent` | `claude-sonnet-4.6` | design QA critique |
+| `architecture-agent` | `gpt-5.4` | architecture reasoning |
+| `dev` | `gpt-5.3-codex` | issue-scoped implementation |
+| `runtime-qa` | `gpt-5.4` | runtime verdict synthesis |
+
+Rules:
+
+1. Gates 1, 2, 3B, 4, and 5.5 use sync `runSubagent` handoffs; those calls must pass an explicit `model` matching the shared policy.
+2. `scripts/run-agent.ts` resolves the role default automatically when `--model` is omitted and logs both the resolved model and whether it came from the role default or an override.
+3. `scripts/mcp-dev-orchestrator.ts` uses the same routing table for parallel async runs and includes the resolved model in task status output.
+4. If a task genuinely needs a non-default model, dispatch it directly with `scripts/run-agent.ts --model <id>` and record why in the handoff or dispatch note.
+5. Before introducing a new live role, add it to `scripts/agent-model-routing.ts` and this table in the same change.
+
 ---
 
 ## Core Script
@@ -43,6 +65,7 @@ Before every agent dispatch, classify the expected output:
 **Dependencies**:
 - `@github/copilot-sdk` (consumed from `node_modules`)
 - `tsx` — TypeScript executor (via `npx tsx`)
+- `scripts/agent-model-routing.ts` — shared role-to-model defaults
 - `.github/agents/*.agent.md` — role definitions (name, tools frontmatter, system message body)
 - `.vscode/mcp.json` — MCP server registry with `_envHeaders` and `_toolPrefixes` extensions
 - `local.env` — local secrets (gitignored); must be sourced before running if any MCP server needs env-based auth

--- a/scripts/agent-model-routing.ts
+++ b/scripts/agent-model-routing.ts
@@ -1,0 +1,17 @@
+export const FALLBACK_MODEL = "gpt-5.4";
+
+export const ROLE_DEFAULT_MODELS = {
+    "architect-orchestrator": "gpt-5.4",
+    "requirement-challenger": "claude-sonnet-4.6",
+    "prd-agent": "claude-sonnet-4.6",
+    "design-qa-agent": "claude-sonnet-4.6",
+    "architecture-agent": "gpt-5.4",
+    dev: "gpt-5.3-codex",
+    "runtime-qa": "gpt-5.4",
+    "ux-agent": "claude-sonnet-4.6",
+    "figma-agent": "gpt-5.4",
+} as const satisfies Record<string, string>;
+
+export function defaultModelForRole(role: string): string {
+    return ROLE_DEFAULT_MODELS[role] ?? FALLBACK_MODEL;
+}

--- a/scripts/agent-model-routing.ts
+++ b/scripts/agent-model-routing.ts
@@ -8,8 +8,6 @@ export const ROLE_DEFAULT_MODELS = {
     "architecture-agent": "gpt-5.4",
     dev: "gpt-5.3-codex",
     "runtime-qa": "gpt-5.4",
-    "ux-agent": "claude-sonnet-4.6",
-    "figma-agent": "gpt-5.4",
 } as const satisfies Record<string, string>;
 
 export function defaultModelForRole(role: string): string {

--- a/scripts/agent-model-routing.ts
+++ b/scripts/agent-model-routing.ts
@@ -10,6 +10,27 @@ export const ROLE_DEFAULT_MODELS = {
     "runtime-qa": "gpt-5.4",
 } as const satisfies Record<string, string>;
 
+export type RoleModelSource = "role-default" | "fallback";
+
+export type RoleModelSelection = {
+    model: string;
+    source: RoleModelSource;
+};
+
+export function modelSelectionForRole(role: string): RoleModelSelection {
+    if (Object.prototype.hasOwnProperty.call(ROLE_DEFAULT_MODELS, role)) {
+        return {
+            model: ROLE_DEFAULT_MODELS[role as keyof typeof ROLE_DEFAULT_MODELS],
+            source: "role-default",
+        };
+    }
+
+    return {
+        model: FALLBACK_MODEL,
+        source: "fallback",
+    };
+}
+
 export function defaultModelForRole(role: string): string {
-    return ROLE_DEFAULT_MODELS[role] ?? FALLBACK_MODEL;
+    return modelSelectionForRole(role).model;
 }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -32,13 +32,13 @@ import { fileURLToPath } from "node:url";
 import { basename, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
+import { FALLBACK_MODEL, defaultModelForRole } from "./agent-model-routing.ts";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const WORKSPACE_ROOT = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const AGENTS_DIR = join(WORKSPACE_ROOT, ".github", "agents");
 const MCP_CONFIG_PATH = join(WORKSPACE_ROOT, ".vscode", "mcp.json");
-const MODEL = "gpt-5.3-codex";
 const LOG_DIR = resolve(fileURLToPath(new URL(".", import.meta.url)), "../logs/parallel-agents");
 const AGENT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour per agent
 
@@ -184,6 +184,7 @@ interface Task {
 interface TaskResult {
     taskId: string;
     role: string;
+    model: string;
     sessionId: string;
     status: TaskStatus;
     output?: string;
@@ -268,6 +269,7 @@ function loadPersistedRuns(): void {
                         .map((tid) => ({
                             taskId: tid,
                             role: "unknown",
+                            model: FALLBACK_MODEL,
                             sessionId: "unknown",
                             status: "failed" as TaskStatus,
                             error: "Orchestrator crashed or restarted before task completed",
@@ -320,6 +322,7 @@ async function runAgentTask(
     runId?: string,
     dispatchedAt?: string,
 ): Promise<TaskResult> {
+    const model = defaultModelForRole(task.role);
     const title = task.prompt.split("\n").find((l) => l.trim())?.trim().slice(0, 80) ?? task.id;
     const repo = basename(WORKSPACE_ROOT);
     const provenance = runId
@@ -331,7 +334,7 @@ async function runAgentTask(
             `task-id:    ${task.id}`,
             `title:      ${title}`,
             `role:       ${task.role}`,
-            `model:      ${MODEL}`,
+            `model:      ${model}`,
             `repo:       ${repo}`,
             `dispatched: ${dispatchedAt}`,
             "```",
@@ -351,7 +354,7 @@ async function runAgentTask(
         // createSession is inside try so a failure returns a task-scoped
         // "failed" result rather than throwing into Promise.all.
         session = await client.createSession({
-            model: MODEL,
+            model,
             onPermissionRequest: approveAll,
             systemMessage: { content: systemMessageForRole(task.role, task.systemMessage) },
             ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
@@ -378,6 +381,7 @@ async function runAgentTask(
             return {
                 taskId: task.id,
                 role: task.role,
+                model,
                 sessionId: session.sessionId,
                 status: "needs-clarification",
                 output,
@@ -385,11 +389,12 @@ async function runAgentTask(
             };
         }
 
-        return { taskId: task.id, role: task.role, sessionId: session.sessionId, status: "done", output };
+        return { taskId: task.id, role: task.role, model, sessionId: session.sessionId, status: "done", output };
     } catch (err) {
         return {
             taskId: task.id,
             role: task.role,
+            model,
             sessionId: session?.sessionId ?? "unknown",
             status: "failed",
             error: err instanceof Error ? err.message : String(err),
@@ -462,6 +467,7 @@ function startRun(tasks: Task[], clarifications: Record<string, string>): Run {
         run.results = tasks.map((t) => ({
             taskId: t.id,
             role: t.role,
+            model: defaultModelForRole(t.role),
             sessionId: "unknown",
             status: "failed" as TaskStatus,
             error: String(err),
@@ -638,6 +644,7 @@ server.tool(
             results: run.results.map((r) => ({
                 taskId: r.taskId,
                 role: r.role,
+                model: r.model,
                 status: r.status,
                 sessionId: r.sessionId,
                 ...(r.challenge ? { challenge: r.challenge } : {}),

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -246,18 +246,40 @@ function persistRuns(): void {
     }
 }
 
+function hydratePersistedResults(results: Array<PersistedTaskResult & { model?: string }>): {
+    results: TaskResult[];
+    changed: boolean;
+} {
+    let changed = false;
+    const hydratedResults = results.map((result) => {
+        if (typeof result.model === "string" && result.model.length > 0) {
+            return result as TaskResult;
+        }
+
+        changed = true;
+        return {
+            ...result,
+            model: defaultModelForRole(result.role),
+        } as TaskResult;
+    });
+
+    return { results: hydratedResults, changed };
+}
+
 function loadPersistedRuns(): void {
     try {
         if (!existsSync(RUNS_FILE)) return;
         let mutated = false;
         const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, PersistedRun>;
         for (const [id, persisted] of Object.entries(raw)) {
+            const { results, changed } = hydratePersistedResults(persisted.results);
             // Hydrate the lossy persisted shape back to a full Run before mutating.
             const run: Run = {
                 ...persisted,
                 _tasks: [],
-                results: persisted.results as TaskResult[],
+                results,
             };
+            if (changed) mutated = true;
             // Mark any run that was "running" at crash time as failed
             if (run.status === "running") {
                 run.status = "failed";
@@ -614,12 +636,13 @@ server.tool(
                 const raw = JSON.parse(readFileSync(RUNS_FILE, "utf-8")) as Record<string, PersistedRun>;
                 const diskRun = raw[runId];
                 if (diskRun) {
+                    const { results } = hydratePersistedResults(diskRun.results);
                     // Hydrate the lossy persisted shape back to Run: restore _tasks from
                     // memory (disk never has it) and keep results typed correctly.
                     const hydratedDisk: Run = {
                         ...diskRun,
                         _tasks: runs.get(runId)?._tasks ?? [],
-                        results: diskRun.results as TaskResult[],
+                        results,
                     };
                     runs.set(runId, mergeRunState(runs.get(runId), hydratedDisk));
                 }

--- a/scripts/mcp-dev-orchestrator.ts
+++ b/scripts/mcp-dev-orchestrator.ts
@@ -246,7 +246,7 @@ function persistRuns(): void {
     }
 }
 
-function hydratePersistedResults(results: Array<PersistedTaskResult & { model?: string }>): {
+function hydratePersistedResults(results: Array<Omit<PersistedTaskResult, "model"> & { model?: string }>): {
     results: TaskResult[];
     changed: boolean;
 } {

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -8,7 +8,7 @@
  * Options:
  *   --pre-sleep <seconds>   Sleep before sending the prompt (useful for async demo runs)
  *   --no-intro              Skip the automatic role-introduction prefix
- *   --model <model-id>      Override the default model (default: gpt-5.3-codex)
+ *   --model <model-id>      Override the role default model (fallback: gpt-5.4)
  *   --task-id <task-id>     Optional issue/task reference for provenance block
  *   --allow-agent-orchestrator-mcp
  *                           Allow attaching the agent-orchestrator MCP server (disabled by default)
@@ -29,10 +29,10 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { fileURLToPath } from "node:url";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
+import { defaultModelForRole } from "./agent-model-routing.ts";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
-const DEFAULT_MODEL = "gpt-5.3-codex";
 const REASONING_EFFORT = "high" as const;
 const TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 const MAX_RETRIES = 3;             // Retry sendAndWait on transient failures
@@ -179,7 +179,7 @@ function resolveAgentMcpServers(
 
 let preSleepMs = 0;
 let noIntro = false;
-let model = DEFAULT_MODEL;
+let modelOverride: string | undefined;
 let taskIdArg: string | undefined;
 let allowAgentOrchestratorMcp = false;
 let outputFormat: "text" | "json" = "text";
@@ -207,7 +207,7 @@ for (let i = 0; i < argv.length;) {
         noIntro = true;
         argv.splice(i, 1);
     } else if (argv[i] === "--model") {
-        model = requireOptionValue("--model", argv[i + 1]);
+        modelOverride = requireOptionValue("--model", argv[i + 1]);
         argv.splice(i, 2);
     } else if (argv[i] === "--task-id") {
         taskIdArg = requireOptionValue("--task-id", argv[i + 1]);
@@ -246,6 +246,9 @@ if (argv.length !== 2) {
     process.exit(1);
 }
 const [role, rawPrompt] = argv;
+const roleDefaultModel = defaultModelForRole(role);
+const model = modelOverride ?? roleDefaultModel;
+const modelSource = modelOverride ? "--model override" : "role default";
 
 // Support @file references: `@path/to/file.md` reads file contents as the prompt
 const prompt = rawPrompt.startsWith("@")
@@ -358,6 +361,7 @@ function inferTaskId(prompt: string, explicitTaskId?: string): string {
 const runId = randomUUID();
 const startedAt = new Date().toISOString();
 logInfo(`[run-agent] started  runId=${runId} role=${role} model=${model} effort=${REASONING_EFFORT} at=${startedAt}`);
+logInfo(`[run-agent] routing  role-default=${roleDefaultModel} model-source=${modelSource}`);
 logInfo(`[run-agent] prompt   ${prompt.slice(0, 120).replace(/\n/g, " ")}${prompt.length > 120 ? "…" : ""}`);
 
 const { tools, systemMessage } = readAgentMeta(role);

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -249,7 +249,7 @@ const [role, rawPrompt] = argv;
 const policyModelSelection = modelSelectionForRole(role);
 const policyModel = policyModelSelection.model;
 const model = modelOverride ?? policyModel;
-const modelSource = modelOverride ? "--model override" : policyModelSelection.source;
+const modelSource = modelOverride ? "model-override" : policyModelSelection.source;
 
 // Support @file references: `@path/to/file.md` reads file contents as the prompt
 const prompt = rawPrompt.startsWith("@")

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -8,7 +8,7 @@
  * Options:
  *   --pre-sleep <seconds>   Sleep before sending the prompt (useful for async demo runs)
  *   --no-intro              Skip the automatic role-introduction prefix
- *   --model <model-id>      Override the role default model (fallback: gpt-5.4)
+ *   --model <model-id>      Override the role default model (otherwise uses configured routing)
  *   --task-id <task-id>     Optional issue/task reference for provenance block
  *   --allow-agent-orchestrator-mcp
  *                           Allow attaching the agent-orchestrator MCP server (disabled by default)

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -29,7 +29,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { fileURLToPath } from "node:url";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
-import { defaultModelForRole } from "./agent-model-routing.ts";
+import { modelSelectionForRole } from "./agent-model-routing.ts";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -246,9 +246,10 @@ if (argv.length !== 2) {
     process.exit(1);
 }
 const [role, rawPrompt] = argv;
-const roleDefaultModel = defaultModelForRole(role);
-const model = modelOverride ?? roleDefaultModel;
-const modelSource = modelOverride ? "--model override" : "role default";
+const policyModelSelection = modelSelectionForRole(role);
+const policyModel = policyModelSelection.model;
+const model = modelOverride ?? policyModel;
+const modelSource = modelOverride ? "--model override" : policyModelSelection.source;
 
 // Support @file references: `@path/to/file.md` reads file contents as the prompt
 const prompt = rawPrompt.startsWith("@")
@@ -361,7 +362,10 @@ function inferTaskId(prompt: string, explicitTaskId?: string): string {
 const runId = randomUUID();
 const startedAt = new Date().toISOString();
 logInfo(`[run-agent] started  runId=${runId} role=${role} model=${model} effort=${REASONING_EFFORT} at=${startedAt}`);
-logInfo(`[run-agent] routing  role-default=${roleDefaultModel} model-source=${modelSource}`);
+logInfo(`[run-agent] routing  policy-model=${policyModel} policy-source=${policyModelSelection.source} model-source=${modelSource}`);
+if (!modelOverride && policyModelSelection.source === "fallback") {
+    logInfo(`[run-agent] warning  unknown role='${role}' not found in routing table; using fallback model=${policyModel}`);
+}
 logInfo(`[run-agent] prompt   ${prompt.slice(0, 120).replace(/\n/g, " ")}${prompt.length > 120 ? "…" : ""}`);
 
 const { tools, systemMessage } = readAgentMeta(role);


### PR DESCRIPTION
## Summary
Harden repository-wide model routing so each agent role uses the intended default reasoning lane.

## What changed
- added a shared role-to-model routing helper in `scripts/agent-model-routing.ts`
- updated `scripts/run-agent.ts` to resolve role defaults automatically and log routing provenance
- updated `scripts/mcp-dev-orchestrator.ts` to use the same role defaults and surface the resolved model in task status output
- documented the shared policy in `.github/AGENTS.md`, `.github/agents/architect-orchestrator.agent.md`, `.github/skills/async-agent-dispatch/SKILL.md`, `.github/skills/architecture-gate-orchestration/SKILL.md`, and `.github/orchestrator-context.md`

## Validation
- editor diagnostics: no errors in the changed TypeScript files
- routing helper smoke test:
  - `requirement-challenger=claude-sonnet-4.6`
  - `architecture-agent=gpt-5.4`
  - `dev=gpt-5.3-codex`
  - `runtime-qa=gpt-5.4`
- live dispatcher smoke test confirmed `requirement-challenger` starts on `claude-sonnet-4.6` with `model-source=role default`

## Notes
- this PR is intentionally isolated from other local changes that will be opened separately
