### PR TITLE
[create-debate][T5] Replace-flow integration (#207)

### DIFF
--- a/src/components/ActiveDebateHeader.tsx
+++ b/src/components/ActiveDebateHeader.tsx
@@ -6,15 +6,13 @@ import '../styles/components/active-debate-header.css';
 interface ActiveDebateHeaderProps {
     topic: string;
     onStartNewDebate: () => void;
-    restoreOverflowFocus?: boolean;
-    onOverflowFocusRestored?: () => void;
+    restoreOverflowFocusRequest?: number;
 }
 
 export function ActiveDebateHeader({
     topic,
     onStartNewDebate,
-    restoreOverflowFocus = false,
-    onOverflowFocusRestored,
+    restoreOverflowFocusRequest = 0,
 }: ActiveDebateHeaderProps) {
     const [isDebateActionsOpen, setIsDebateActionsOpen] = useState(false);
     const debateActionsRef = useRef<HTMLDivElement | null>(null);
@@ -67,27 +65,21 @@ export function ActiveDebateHeader({
     }, [isDebateActionsOpen]);
 
     useEffect(() => {
-        if (!restoreOverflowFocus) {
+        if (restoreOverflowFocusRequest === 0) {
             return;
         }
 
-        let didRestoreOverflowFocus = false;
         const restoreOverflowFocusAnimationFrameId = window.requestAnimationFrame(() => {
             const overflowTrigger = overflowTriggerRef.current;
             if (overflowTrigger && document.contains(overflowTrigger)) {
                 overflowTrigger.focus();
             }
-            didRestoreOverflowFocus = true;
-            onOverflowFocusRestored?.();
         });
 
         return () => {
             window.cancelAnimationFrame(restoreOverflowFocusAnimationFrameId);
-            if (!didRestoreOverflowFocus) {
-                onOverflowFocusRestored?.();
-            }
         };
-    }, [restoreOverflowFocus, onOverflowFocusRestored]);
+    }, [restoreOverflowFocusRequest]);
 
     return (
         <header className="active-debate-header">

--- a/src/components/ActiveDebateHeader.tsx
+++ b/src/components/ActiveDebateHeader.tsx
@@ -71,13 +71,22 @@ export function ActiveDebateHeader({
             return;
         }
 
-        window.requestAnimationFrame(() => {
+        let didRestoreOverflowFocus = false;
+        const restoreOverflowFocusAnimationFrameId = window.requestAnimationFrame(() => {
             const overflowTrigger = overflowTriggerRef.current;
             if (overflowTrigger && document.contains(overflowTrigger)) {
                 overflowTrigger.focus();
             }
+            didRestoreOverflowFocus = true;
             onOverflowFocusRestored?.();
         });
+
+        return () => {
+            window.cancelAnimationFrame(restoreOverflowFocusAnimationFrameId);
+            if (!didRestoreOverflowFocus) {
+                onOverflowFocusRestored?.();
+            }
+        };
     }, [restoreOverflowFocus, onOverflowFocusRestored]);
 
     return (

--- a/src/components/ActiveDebateHeader.tsx
+++ b/src/components/ActiveDebateHeader.tsx
@@ -6,11 +6,15 @@ import '../styles/components/active-debate-header.css';
 interface ActiveDebateHeaderProps {
     topic: string;
     onStartNewDebate: () => void;
+    restoreOverflowFocus?: boolean;
+    onOverflowFocusRestored?: () => void;
 }
 
 export function ActiveDebateHeader({
     topic,
     onStartNewDebate,
+    restoreOverflowFocus = false,
+    onOverflowFocusRestored,
 }: ActiveDebateHeaderProps) {
     const [isDebateActionsOpen, setIsDebateActionsOpen] = useState(false);
     const debateActionsRef = useRef<HTMLDivElement | null>(null);
@@ -61,6 +65,20 @@ export function ActiveDebateHeader({
             document.removeEventListener('keydown', handleEscape);
         };
     }, [isDebateActionsOpen]);
+
+    useEffect(() => {
+        if (!restoreOverflowFocus) {
+            return;
+        }
+
+        window.requestAnimationFrame(() => {
+            const overflowTrigger = overflowTriggerRef.current;
+            if (overflowTrigger && document.contains(overflowTrigger)) {
+                overflowTrigger.focus();
+            }
+            onOverflowFocusRestored?.();
+        });
+    }, [restoreOverflowFocus, onOverflowFocusRestored]);
 
     return (
         <header className="active-debate-header">

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -179,7 +179,10 @@ export function DebateScreen() {
                     />
                 </>
             ) : (
-                <section className="debate-screen__empty-state" aria-label="Create debate">
+                <section
+                    className="debate-screen__empty-state"
+                    aria-label={isReplaceMode ? 'Replace debate' : 'Create debate'}
+                >
                     <ThemeToggle
                         variant="chrome"
                         className="debate-screen__empty-theme-toggle"

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -96,12 +96,14 @@ export function DebateScreen() {
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         setIsReplaceFlowOpen(false);
+        setRestoreOverflowFocusRequest(0);
         ignoreNextSheetCloseRef.current = false;
     }
 
     function handleStartReplaceFlow(): void {
         setDebateActionError(null);
         setIsReplaceFlowOpen(true);
+        setRestoreOverflowFocusRequest(0);
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         ignoreNextSheetCloseRef.current = false;

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Argument, Debate, Side } from '../data/debate';
 import {
-    clearActiveDebate,
     loadStoredActiveDebateRecord,
     replaceActiveDebate,
 } from '../lib/activeDebateStorage';
@@ -51,10 +50,12 @@ export function DebateScreen() {
     const [selectedSide, setSelectedSide] = useState<Side>('tark');
     const [isFabExpanded, setIsFabExpanded] = useState(false);
     const [isSheetOpen, setIsSheetOpen] = useState(false);
+    const [isReplaceFlowOpen, setIsReplaceFlowOpen] = useState(false);
     const [debateActionError, setDebateActionError] = useState<string | null>(null);
     const ignoreNextSheetCloseRef = useRef(false);
     const clearIgnoreCloseAnimationFrameRef = useRef<number | null>(null);
     const hasActiveDebate = hasActiveDebateTopic(activeDebate.topic);
+    const isReplaceMode = hasActiveDebate && isReplaceFlowOpen;
 
     useEffect(() => {
         return () => {
@@ -93,35 +94,33 @@ export function DebateScreen() {
         setSelectedSide('tark');
         setIsFabExpanded(false);
         setIsSheetOpen(false);
+        setIsReplaceFlowOpen(false);
         ignoreNextSheetCloseRef.current = false;
     }
 
-    function handleStartNewDebate(): void {
-        const clearResult = clearActiveDebate();
-        if (!clearResult.ok) {
-            setDebateActionError(DEBATE_PERSISTENCE_ERROR_MESSAGE);
-            return;
-        }
-
+    function handleStartReplaceFlow(): void {
         setDebateActionError(null);
-        setActiveDebate(emptyActiveDebate());
-        setLocalPosts([]);
-        setSelectedSide('tark');
+        setIsReplaceFlowOpen(true);
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         ignoreNextSheetCloseRef.current = false;
     }
 
+    function handleCancelReplaceFlow(): void {
+        setDebateActionError(null);
+        setIsReplaceFlowOpen(false);
+    }
+
     return (
         <main
             role="main"
-            className={`debate-screen${hasActiveDebate ? '' : ' debate-screen--empty'}`}
+            className={`debate-screen${isReplaceMode || !hasActiveDebate ? ' debate-screen--empty' : ''}`}
         >
-            {hasActiveDebate ? (
+            {hasActiveDebate && !isReplaceMode ? (
                 <>
                     <ActiveDebateHeader
                         topic={activeDebate.topic}
-                        onStartNewDebate={handleStartNewDebate}
+                        onStartNewDebate={handleStartReplaceFlow}
                     />
                     {debateActionError ? (
                         <p
@@ -188,7 +187,15 @@ export function DebateScreen() {
                             {debateActionError}
                         </p>
                     ) : null}
-                    <DebateTopicForm mode="create" onStartDebate={handleStartDebate} />
+                    {isReplaceMode ? (
+                        <DebateTopicForm
+                            mode="replace"
+                            onStartDebate={handleStartDebate}
+                            onCancelReplace={handleCancelReplaceFlow}
+                        />
+                    ) : (
+                        <DebateTopicForm mode="create" onStartDebate={handleStartDebate} />
+                    )}
                 </section>
             )}
         </main>

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -51,6 +51,7 @@ export function DebateScreen() {
     const [isFabExpanded, setIsFabExpanded] = useState(false);
     const [isSheetOpen, setIsSheetOpen] = useState(false);
     const [isReplaceFlowOpen, setIsReplaceFlowOpen] = useState(false);
+    const [shouldRestoreOverflowFocus, setShouldRestoreOverflowFocus] = useState(false);
     const [debateActionError, setDebateActionError] = useState<string | null>(null);
     const ignoreNextSheetCloseRef = useRef(false);
     const clearIgnoreCloseAnimationFrameRef = useRef<number | null>(null);
@@ -95,12 +96,14 @@ export function DebateScreen() {
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         setIsReplaceFlowOpen(false);
+        setShouldRestoreOverflowFocus(false);
         ignoreNextSheetCloseRef.current = false;
     }
 
     function handleStartReplaceFlow(): void {
         setDebateActionError(null);
         setIsReplaceFlowOpen(true);
+        setShouldRestoreOverflowFocus(false);
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         ignoreNextSheetCloseRef.current = false;
@@ -108,6 +111,7 @@ export function DebateScreen() {
 
     function handleCancelReplaceFlow(): void {
         setDebateActionError(null);
+        setShouldRestoreOverflowFocus(true);
         setIsReplaceFlowOpen(false);
     }
 
@@ -121,6 +125,8 @@ export function DebateScreen() {
                     <ActiveDebateHeader
                         topic={activeDebate.topic}
                         onStartNewDebate={handleStartReplaceFlow}
+                        restoreOverflowFocus={shouldRestoreOverflowFocus}
+                        onOverflowFocusRestored={() => setShouldRestoreOverflowFocus(false)}
                     />
                     {debateActionError ? (
                         <p

--- a/src/components/DebateScreen.tsx
+++ b/src/components/DebateScreen.tsx
@@ -51,7 +51,7 @@ export function DebateScreen() {
     const [isFabExpanded, setIsFabExpanded] = useState(false);
     const [isSheetOpen, setIsSheetOpen] = useState(false);
     const [isReplaceFlowOpen, setIsReplaceFlowOpen] = useState(false);
-    const [shouldRestoreOverflowFocus, setShouldRestoreOverflowFocus] = useState(false);
+    const [restoreOverflowFocusRequest, setRestoreOverflowFocusRequest] = useState(0);
     const [debateActionError, setDebateActionError] = useState<string | null>(null);
     const ignoreNextSheetCloseRef = useRef(false);
     const clearIgnoreCloseAnimationFrameRef = useRef<number | null>(null);
@@ -96,14 +96,12 @@ export function DebateScreen() {
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         setIsReplaceFlowOpen(false);
-        setShouldRestoreOverflowFocus(false);
         ignoreNextSheetCloseRef.current = false;
     }
 
     function handleStartReplaceFlow(): void {
         setDebateActionError(null);
         setIsReplaceFlowOpen(true);
-        setShouldRestoreOverflowFocus(false);
         setIsFabExpanded(false);
         setIsSheetOpen(false);
         ignoreNextSheetCloseRef.current = false;
@@ -111,7 +109,7 @@ export function DebateScreen() {
 
     function handleCancelReplaceFlow(): void {
         setDebateActionError(null);
-        setShouldRestoreOverflowFocus(true);
+        setRestoreOverflowFocusRequest((existingRequest) => existingRequest + 1);
         setIsReplaceFlowOpen(false);
     }
 
@@ -125,8 +123,7 @@ export function DebateScreen() {
                     <ActiveDebateHeader
                         topic={activeDebate.topic}
                         onStartNewDebate={handleStartReplaceFlow}
-                        restoreOverflowFocus={shouldRestoreOverflowFocus}
-                        onOverflowFocusRestored={() => setShouldRestoreOverflowFocus(false)}
+                        restoreOverflowFocusRequest={restoreOverflowFocusRequest}
                     />
                     {debateActionError ? (
                         <p

--- a/src/components/DebateTopicForm.tsx
+++ b/src/components/DebateTopicForm.tsx
@@ -83,7 +83,7 @@ export function DebateTopicForm(props: DebateTopicFormProps) {
                     className={`debate-topic-form__topic-input${isTopicTooLong ? ' debate-topic-form__topic-input--error' : ''}`}
                     value={topicDraft}
                     onChange={(event) => setTopicDraft(event.target.value)}
-                    autoFocus={props.mode === 'create'}
+                    autoFocus
                     placeholder="What is the Tark Vitark about?"
                     aria-label="Debate topic"
                     aria-describedby={topicDescriptionIds}

--- a/src/components/DebateTopicForm.tsx
+++ b/src/components/DebateTopicForm.tsx
@@ -80,6 +80,7 @@ export function DebateTopicForm(props: DebateTopicFormProps) {
             <form className="debate-topic-form__form" onSubmit={handleSubmit}>
                 <input
                     type="text"
+                    name="debate-topic"
                     className={`debate-topic-form__topic-input${isTopicTooLong ? ' debate-topic-form__topic-input--error' : ''}`}
                     value={topicDraft}
                     onChange={(event) => setTopicDraft(event.target.value)}

--- a/src/styles/components/debate-topic-form.css
+++ b/src/styles/components/debate-topic-form.css
@@ -142,7 +142,7 @@
     border-radius: 20px;
     padding: 0 12px;
     background: transparent;
-    color: var(--color-primary);
+    color: var(--color-brand-primary);
     font-family: var(--font-family-plain);
     font-size: 14px;
     font-weight: 500;

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -310,6 +310,7 @@ describe('DebateScreen', () => {
         await waitFor(() => {
             expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(activeDebateFixture.topic);
             expect(screen.getAllByRole('listitem')).toHaveLength(activeDebateFixture.arguments.length);
+            expect(screen.getByRole('button', { name: 'Open debate actions' })).toHaveFocus();
         });
 
         expect(window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY)).toEqual(

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -274,7 +274,7 @@ describe('DebateScreen', () => {
         expect(screen.queryByRole('navigation', { name: 'Debate sides legend' })).not.toBeInTheDocument();
     });
 
-    it('AC-34, AC-40: uses the overflow trigger to enter replace mode with inline warning', async () => {
+    it('AC-34, AC-40: enters replace mode from New Debate with inline warning', async () => {
         render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open debate actions' }));

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -274,7 +274,7 @@ describe('DebateScreen', () => {
         expect(screen.queryByRole('navigation', { name: 'Debate sides legend' })).not.toBeInTheDocument();
     });
 
-    it('AC-34: uses the overflow trigger to enter a new debate flow', async () => {
+    it('AC-34, AC-40: uses the overflow trigger to enter replace mode with inline warning', async () => {
         render(<DebateScreen />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open debate actions' }));
@@ -284,12 +284,73 @@ describe('DebateScreen', () => {
             const topicInput = screen.getByRole('textbox', { name: 'Debate topic' });
             expect(topicInput).toBeInTheDocument();
             expect(topicInput).toHaveFocus();
+            expect(screen.getByText(/You already have an active debate\./)).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
             expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
             expect(screen.queryByRole('button', { name: 'Open debate actions' })).not.toBeInTheDocument();
         });
     });
 
-    it('AC-34: keeps active debate visible when New Debate persistence reset fails', async () => {
+    it('AC-35: cancel exits replace mode with the current debate unchanged', async () => {
+        render(<DebateScreen />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open debate actions' }));
+        fireEvent.click(screen.getByRole('button', { name: 'New Debate' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+        });
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'Debate topic' }), {
+            target: { value: 'Should city centers ban private cars?' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(activeDebateFixture.topic);
+            expect(screen.getAllByRole('listitem')).toHaveLength(activeDebateFixture.arguments.length);
+        });
+
+        expect(window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY)).toEqual(
+            JSON.stringify(createStoredActiveDebateFixtureRecord())
+        );
+    });
+
+    it('AC-34: replace submit writes a fresh topic and clears carried arguments', async () => {
+        render(<DebateScreen />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open debate actions' }));
+        fireEvent.click(screen.getByRole('button', { name: 'New Debate' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Debate topic' })).toBeInTheDocument();
+        });
+
+        const replacementTopic = 'Should governments mandate open-source AI models?';
+        fireEvent.change(screen.getByRole('textbox', { name: 'Debate topic' }), {
+            target: { value: `  ${replacementTopic}  ` },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(replacementTopic);
+            expect(screen.queryByRole('textbox', { name: 'Debate topic' })).not.toBeInTheDocument();
+            expect(screen.getByRole('region', { name: 'Debate arguments' })).toBeInTheDocument();
+        });
+
+        expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+        expect(window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY)).toEqual(
+            JSON.stringify(
+                createStoredActiveDebateFixtureRecord({
+                    topic: replacementTopic,
+                    arguments: [],
+                })
+            )
+        );
+    });
+
+    it('AC-34: failed replace submit keeps the current debate intact until save succeeds', async () => {
         const storedRecord = window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY);
         const unavailableWriteStorage = {
             clear() {
@@ -322,14 +383,27 @@ describe('DebateScreen', () => {
 
             fireEvent.click(screen.getByRole('button', { name: 'Open debate actions' }));
             fireEvent.click(screen.getByRole('button', { name: 'New Debate' }));
+            fireEvent.change(screen.getByRole('textbox', { name: 'Debate topic' }), {
+                target: { value: 'Should cities ban private cars from downtown roads?' },
+            });
+            fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
             await waitFor(() => {
-                expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
-                expect(screen.queryByRole('textbox', { name: 'Debate topic' })).not.toBeInTheDocument();
+                expect(screen.getByRole('textbox', { name: 'Debate topic' })).toBeInTheDocument();
                 expect(screen.getByRole('alert')).toHaveTextContent(
                     'Unable to start a new debate right now. Please try again.'
                 );
             });
+
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            await waitFor(() => {
+                expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+                    activeDebateFixture.topic
+                );
+                expect(screen.getAllByRole('listitem')).toHaveLength(activeDebateFixture.arguments.length);
+            });
+            expect(window.localStorage.getItem(ACTIVE_DEBATE_STORAGE_KEY)).toEqual(storedRecord);
         } finally {
             vi.unstubAllGlobals();
         }

--- a/tests/components/DebateScreen.test.tsx
+++ b/tests/components/DebateScreen.test.tsx
@@ -286,6 +286,7 @@ describe('DebateScreen', () => {
             expect(topicInput).toHaveFocus();
             expect(screen.getByText(/You already have an active debate\./)).toBeInTheDocument();
             expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+            expect(screen.getByRole('region', { name: 'Replace debate' })).toBeInTheDocument();
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
             expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
             expect(screen.queryByRole('button', { name: 'Open debate actions' })).not.toBeInTheDocument();

--- a/tests/components/DebateTopicForm.test.tsx
+++ b/tests/components/DebateTopicForm.test.tsx
@@ -15,7 +15,9 @@ describe('DebateTopicForm', () => {
     it('shows the create flow with Start disabled at 0 / 120 (AC-29)', () => {
         render(<DebateTopicForm mode="create" onStartDebate={vi.fn()} />);
 
-        expect(screen.getByRole('textbox', { name: 'Debate topic' })).toHaveValue('');
+        const topicInput = screen.getByRole('textbox', { name: 'Debate topic' });
+        expect(topicInput).toHaveValue('');
+        expect(topicInput).toHaveAttribute('name', 'debate-topic');
         expect(screen.getByText('0 / 120')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Start' })).toBeDisabled();
         expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
@@ -156,6 +158,7 @@ describe('DebateTopicForm', () => {
         expect(debateTopicFormCss).toContain('var(--color-outline)');
         expect(debateTopicFormCss).toContain('var(--color-error)');
         expect(debateTopicFormCss).toContain('var(--color-primary)');
+        expect(debateTopicFormCss).toContain('color: var(--color-brand-primary);');
         expect(debateTopicFormCss).toContain('var(--color-on-primary)');
         expect(debateTopicFormCss).toContain('var(--color-surface-container-highest)');
         expect(debateTopicFormCss).toContain('var(--color-on-surface-variant)');


### PR DESCRIPTION
Closes #207

## Implementation Summary
- Wired the active-header **New Debate** action to open replace mode instead of clearing the active debate immediately.
- Kept the current debate and its arguments untouched while replace mode is open and until replace persistence succeeds.
- Added explicit replace-cancel behavior that returns to the current active debate unchanged.
- Kept replace submit behavior atomic by persisting a fresh topic with zero carried-over arguments before switching back to active mode.
- Preserved inline warning behavior in replace mode, with no blocking dialog and no standalone clear action.
- Restored keyboard focus to the header action after Cancel and hardened the focus-restore signal so it only applies to cancel transitions.
- Restored dark-theme ReplaceFlow fidelity by rendering **Cancel** with the brand token (`--color-brand-primary`), matching the approved lavender dark frame.
- Added a `name` attribute on the replace topic input to address browser form-field metadata warnings.

## Files Changed
- `src/components/ActiveDebateHeader.tsx` — overflow menu and cancel-return focus restoration wiring.
- `src/components/DebateScreen.tsx` — replace-flow state integration, cancel handling, and active/replace render gating.
- `src/components/DebateTopicForm.tsx` — replace/create topic form behavior and topic-input `name` attribute.
- `src/styles/components/debate-topic-form.css` — Cancel text color token alignment for dark-theme fidelity.
- `tests/components/DebateScreen.test.tsx` — AC-34/35/40 replace-flow integration coverage.
- `tests/components/DebateTopicForm.test.tsx` — topic-input attribute coverage and token-usage assertion for Cancel color.

## Verification Evidence
- `npm run build`
- `npm run test`
- `npm run test -- tests/components/DebateTopicForm.test.tsx tests/components/DebateScreen.test.tsx`
- `npm run test:bdd` *(known pre-existing 4 failures in `features/post-tark-vitark.feature` unchanged: scenarios at lines 33, 40, 54, 73)*

## BDD Evidence
- AC-34 mapped to `tests/components/DebateScreen.test.tsx`:
  - `enters replace mode from New Debate with inline warning`
  - `replace submit writes a fresh topic and clears carried arguments`
  - `failed replace submit keeps the current debate intact until save succeeds`
- AC-35 mapped to `tests/components/DebateScreen.test.tsx`:
  - `cancel exits replace mode with the current debate unchanged`
- AC-40 mapped to `tests/components/DebateScreen.test.tsx` and `tests/components/DebateTopicForm.test.tsx`:
  - inline warning renders in replace mode and no blocking dialog appears.

## Runtime QA Verdict Package (Gate 5.5)
- Runtime QA Verdict: **Pass**
- Validated PR head: `b4d2e5e1773cd21b33a99eb2792b5c643ab2c978`
- Route list: `/`
- AC journey mapping executed: AC-34 (replace/start), AC-35 (replace/cancel), AC-40 (inline warning/no dialog)
- Coverage matrix executed: `360x800` + `768x1024`, Light and Dark
- Figma references used for fidelity checks: `947:476`, `947:521`, `897:462`, `897:475`, `977:481`, `898:463`, `898:475`, `977:483`
- Critical fidelity result: Dark ReplaceFlow Cancel rendered lavender (`#BBC3FF`) and not dark blue
- Non-blocking note: `GET /favicon.ico` 404
- Runtime QA gate recommendation: **proceed to Gate 6**

## Review Notes
- Latest Copilot review on current head (`b4d2e5e1773cd21b33a99eb2792b5c643ab2c978`) generated no new comments.

## Agent Provenance
run-id: f027694f-059d-4efe-92c8-0188b6643b1a
task-id: create-debate/gate5/dev-207-runtime-fix
role: dev
dispatched: 2026-04-28T12:25:21.807Z
model: gpt-5.3-codex