### PR TITLE
chore: record debate-screen-polish closeout

### DIFF
--- a/.github/orchestrator-context.md
+++ b/.github/orchestrator-context.md
@@ -191,7 +191,7 @@ On first response in any new activity:
 | `coming-soon-splash-page` | ✅ Pass | ✅ Full Pass | ✅ Pass (PO approved 2026-03-29) | ✅ Pass | ✅ Complete (T3 PR #18, T4 PR #19, T5 PR #20 all merged) | ✅ Complete (2026-03-29) |
 | `debate-screen` | ✅ Pass | ✅ Full Pass | ✅ Pass (PO approved 2026-04-06) | ✅ Pass (Revision 1.1) | ✅ Complete (T1–T9 + visual polish PR #61) | ✅ Complete (2026-04-07) |
 | `post-tark-vitark` | ✅ Re-pass (refined, 2026-04-08) | ✅ Re-pass (2026-04-08) | ✅ Pass (PO approved 2026-04-16, PR #83 merged) | ✅ Pass (2026-04-16, PR #94 merged) | ✅ Complete (T-1–T-8 + post-build PRs #106, #108, slice merge PR #109) | ✅ Complete (2026-04-17, PR #112 merged) |
-| `debate-screen-polish` | ✅ Pass (2026-04-17, Standard) | ✅ Full Pass (2026-04-17) | ✅ Pass | ✅ Pass | — | — |
+| `debate-screen-polish` | ✅ Pass (2026-04-17, Standard) | ✅ Full Pass (2026-04-17) | ✅ Pass | ✅ Pass | ✅ Complete (T-1 #124, T-2 #125, T-3 #126; integrated 2026-04-19) | ✅ Complete (2026-04-19; tracker #127 closed) |
 
 ## Log Archive Protocol
 
@@ -224,19 +224,7 @@ Template:
 - Next micro-goal:
 - Blockers/owner decisions:
 
-### 2026-04-17 (debate-screen-polish Gate 2 Full Pass)
-- Gate status: `debate-screen-polish` Gate 2 ✅ Full Pass. PRD v0 complete with 11 FRs, 12 ACs, 5 constraints, 5 success metrics.
-- Artifact changes: Created `docs/slices/debate-screen-polish/02-prd.md`.
-- Open questions status: OQ-1 (width) non-blocking — Gate 3A owns resolution, AC-1 carries placeholder. OQ-4 (fix strategy) non-blocking — Gate 4 owns resolution. OQ-3 non-blocking, no gate assignment. OQ-5 de-facto resolved by AC-6 + AC-7.
-- Next micro-goal: Gate 3 — UX+Design single-pass (Orchestrator executes via `ux-design-execution` skill).
-- Blockers/owner decisions: None. Ready for Gate 3.
-
-### 2026-04-17 (debate-screen-polish Gate 1 Pass)
-- Gate status: `debate-screen-polish` Gate 1 ✅ Pass. Complexity: Standard (full 6-gate flow).
-- Artifact changes: Created `docs/slices/debate-screen-polish/01-requirement.md`.
-- Open questions status: OQ-2 resolved (stagger preserved — Tark left, Vitark right). OQ-1 (target mobile card width) accepted as PO-approved open to be resolved at Gate 3A via Figma frames. OQ-3, OQ-4, OQ-5 non-blocking, carried forward.
-- Next micro-goal: Gate 2 — invoke PRD Agent with Requirement Context Package.
-- Blockers/owner decisions: None. OQ-1 resolution delegated to Gate 3A.
+### debate-screen-polish — Gate 6 ✅ Complete (2026-04-19) — Full log: docs/slices/debate-screen-polish/context-log.md
 
 ### coming-soon-splash-page — Gate 6 ✅ Complete (2026-03-29) — Full log: docs/slices/coming-soon-splash-page/context-log.md
 

--- a/docs/slices/debate-screen-polish/context-log.md
+++ b/docs/slices/debate-screen-polish/context-log.md
@@ -6,19 +6,19 @@ Gate 3 and Gate 4 were completed for this slice, but those transitions were not 
 
 ---
 
-### 2026-04-17 (debate-screen-polish Gate 2 Full Pass)
-- Gate status: `debate-screen-polish` Gate 2 ✅ Full Pass. PRD v0 complete with 11 FRs, 12 ACs, 5 constraints, 5 success metrics.
-- Artifact changes: Created `docs/slices/debate-screen-polish/02-prd.md`.
-- Open questions status: OQ-1 (width) non-blocking — Gate 3A owns resolution, AC-1 carries placeholder. OQ-4 (fix strategy) non-blocking — Gate 4 owns resolution. OQ-3 non-blocking, no gate assignment. OQ-5 de-facto resolved by AC-6 + AC-7.
-- Next micro-goal: Gate 3 — UX+Design single-pass (Orchestrator executes via `ux-design-execution` skill).
-- Blockers/owner decisions: None. Ready for Gate 3.
-
 ### 2026-04-17 (debate-screen-polish Gate 1 Pass)
 - Gate status: `debate-screen-polish` Gate 1 ✅ Pass. Complexity: Standard (full 6-gate flow).
 - Artifact changes: Created `docs/slices/debate-screen-polish/01-requirement.md`.
 - Open questions status: OQ-2 resolved (stagger preserved — Tark left, Vitark right). OQ-1 (target mobile card width) accepted as PO-approved open to be resolved at Gate 3A via Figma frames. OQ-3, OQ-4, OQ-5 non-blocking, carried forward.
 - Next micro-goal: Gate 2 — invoke PRD Agent with Requirement Context Package.
 - Blockers/owner decisions: None. OQ-1 resolution delegated to Gate 3A.
+
+### 2026-04-17 (debate-screen-polish Gate 2 Full Pass)
+- Gate status: `debate-screen-polish` Gate 2 ✅ Full Pass. PRD v0 complete with 11 FRs, 12 ACs, 5 constraints, 5 success metrics.
+- Artifact changes: Created `docs/slices/debate-screen-polish/02-prd.md`.
+- Open questions status: OQ-1 (width) non-blocking — Gate 3A owns resolution, AC-1 carries placeholder. OQ-4 (fix strategy) non-blocking — Gate 4 owns resolution. OQ-3 non-blocking, no gate assignment. OQ-5 de-facto resolved by AC-6 + AC-7.
+- Next micro-goal: Gate 3 — UX+Design single-pass (Orchestrator executes via `ux-design-execution` skill).
+- Blockers/owner decisions: None. Ready for Gate 3.
 
 ### 2026-04-19 (debate-screen-polish Slice Completion, recorded 2026-04-23)
 - Gate status: `debate-screen-polish` slice closure confirmed from execution evidence. Slice tracker #127 is closed. Task issues #124, #125, and #126 are closed. Duplicate issue #128 is closed as a duplicate of #124.

--- a/docs/slices/debate-screen-polish/context-log.md
+++ b/docs/slices/debate-screen-polish/context-log.md
@@ -1,0 +1,28 @@
+# Context Update Log — debate-screen-polish
+
+Archived from `.github/orchestrator-context.md` on 2026-04-23. Gate 6 completion was retroactively recorded from slice-local closure evidence in `docs/slices/debate-screen-polish/06-tasks.md` and live GitHub issue state because the live orchestrator context had not been updated after the slice was integrated.
+
+Gate 3 and Gate 4 were completed for this slice, but those transitions were not logged separately in `.github/orchestrator-context.md`; use the gate artifacts in this slice folder as the authoritative record for those stages.
+
+---
+
+### 2026-04-17 (debate-screen-polish Gate 2 Full Pass)
+- Gate status: `debate-screen-polish` Gate 2 ✅ Full Pass. PRD v0 complete with 11 FRs, 12 ACs, 5 constraints, 5 success metrics.
+- Artifact changes: Created `docs/slices/debate-screen-polish/02-prd.md`.
+- Open questions status: OQ-1 (width) non-blocking — Gate 3A owns resolution, AC-1 carries placeholder. OQ-4 (fix strategy) non-blocking — Gate 4 owns resolution. OQ-3 non-blocking, no gate assignment. OQ-5 de-facto resolved by AC-6 + AC-7.
+- Next micro-goal: Gate 3 — UX+Design single-pass (Orchestrator executes via `ux-design-execution` skill).
+- Blockers/owner decisions: None. Ready for Gate 3.
+
+### 2026-04-17 (debate-screen-polish Gate 1 Pass)
+- Gate status: `debate-screen-polish` Gate 1 ✅ Pass. Complexity: Standard (full 6-gate flow).
+- Artifact changes: Created `docs/slices/debate-screen-polish/01-requirement.md`.
+- Open questions status: OQ-2 resolved (stagger preserved — Tark left, Vitark right). OQ-1 (target mobile card width) accepted as PO-approved open to be resolved at Gate 3A via Figma frames. OQ-3, OQ-4, OQ-5 non-blocking, carried forward.
+- Next micro-goal: Gate 2 — invoke PRD Agent with Requirement Context Package.
+- Blockers/owner decisions: None. OQ-1 resolution delegated to Gate 3A.
+
+### 2026-04-19 (debate-screen-polish Slice Completion, recorded 2026-04-23)
+- Gate status: `debate-screen-polish` slice closure confirmed from execution evidence. Slice tracker #127 is closed. Task issues #124, #125, and #126 are closed. Duplicate issue #128 is closed as a duplicate of #124.
+- Artifact changes: `docs/slices/debate-screen-polish/06-tasks.md` already marked the slice "fully integrated and CLOSED" as of 2026-04-19. `.github/orchestrator-context.md` was updated on 2026-04-23 so the live status table no longer shows the slice as incomplete.
+- Open questions status: None surfaced during reconciliation. The slice tracker body remained stale (`In Build`), but its closure comment and the closed task issues are the authoritative completion signal.
+- Next micro-goal: No further work required for `debate-screen-polish`. The next slice may start from Gate 1 intake.
+- Blockers/owner decisions: None.


### PR DESCRIPTION
## Summary
Record the already-completed `debate-screen-polish` slice in the live orchestrator context and archive its slice-specific context log.

## What Changed
- update `.github/orchestrator-context.md` to mark Gate 5 and Gate 6 complete for `debate-screen-polish`
- add `docs/slices/debate-screen-polish/context-log.md`
- replace the live debate-screen-polish log entries with an archive summary line

## Why
The slice had already been integrated on `master`, but the live orchestrator context still showed it as incomplete. This PR reconciles the repo record to the actual GitHub slice tracker and story issue state.

## Evidence
- slice tracker: #127
- story issues: #124, #125, #126
- duplicate issue: #128

## Notes
This is a bookkeeping-only PR. No runtime behavior changes.