### PR TITLE
Refine protocol communication and output guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Protocol-Version: 3.26 -->
+<!-- Protocol-Version: 3.27 -->
 <!-- Last-Updated: 2026-04-23 -->
 
 # Shared Agent Protocol
@@ -24,6 +24,13 @@ This repository follows a human-led, agent-executed workflow.
 1. This file is the canonical source for shared cross-agent rules.
 2. Agent files under `.github/agents/` must reference shared sections in this file instead of duplicating full text.
 3. Agent files should only define role-specific constraints, inputs, and outputs.
+
+## Communication Style
+
+1. Default agent voice should be clear, friendly, slightly goofy, and a little nerdy when the situation allows.
+2. Responses should be pleasant for a human to scan: use clear section breaks, tidy spacing, and formatting that feels readable instead of sterile.
+3. Personality must not reduce technical precision. Risks, blockers, ownership boundaries, destructive actions, and irreversible steps must still be stated plainly.
+4. Playful language is welcome; fluff, vagueness, or softened warnings are not.
 
 ## Slice Complexity Classification
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -184,17 +184,20 @@ Always cover these reporting fields in this order when they are relevant:
 Formatting rules:
 
 1. Prefer readable Markdown structure over plain text label stacks: use bold mini-headings, short bullet lists, concise paragraphs, or a mix of these when helpful.
-2. Do not force the literal section titles above when a more natural presentation would read better.
+2. Treat the five items above as semantic reporting fields that must stay in the same order when present, even if headings are renamed or collapsed for readability.
 3. For short updates, prefer a compact three-block shape such as `Quick Snapshot`, `Next Move`, and `Blockers` over a five-part breakdown.
-4. When using that compact shape, fold light `Decisions` and `Assumptions` into `Quick Snapshot` in the same relative order they would normally appear.
-5. Omit empty sections instead of printing hollow headers. If a field is empty, collapse it into a short inline note such as `Blockers: none.`
-6. Avoid naked one-line labels with blank space under them. If a field needs its own line, give it at least a short sentence or bullet.
-7. Use stronger section breaks only when the update is complex, gate-critical, or contains owner decisions that benefit from emphasis.
-8. Keep formatting human-friendly, not ornamental: clarity first, personality second.
+4. Do not force the literal section titles above when a more natural presentation would read better, unless a gate-specific rule below requires an explicit heading.
+5. When using the compact shape, map fields explicitly in this order: `Quick Snapshot` = `Slice Status` first, then light `Decisions`, then light `Assumptions`; `Next Move` = `Next Handoff`; `Blockers` = `Blockers`.
+6. Omit empty sections instead of printing hollow headers. If a field is empty, collapse it into a short inline note such as `Blockers: none.`
+7. Avoid naked one-line labels with blank space under them. If a field needs its own line, give it at least a short sentence or bullet.
+8. Use stronger section breaks only when the update is complex, gate-critical, or contains owner decisions that benefit from emphasis.
+9. Keep formatting human-friendly, not ornamental: clarity first, personality second.
 
-Gate 3 reporting addendum (must keep the same top-level section order above):
+Gate 3 reporting addendum (preserve the reporting field order above when those fields are present; alternate headings and compact layouts are still allowed under the formatting rules):
 
-1. When reporting Gate 3A (UX+Design single-pass) or Gate 3B (Design QA) status, include a `Design Access` subsection inside `Slice Status` with runtime-preview node-targeted Figma URL(s) (`?node-id=`), page list, key frame/state node IDs, pass-level change summary, and the exact Product Owner review action requested. Annotated traceability links may be listed separately as secondary evidence.
+1. When reporting Gate 3A (UX+Design single-pass) or Gate 3B (Design QA) status, always include an explicit top-level `Slice Status` section, even if the rest of the update uses the compact shape.
+2. Inside that `Slice Status` section, include a `Design Access` subsection with runtime-preview node-targeted Figma URL(s) (`?node-id=`), page list, key frame/state node IDs, pass-level change summary, and the exact Product Owner review action requested. Annotated traceability links may be listed separately as secondary evidence.
+3. For Gate 3 updates that otherwise use the compact shape, place any remaining light `Decisions` and `Assumptions` after `Design Access` within `Slice Status`, then continue with `Next Move`/`Next Handoff` and `Blockers` in the same semantic order.
 
 For first response in a new activity, prepend:
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -173,7 +173,7 @@ Follow the merge recommendation checklist in `build-evidence-and-merge-readiness
 
 ## Output Format
 
-Always return sections in this order:
+Always cover these reporting fields in this order when they are relevant:
 
 1. `Slice Status`: current gate and progress.
 2. `Decisions`: approved and pending decisions.
@@ -181,13 +181,24 @@ Always return sections in this order:
 4. `Next Handoff`: target agent + packet summary.
 5. `Blockers`: hard blockers and required owner action.
 
+Formatting rules:
+
+1. Prefer readable Markdown structure over plain text label stacks: use bold mini-headings, short bullet lists, concise paragraphs, or a mix of these when helpful.
+2. Do not force the literal section titles above when a more natural presentation would read better.
+3. For short updates, prefer a compact three-block shape such as `Quick Snapshot`, `Next Move`, and `Blockers` over a five-part breakdown.
+4. When using that compact shape, fold light `Decisions` and `Assumptions` into `Quick Snapshot` in the same relative order they would normally appear.
+5. Omit empty sections instead of printing hollow headers. If a field is empty, collapse it into a short inline note such as `Blockers: none.`
+6. Avoid naked one-line labels with blank space under them. If a field needs its own line, give it at least a short sentence or bullet.
+7. Use stronger section breaks only when the update is complex, gate-critical, or contains owner decisions that benefit from emphasis.
+8. Keep formatting human-friendly, not ornamental: clarity first, personality second.
+
 Gate 3 reporting addendum (must keep the same top-level section order above):
 
 1. When reporting Gate 3A (UX+Design single-pass) or Gate 3B (Design QA) status, include a `Design Access` subsection inside `Slice Status` with runtime-preview node-targeted Figma URL(s) (`?node-id=`), page list, key frame/state node IDs, pass-level change summary, and the exact Product Owner review action requested. Annotated traceability links may be listed separately as secondary evidence.
 
 For first response in a new activity, prepend:
 
-1. `Resume Snapshot`: current gate, known artifacts, next micro-goal.
+1. `Resume Snapshot`: current gate, known artifacts, next micro-goal. This may be rendered as a short kickoff blurb instead of a rigid standalone header when that reads better.
 
 ## Subagent Allow-List Policy
 

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -188,7 +188,7 @@ Formatting rules:
 3. For short updates, prefer a compact three-block shape such as `Quick Snapshot`, `Next Move`, and `Blockers` over a five-part breakdown.
 4. Do not force the literal section titles above when a more natural presentation would read better, unless a gate-specific rule below requires an explicit heading.
 5. When using the compact shape, map fields explicitly in this order: `Quick Snapshot` = `Slice Status` first, then light `Decisions`, then light `Assumptions`; `Next Move` = `Next Handoff`; `Blockers` = `Blockers`.
-6. Omit empty sections instead of printing hollow headers. If a field is empty, collapse it into a short inline note such as `Blockers: none.`
+6. Omit empty sections instead of printing hollow headers. If a field is empty, collapse it into a short inline note such as `Blockers: none.`, but place that note where the field would normally appear in the reporting order.
 7. Avoid naked one-line labels with blank space under them. If a field needs its own line, give it at least a short sentence or bullet.
 8. Use stronger section breaks only when the update is complex, gate-critical, or contains owner decisions that benefit from emphasis.
 9. Keep formatting human-friendly, not ornamental: clarity first, personality second.

--- a/.github/agents/architect-orchestrator.agent.md
+++ b/.github/agents/architect-orchestrator.agent.md
@@ -191,7 +191,7 @@ Formatting rules:
 6. Omit empty sections instead of printing hollow headers. If a field is empty, collapse it into a short inline note such as `Blockers: none.`, but place that note where the field would normally appear in the reporting order.
 7. Avoid naked one-line labels with blank space under them. If a field needs its own line, give it at least a short sentence or bullet.
 8. Use stronger section breaks only when the update is complex, gate-critical, or contains owner decisions that benefit from emphasis.
-9. Keep formatting human-friendly, not ornamental: clarity first, personality second.
+9. Follow the repo-wide `Communication Style` guidance in `.github/AGENTS.md` for general tone and formatting expectations.
 
 Gate 3 reporting addendum (preserve the reporting field order above when those fields are present; alternate headings and compact layouts are still allowed under the formatting rules):
 


### PR DESCRIPTION
## Summary
- add shared communication-style guidance to the repo protocol
- remove duplicated style guidance from the orchestrator agent file
- make orchestrator output formatting more human-friendly and bias short updates toward a compact three-block shape

## Why
The existing orchestrator output contract pushed responses toward rigid, low-signal heading shells. This change keeps the reporting contract intact while making updates easier for a human to read.

## Notes
- no product behavior changed
- this is protocol and instruction-only work