### PR TITLE
[create-debate][T4] DebateScreen empty-state and create integration

### DIFF
--- a/src/styles/components/debate-topic-form.css
+++ b/src/styles/components/debate-topic-form.css
@@ -160,6 +160,18 @@
     outline-offset: 2px;
 }
 
+@media (min-width: 768px) {
+    .debate-topic-form__form {
+        max-width: 600px;
+    }
+}
+
+@media (min-width: 1024px) {
+    .debate-topic-form__form {
+        max-width: 640px;
+    }
+}
+
 [data-theme='dark'] .debate-topic-form__start:disabled {
     color: var(--color-surface-default);
 }

--- a/src/styles/components/debate-topic-form.css
+++ b/src/styles/components/debate-topic-form.css
@@ -162,13 +162,13 @@
 
 @media (min-width: 768px) {
     .debate-topic-form__form {
-        max-width: 600px;
+        max-width: var(--size-create-debate-content-max-width-tablet);
     }
 }
 
 @media (min-width: 1024px) {
     .debate-topic-form__form {
-        max-width: 640px;
+        max-width: var(--size-create-debate-content-max-width-desktop);
     }
 }
 

--- a/src/styles/components/debate-topic-form.css
+++ b/src/styles/components/debate-topic-form.css
@@ -1,4 +1,6 @@
 .debate-topic-form {
+    width: 100%;
+    max-width: var(--size-create-debate-content-max-width);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -25,7 +27,6 @@
 
 .debate-topic-form__form {
     width: 100%;
-    max-width: var(--size-create-debate-content-max-width);
     display: flex;
     flex-direction: column;
 }
@@ -161,13 +162,13 @@
 }
 
 @media (min-width: 768px) {
-    .debate-topic-form__form {
+    .debate-topic-form {
         max-width: var(--size-create-debate-content-max-width-tablet);
     }
 }
 
 @media (min-width: 1024px) {
-    .debate-topic-form__form {
+    .debate-topic-form {
         max-width: var(--size-create-debate-content-max-width-desktop);
     }
 }

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -35,6 +35,13 @@
     color: var(--color-on-surface);
 }
 
+@media (min-width: 768px) {
+    .debate-screen__empty-theme-toggle {
+        left: var(--space-4);
+        top: var(--space-4);
+    }
+}
+
 .debate-screen__action-error {
     max-width: var(--size-create-debate-content-max-width);
     color: var(--color-error);

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -51,6 +51,18 @@
     letter-spacing: var(--typescale-label-md-tracking);
 }
 
+@media (min-width: 768px) {
+    .debate-screen__action-error {
+        max-width: var(--size-create-debate-content-max-width-tablet);
+    }
+}
+
+@media (min-width: 1024px) {
+    .debate-screen__action-error {
+        max-width: var(--size-create-debate-content-max-width-desktop);
+    }
+}
+
 .debate-screen__active-action-error {
     margin: 0 auto var(--space-4);
     padding: 0 var(--space-4);

--- a/src/styles/debate-screen.css
+++ b/src/styles/debate-screen.css
@@ -23,6 +23,7 @@
     min-height: 100vh;
     min-height: 100dvh;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 0 var(--space-4) max(var(--space-4), env(safe-area-inset-bottom, 0px));
@@ -71,5 +72,6 @@
 
 .debate-screen__empty-action-error {
     margin: 0 0 var(--space-4);
+    width: 100%;
     text-align: center;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -83,6 +83,8 @@
   /* ── Dimension ── */
   --divider-thickness: 1px;
   --size-create-debate-content-max-width: 358px;
+  --size-create-debate-content-max-width-tablet: 600px;
+  --size-create-debate-content-max-width-desktop: 640px;
 }
 
 [data-theme="dark"] {

--- a/tests/a11y/debate-screen-a11y.test.tsx
+++ b/tests/a11y/debate-screen-a11y.test.tsx
@@ -66,7 +66,7 @@ describe('axe-core accessibility audit — DebateScreen', () => {
         }
     });
 
-    it('AC-37: empty-to-active transition keeps zero critical/serious violations', async () => {
+    it('AC-37: starting a debate keeps both the topic draft and active debate accessible', async () => {
         window.localStorage.clear();
         const { container } = render(<DebateScreen />);
 

--- a/tests/a11y/debate-screen-a11y.test.tsx
+++ b/tests/a11y/debate-screen-a11y.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import * as axe from 'axe-core';
 import { DebateScreen } from '../../src/components/DebateScreen';
@@ -64,5 +64,26 @@ describe('axe-core accessibility audit — DebateScreen', () => {
             unmount();
             document.documentElement.removeAttribute('data-theme');
         }
+    });
+
+    it('AC-37: empty-to-active transition keeps zero critical/serious violations', async () => {
+        window.localStorage.clear();
+        const { container } = render(<DebateScreen />);
+
+        const emptyStateResults = await runAxe(container);
+        expect(filterViolations(emptyStateResults, ['critical', 'serious'])).toHaveLength(0);
+
+        const createdDebateTopic = 'Is remote work better than office work?';
+        fireEvent.change(screen.getByRole('textbox', { name: 'Debate topic' }), {
+            target: { value: createdDebateTopic },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(createdDebateTopic);
+        });
+
+        const activeStateResults = await runAxe(container);
+        expect(filterViolations(activeStateResults, ['critical', 'serious'])).toHaveLength(0);
     });
 });

--- a/tests/a11y/landmarks.test.tsx
+++ b/tests/a11y/landmarks.test.tsx
@@ -59,7 +59,7 @@ describe('Landmark and heading verification', () => {
         expect(navIdx).toBeLessThan(sectionIdx);
     });
 
-    it('AC-37: landmark transition from create flow to active debate preserves semantic regions', async () => {
+    it('AC-37: starting a debate turns topic drafting into an active debate with the expected structure', async () => {
         window.localStorage.clear();
         render(<DebateScreen />);
 

--- a/tests/a11y/landmarks.test.tsx
+++ b/tests/a11y/landmarks.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import {
@@ -57,6 +57,27 @@ describe('Landmark and heading verification', () => {
         const sectionIdx = tagNames.indexOf('section');
         expect(headerIdx).toBeLessThan(navIdx);
         expect(navIdx).toBeLessThan(sectionIdx);
+    });
+
+    it('AC-37: landmark transition from create flow to active debate preserves semantic regions', async () => {
+        window.localStorage.clear();
+        render(<DebateScreen />);
+
+        expect(screen.getByRole('main')).toBeInTheDocument();
+        expect(screen.queryByRole('navigation', { name: 'Debate sides legend' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('region', { name: 'Debate arguments' })).not.toBeInTheDocument();
+
+        const createdDebateTopic = 'Is remote work better than office work?';
+        fireEvent.change(screen.getByRole('textbox', { name: 'Debate topic' }), {
+            target: { value: createdDebateTopic },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(createdDebateTopic);
+            expect(screen.getByRole('navigation', { name: 'Debate sides legend' })).toBeInTheDocument();
+            expect(screen.getByRole('region', { name: 'Debate arguments' })).toBeInTheDocument();
+        });
     });
 });
 

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -248,13 +248,12 @@ describe('DebateScreen', () => {
         });
 
         expect(window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY)).toEqual(
-            JSON.stringify({
-                version: ACTIVE_DEBATE_RECORD_VERSION,
-                activeDebate: {
+            JSON.stringify(
+                createStoredActiveDebateFixtureRecord({
                     topic: createdDebateTopic,
                     arguments: [],
-                },
-            }),
+                })
+            ),
         );
     });
 

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -4,7 +4,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Debate } from '../../src/data/debate';
 import { DebateScreen } from '../../src/components/DebateScreen';
-import { ACTIVE_DEBATE_STORAGE_KEY } from '../../src/lib/activeDebateStorage';
+import {
+    ACTIVE_DEBATE_RECORD_VERSION,
+    ACTIVE_DEBATE_STORAGE_KEY,
+} from '../../src/lib/activeDebateStorage';
 import {
     activeDebateFixture,
     createStoredActiveDebateFixtureRecord,
@@ -216,6 +219,63 @@ describe('DebateScreen', () => {
         expect(screen.queryByRole('button', { name: 'Open debate actions' })).not.toBeInTheDocument();
     });
 
+    it('AC-29: renders create mode without legend, timeline, or podium when no active debate exists', () => {
+        window.localStorage.clear();
+        render(<DebateScreen />);
+
+        expect(screen.getByRole('textbox', { name: 'Debate topic' })).toBeInTheDocument();
+        expect(screen.queryByRole('navigation', { name: 'Debate sides legend' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('region', { name: 'Debate arguments' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Open post composer' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog', { name: 'Post composer' })).not.toBeInTheDocument();
+    });
+
+    it('AC-31: persists a fresh active debate and transitions into active mode after Start', async () => {
+        window.localStorage.clear();
+        render(<DebateScreen />);
+
+        const createdDebateTopic = 'Is remote work better than office work?';
+        fireEvent.change(screen.getByRole('textbox', { name: 'Debate topic' }), {
+            target: { value: `  ${createdDebateTopic}  ` },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(createdDebateTopic);
+            expect(screen.queryByRole('textbox', { name: 'Debate topic' })).not.toBeInTheDocument();
+            expect(screen.getByRole('navigation', { name: 'Debate sides legend' })).toBeInTheDocument();
+            expect(screen.getByRole('region', { name: 'Debate arguments' })).toBeInTheDocument();
+        });
+
+        expect(window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY)).toEqual(
+            JSON.stringify({
+                version: ACTIVE_DEBATE_RECORD_VERSION,
+                activeDebate: {
+                    topic: createdDebateTopic,
+                    arguments: [],
+                },
+            }),
+        );
+    });
+
+    it('AC-32: first render falls back to create mode instead of seeded runtime debate content', () => {
+        window.localStorage.clear();
+        render(<DebateScreen />);
+
+        expect(screen.queryByText(activeDebateFixture.topic)).not.toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Debate topic' })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+    });
+
+    it('AC-39: corrupt active debate storage payload fails closed to create mode', () => {
+        window.localStorage.setItem(ACTIVE_DEBATE_STORAGE_KEY, '{"version":1');
+        render(<DebateScreen />);
+
+        expect(screen.getByRole('textbox', { name: 'Debate topic' })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+        expect(screen.queryByRole('navigation', { name: 'Debate sides legend' })).not.toBeInTheDocument();
+    });
+
     it('AC-34: uses the overflow trigger to enter a new debate flow', async () => {
         render(<DebateScreen />);
 
@@ -343,5 +403,13 @@ describe('DebateScreen', () => {
         expect(podiumCss).toMatch(
             /@media\s*\(min-width:\s*768px\)\s*\{[\s\S]*:root\s*\{[\s\S]*--podium-height:\s*calc\(109px\s*\+\s*env\(safe-area-inset-bottom,\s*0px\)\);/
         );
+    });
+
+    it('matches create-mode theme-toggle offsets for mobile and tablet/desktop Figma frames', () => {
+        expect(debateScreenCss).toContain('left: calc(var(--space-4) / 2);');
+        expect(debateScreenCss).toContain('top: calc(var(--space-5) + (var(--space-4) / 2));');
+        expect(debateScreenCss).toContain('@media (min-width: 768px)');
+        expect(debateScreenCss).toContain('left: var(--space-4);');
+        expect(debateScreenCss).toContain('top: var(--space-4);');
     });
 });

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Debate } from '../../src/data/debate';
 import { DebateScreen } from '../../src/components/DebateScreen';
 import {
-    ACTIVE_DEBATE_RECORD_VERSION,
     ACTIVE_DEBATE_STORAGE_KEY,
 } from '../../src/lib/activeDebateStorage';
 import {

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -218,7 +218,7 @@ describe('DebateScreen', () => {
         expect(screen.queryByRole('button', { name: 'Open debate actions' })).not.toBeInTheDocument();
     });
 
-    it('AC-29: renders create mode without legend, timeline, or podium when no active debate exists', () => {
+    it('AC-29: keeps debate creation focused on starting a topic when no active debate exists', () => {
         window.localStorage.clear();
         render(<DebateScreen />);
 

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -405,7 +405,13 @@ describe('DebateScreen', () => {
 
     it('matches create-mode theme-toggle offsets for mobile and tablet/desktop Figma frames', () => {
         expect(debateScreenCss).toContain(
+            '.debate-screen__empty-state {\n    position: relative;\n    min-height: 100vh;\n    min-height: 100dvh;\n    display: flex;\n    flex-direction: column;'
+        );
+        expect(debateScreenCss).toContain(
             '.debate-screen__action-error {\n    max-width: var(--size-create-debate-content-max-width);'
+        );
+        expect(debateScreenCss).toContain(
+            '.debate-screen__empty-action-error {\n    margin: 0 0 var(--space-4);\n    width: 100%;'
         );
         expect(debateScreenCss).toContain('left: calc(var(--space-4) / 2);');
         expect(debateScreenCss).toContain('top: calc(var(--space-5) + (var(--space-4) / 2));');

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -403,7 +403,7 @@ describe('DebateScreen', () => {
         );
     });
 
-    it('matches create-mode theme-toggle offsets for mobile and tablet/desktop Figma frames', () => {
+    it('AC-29: keeps topic drafting aligned across mobile, tablet, and desktop breakpoints', () => {
         expect(debateScreenCss).toContain(
             '.debate-screen__empty-state {\n    position: relative;\n    min-height: 100vh;\n    min-height: 100dvh;\n    display: flex;\n    flex-direction: column;'
         );

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -404,10 +404,20 @@ describe('DebateScreen', () => {
     });
 
     it('matches create-mode theme-toggle offsets for mobile and tablet/desktop Figma frames', () => {
+        expect(debateScreenCss).toContain(
+            '.debate-screen__action-error {\n    max-width: var(--size-create-debate-content-max-width);'
+        );
         expect(debateScreenCss).toContain('left: calc(var(--space-4) / 2);');
         expect(debateScreenCss).toContain('top: calc(var(--space-5) + (var(--space-4) / 2));');
         expect(debateScreenCss).toContain('@media (min-width: 768px)');
+        expect(debateScreenCss).toContain(
+            'max-width: var(--size-create-debate-content-max-width-tablet);'
+        );
         expect(debateScreenCss).toContain('left: var(--space-4);');
         expect(debateScreenCss).toContain('top: var(--space-4);');
+        expect(debateScreenCss).toContain('@media (min-width: 1024px)');
+        expect(debateScreenCss).toContain(
+            'max-width: var(--size-create-debate-content-max-width-desktop);'
+        );
     });
 });

--- a/tests/components/DebateTopicForm.test.tsx
+++ b/tests/components/DebateTopicForm.test.tsx
@@ -131,7 +131,11 @@ describe('DebateTopicForm', () => {
     });
 
     it('pins topic-form geometry and token usage to Figma values for create and replace states', () => {
+        expect(debateTopicFormCss).toContain(
+            '.debate-topic-form {\n    width: 100%;\n    max-width: var(--size-create-debate-content-max-width);'
+        );
         expect(debateTopicFormCss).toContain('max-width: var(--size-create-debate-content-max-width);');
+        expect(debateTopicFormCss).toContain('.debate-topic-form__form {\n    width: 100%;');
         expect(debateTopicFormCss).toContain('@media (min-width: 768px)');
         expect(debateTopicFormCss).toContain(
             'max-width: var(--size-create-debate-content-max-width-tablet);'

--- a/tests/components/DebateTopicForm.test.tsx
+++ b/tests/components/DebateTopicForm.test.tsx
@@ -131,6 +131,10 @@ describe('DebateTopicForm', () => {
 
     it('pins topic-form geometry and token usage to Figma values for create and replace states', () => {
         expect(debateTopicFormCss).toContain('max-width: var(--size-create-debate-content-max-width);');
+        expect(debateTopicFormCss).toContain('@media (min-width: 768px)');
+        expect(debateTopicFormCss).toContain('max-width: 600px;');
+        expect(debateTopicFormCss).toContain('@media (min-width: 1024px)');
+        expect(debateTopicFormCss).toContain('max-width: 640px;');
         expect(debateTopicFormCss).toContain('height: 56px;');
         expect(debateTopicFormCss).toContain('padding: 0 15px;');
         expect(debateTopicFormCss).toContain('height: 40px;');

--- a/tests/components/DebateTopicForm.test.tsx
+++ b/tests/components/DebateTopicForm.test.tsx
@@ -9,6 +9,7 @@ const debateTopicFormCss = readFileSync(
     resolve(process.cwd(), 'src/styles/components/debate-topic-form.css'),
     'utf-8'
 );
+const tokensCss = readFileSync(resolve(process.cwd(), 'src/styles/tokens.css'), 'utf-8');
 
 describe('DebateTopicForm', () => {
     it('shows the create flow with Start disabled at 0 / 120 (AC-29)', () => {
@@ -132,9 +133,15 @@ describe('DebateTopicForm', () => {
     it('pins topic-form geometry and token usage to Figma values for create and replace states', () => {
         expect(debateTopicFormCss).toContain('max-width: var(--size-create-debate-content-max-width);');
         expect(debateTopicFormCss).toContain('@media (min-width: 768px)');
-        expect(debateTopicFormCss).toContain('max-width: 600px;');
+        expect(debateTopicFormCss).toContain(
+            'max-width: var(--size-create-debate-content-max-width-tablet);'
+        );
         expect(debateTopicFormCss).toContain('@media (min-width: 1024px)');
-        expect(debateTopicFormCss).toContain('max-width: 640px;');
+        expect(debateTopicFormCss).toContain(
+            'max-width: var(--size-create-debate-content-max-width-desktop);'
+        );
+        expect(tokensCss).toContain('--size-create-debate-content-max-width-tablet: 600px;');
+        expect(tokensCss).toContain('--size-create-debate-content-max-width-desktop: 640px;');
         expect(debateTopicFormCss).toContain('height: 56px;');
         expect(debateTopicFormCss).toContain('padding: 0 15px;');
         expect(debateTopicFormCss).toContain('height: 40px;');


### PR DESCRIPTION
## Summary
- align the empty-state create layout with the tablet and desktop Figma width and theme-toggle offset values
- add missing DebateScreen acceptance coverage for empty state, create transition, seeded-runtime removal, and corrupt-storage fail-closed behavior
- add empty-to-active accessibility and landmark coverage for the create flow

## Scope Note
Most of the runtime empty-state/create behavior had already landed on `slice/create-debate` during T3. This T4 patch closes the remaining responsive CSS and acceptance/a11y evidence gaps required by issue #206.

## Validation
- `npm run test`
- `npm run typecheck`
- `npx vitest run tests/components/DebateScreen.test.tsx tests/components/DebateTopicForm.test.tsx tests/a11y/landmarks.test.tsx tests/a11y/debate-screen-a11y.test.tsx`
- `npm run test:bdd` *(still shows the known pre-existing 4 failures in `features/post-tark-vitark.feature`)*

Closes #206