### PR TITLE
Add async agent progress logging

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- Protocol-Version: 3.35 -->
-<!-- Last-Updated: 2026-04-30 -->
+<!-- Protocol-Version: 3.39 -->
+<!-- Last-Updated: 2026-05-07 -->
 
 # Shared Agent Protocol
 
@@ -127,6 +127,14 @@ The full Gate 5, Gate 5.5 Runtime QA, and Gate 6 orchestration workflow - issue-
 8. Before a new role is used in live orchestration, add its default model to `scripts/agent-model-routing.ts` and document it in `.github/skills/async-agent-dispatch/SKILL.md` in the same change.
 9. Repo-controlled Copilot SDK terminal sessions must set the highest supported `reasoningEffort` for the selected model. This is enforced in `scripts/run-agent.ts` by resolving the model's supported reasoning levels via `listModels()` and selecting the strongest one. If model metadata is unavailable, fall back to `high`. Sync `runSubagent` handoffs currently expose explicit model selection but no repo-controlled reasoning-effort parameter; Gate 3B therefore targets the Codex sync lane as the closest available path to the desired `xhigh` review posture, but exact sync `xhigh` cannot be repo-enforced until the tool surface exposes reasoning control.
 10. For every async terminal dispatch (`run_in_terminal mode=async`) of `scripts/run-agent.ts`, orchestrator must print exactly one dispatch banner in chat per dispatch. The single banner is emitted immediately after the dispatch call returns and must include: role, resolved model, resolved reasoning effort, reasoning source (`supported-efforts` or `fallback`), gate/slice context, terminal id, and timestamp.
+
+## Async Progress Logging
+
+1. Every async terminal dispatch via `scripts/run-agent.ts` must produce wrapper-owned progress artifacts under `logs/parallel-agents/`.
+2. `scripts/run-agent.ts` is the universal cross-role liveness surface for async runs. It must maintain the per-run JSON snapshot record, a single shared append-only JSONL wrapper progress log, and the `runs.json` index fields `phase`, `lastHeartbeatAt`, and `progressLogPath`.
+3. The progress log path must be absolute so the log remains valid even if the dispatched agent changes directories or moves into a sibling worktree.
+4. Wrapper lifecycle events always append to that JSONL progress log. Roles with workspace-write capability may additionally append human-readable milestone entries to a separate absolute Markdown semantic progress file; this human-readable file does not replace the wrapper JSONL log.
+5. Between dispatch and terminal exit, terminal output is diagnostics-only; the wrapper-owned JSON snapshot plus the wrapper JSONL progress log are the primary repo-managed progress surfaces, and the semantic Markdown file is optional supporting context.
 
 ## Terminal Mutation Override Policy
 

--- a/.github/skills/async-agent-dispatch/SKILL.md
+++ b/.github/skills/async-agent-dispatch/SKILL.md
@@ -188,6 +188,22 @@ npx tsx scripts/run-agent.ts --task-id debate-screen/gate5/dev-2 dev \
 
 The VS Code chat panel will show `[SLICE: debate-screen | GATE: 5 | dev-1]` and `[SLICE: debate-screen | GATE: 5 | dev-2]` as session titles, making it immediately obvious which root thread each belongs to.
 
+### Wrapper-Owned Progress Logging
+
+Every `scripts/run-agent.ts` dispatch writes wrapper-owned lifecycle progress for that run:
+
+- `logs/parallel-agents/<run-id>.json` — per-run record
+- `logs/parallel-agents/<run-id>-progress.jsonl` — append-only wrapper lifecycle progress log
+- `logs/parallel-agents/<run-id>-semantic-progress.md` — optional human-readable milestone log for write-capable roles
+- `logs/parallel-agents/runs.json` — index row with `status`, `phase`, `lastHeartbeatAt`, and `progressLogPath`
+
+Rules:
+
+1. Treat these wrapper-owned artifacts as the primary repo-managed progress surface between dispatch and terminal exit.
+2. The injected `## Async Run Context` block tells the agent the exact absolute wrapper progress log path, and when milestone writes are possible it also provides the semantic Markdown log path.
+3. Do not assume the agent can always write milestones: several async roles are read/search-only, so the wrapper lifecycle entries remain the universal baseline signal.
+4. If a role can write to the workspace, append concise Markdown bullet milestones to the semantic progress file rather than modifying the wrapper JSONL log.
+
 ### 5. Liveness check
 
 Useful for verifying rate-limit headroom before a long parallel run:

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -395,7 +395,7 @@ function isProcessAlive(pid: number): boolean {
     }
 }
 
-function acquireRunsIndexLock(): void {
+function acquireRunsIndexLock(waitMs = RUNS_INDEX_LOCK_WAIT_MS): boolean {
     const startedAt = Date.now();
 
     while (true) {
@@ -408,7 +408,7 @@ function acquireRunsIndexLock(): void {
                 }),
                 { encoding: "utf-8", flag: "wx" }
             );
-            return;
+            return true;
         } catch (err) {
             const lockError = err as NodeJS.ErrnoException;
             if (lockError.code !== "EEXIST") {
@@ -425,7 +425,10 @@ function acquireRunsIndexLock(): void {
                 }
             }
 
-            if (Date.now() - startedAt >= RUNS_INDEX_LOCK_WAIT_MS) {
+            if (Date.now() - startedAt >= waitMs) {
+                if (waitMs === 0) {
+                    return false;
+                }
                 const ownerPidText = typeof ownerPid === "number" ? `owner pid=${ownerPid}` : "owner pid=unknown";
                 throw new Error(
                     `[run-agent] Timed out acquiring runs index lock after ${RUNS_INDEX_LOCK_WAIT_MS}ms (${ownerPidText}). ` +
@@ -603,7 +606,7 @@ function recordRunHeartbeat(
         progressLogPath: runContext.progressLogPath,
         phase: "waiting-for-agent",
         lastHeartbeatAt: heartbeatAt,
-    });
+    }, { skipIndexIfLocked: true });
 }
 
 function startWaitHeartbeat(runContext: AsyncRunContext): NodeJS.Timeout {
@@ -614,16 +617,22 @@ function startWaitHeartbeat(runContext: AsyncRunContext): NodeJS.Timeout {
     return heartbeat;
 }
 
-function persistRunsIndex(runRecord: Record<string, unknown>): void {
+function persistRunsIndex(
+    runRecord: Record<string, unknown>,
+    options?: { skipIfLocked?: boolean }
+): void {
     let lockAcquired = false;
     try {
         const runId = runRecord.runId;
         if (typeof runId !== "string" || runId.length === 0) {
             return;
         }
+        const skipIfLocked = options?.skipIfLocked ?? false;
 
         mkdirSync(RUNS_LOG_DIR, { recursive: true });
-        acquireRunsIndexLock();
+        if (!acquireRunsIndexLock(skipIfLocked ? 0 : RUNS_INDEX_LOCK_WAIT_MS)) {
+            return;
+        }
         lockAcquired = true;
         const snapshot = readRunsIndex();
         const previous = snapshot[runId];
@@ -703,7 +712,10 @@ function persistRunsIndex(runRecord: Record<string, unknown>): void {
 }
 
 /** Persist a single run record to per-run JSON and maintain runs.json index. */
-function persistRun(record: Record<string, unknown>): void {
+function persistRun(
+    record: Record<string, unknown>,
+    options?: { skipIndexIfLocked?: boolean }
+): void {
     try {
         const id = record.runId;
         if (typeof id !== "string" || id.length === 0) {
@@ -718,7 +730,7 @@ function persistRun(record: Record<string, unknown>): void {
         }
         const next = { ...prior, ...record };
         writeFileSync(path, JSON.stringify(next, null, 2), "utf-8");
-        persistRunsIndex(next);
+        persistRunsIndex(next, { skipIfLocked: options?.skipIndexIfLocked });
     } catch (err) {
         console.error("[run-agent] Warning: could not persist run log:", err);
     }

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -23,7 +23,7 @@
  */
 
 import { CopilotClient, approveAll, type MCPServerConfig } from "@github/copilot-sdk";
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -71,6 +71,15 @@ interface AgentMeta {
 
 type RunTaskStatus = "done" | "failed" | "needs-clarification";
 type RunStatus = "running" | "done" | "failed" | "pending-clarification";
+type RunPhase =
+    | "dispatched"
+    | "model-resolved"
+    | "session-created"
+    | "waiting-before-send"
+    | "waiting-for-agent"
+    | "completed"
+    | "needs-clarification"
+    | "failed";
 
 interface RunTaskResult {
     taskId: string;
@@ -85,12 +94,31 @@ interface RunRecordIndex {
     startedAt: string;
     finishedAt?: string;
     status: RunStatus;
+    phase?: RunPhase;
+    lastHeartbeatAt?: string;
+    progressLogPath?: string;
+    semanticProgressSupported?: boolean;
+    semanticProgressLogPath?: string;
     taskIds: string[];
     results: RunTaskResult[];
     pendingClarification: string[];
 }
 
 type RunsIndexSnapshot = Record<string, RunRecordIndex>;
+
+interface AsyncRunContext {
+    runId: string;
+    role: string;
+    model: string;
+    startedAt: string;
+    taskId: string;
+    progressLogPath: string;
+    agentMilestonesSupported: boolean;
+    semanticProgressLogPath?: string;
+}
+
+type ProgressEventKind = "meta" | "lifecycle" | "milestone";
+type ProgressEventSource = "wrapper" | "agent";
 
 function readAgentMeta(agentRole: string): AgentMeta {
     const fallback: AgentMeta = {
@@ -291,6 +319,14 @@ function runLogPath(runId: string): string {
     return join(RUNS_LOG_DIR, `${runId}.json`);
 }
 
+function runProgressLogPath(runId: string): string {
+    return join(RUNS_LOG_DIR, `${runId}-progress.jsonl`);
+}
+
+function runSemanticProgressLogPath(runId: string): string {
+    return join(RUNS_LOG_DIR, `${runId}-semantic-progress.md`);
+}
+
 function readRunsIndex(): RunsIndexSnapshot {
     if (!existsSync(RUNS_INDEX_PATH)) {
         return {};
@@ -406,6 +442,119 @@ function resolveRunStatus(status: unknown, fallback: RunStatus): RunStatus {
     return fallback;
 }
 
+function resolveRunPhase(phase: unknown, fallback?: RunPhase): RunPhase | undefined {
+    if (
+        phase === "dispatched" ||
+        phase === "model-resolved" ||
+        phase === "session-created" ||
+        phase === "waiting-before-send" ||
+        phase === "waiting-for-agent" ||
+        phase === "completed" ||
+        phase === "needs-clarification" ||
+        phase === "failed"
+    ) {
+        return phase;
+    }
+    return fallback;
+}
+
+function ensureProgressLog(runContext: AsyncRunContext): void {
+    mkdirSync(RUNS_LOG_DIR, { recursive: true });
+    if (existsSync(runContext.progressLogPath)) {
+        return;
+    }
+
+    writeFileSync(
+        runContext.progressLogPath,
+        JSON.stringify({
+            timestamp: runContext.startedAt,
+            source: "wrapper" as ProgressEventSource,
+            kind: "meta" as ProgressEventKind,
+            runId: runContext.runId,
+            taskId: runContext.taskId,
+            role: runContext.role,
+            model: runContext.model,
+            workspaceRoot: WORKSPACE_ROOT,
+            runRecordPath: runLogPath(runContext.runId),
+        }) + "\n",
+        "utf-8"
+    );
+}
+
+function ensureSemanticProgressLog(runContext: AsyncRunContext): void {
+    if (!runContext.semanticProgressLogPath) {
+        return;
+    }
+
+    mkdirSync(RUNS_LOG_DIR, { recursive: true });
+    if (existsSync(runContext.semanticProgressLogPath)) {
+        return;
+    }
+
+    writeFileSync(
+        runContext.semanticProgressLogPath,
+        [
+            "# Async Agent Semantic Milestones",
+            "",
+            `run-id: ${runContext.runId}`,
+            `task-id: ${runContext.taskId}`,
+            `role: ${runContext.role}`,
+            `dispatched: ${runContext.startedAt}`,
+            `model: ${runContext.model}`,
+            `workspace-root: ${WORKSPACE_ROOT}`,
+            `wrapper-progress-log: ${runContext.progressLogPath}`,
+            "",
+            "## Milestones",
+            "",
+        ].join("\n"),
+        "utf-8"
+    );
+}
+
+function supportsAgentMilestones(agentTools: string[]): boolean {
+    return agentTools.includes("edit") || agentTools.includes("execute");
+}
+
+function appendProgressEvent(
+    runContext: AsyncRunContext,
+    source: ProgressEventSource,
+    kind: ProgressEventKind,
+    payload: Record<string, unknown>,
+    timestamp = new Date().toISOString()
+): void {
+    ensureProgressLog(runContext);
+    appendFileSync(
+        runContext.progressLogPath,
+        JSON.stringify({
+            timestamp,
+            source,
+            kind,
+            runId: runContext.runId,
+            taskId: runContext.taskId,
+            role: runContext.role,
+            ...payload,
+        }) + "\n",
+        "utf-8"
+    );
+}
+
+function recordRunProgress(
+    runContext: AsyncRunContext,
+    phase: RunPhase,
+    detail: string,
+    heartbeatAt = new Date().toISOString()
+): void {
+    const normalizedDetail = detail.replace(/\s+/g, " ").trim();
+    appendProgressEvent(runContext, "wrapper", "lifecycle", { phase, detail: normalizedDetail }, heartbeatAt);
+    persistRun({
+        runId: runContext.runId,
+        taskId: runContext.taskId,
+        progressLogPath: runContext.progressLogPath,
+        phase,
+        lastHeartbeatAt: heartbeatAt,
+    });
+}
+
 function persistRunsIndex(runRecord: Record<string, unknown>): void {
     let lockAcquired = false;
     try {
@@ -433,6 +582,19 @@ function persistRunsIndex(runRecord: Record<string, unknown>): void {
             ? runRecord.finishedAt
             : previous?.finishedAt;
         const status = resolveRunStatus(runRecord.status, previous?.status ?? "running");
+        const phase = resolveRunPhase(runRecord.phase, previous?.phase);
+        const lastHeartbeatAt = typeof runRecord.lastHeartbeatAt === "string" && runRecord.lastHeartbeatAt.length > 0
+            ? runRecord.lastHeartbeatAt
+            : previous?.lastHeartbeatAt;
+        const progressLogPath = typeof runRecord.progressLogPath === "string" && runRecord.progressLogPath.length > 0
+            ? runRecord.progressLogPath
+            : previous?.progressLogPath;
+        const semanticProgressSupported = typeof runRecord.semanticProgressSupported === "boolean"
+            ? runRecord.semanticProgressSupported
+            : previous?.semanticProgressSupported;
+        const semanticProgressLogPath = typeof runRecord.semanticProgressLogPath === "string" && runRecord.semanticProgressLogPath.length > 0
+            ? runRecord.semanticProgressLogPath
+            : previous?.semanticProgressLogPath;
         const error = typeof runRecord.error === "string" && runRecord.error.length > 0
             ? runRecord.error
             : undefined;
@@ -461,6 +623,11 @@ function persistRunsIndex(runRecord: Record<string, unknown>): void {
             startedAt,
             ...(finishedAt ? { finishedAt } : {}),
             status,
+            ...(phase ? { phase } : {}),
+            ...(lastHeartbeatAt ? { lastHeartbeatAt } : {}),
+            ...(progressLogPath ? { progressLogPath } : {}),
+            ...(typeof semanticProgressSupported === "boolean" ? { semanticProgressSupported } : {}),
+            ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
             taskIds: [taskId],
             results,
             pendingClarification: status === "pending-clarification" ? [taskId] : [],
@@ -529,27 +696,48 @@ function isRetryableSendAndWaitError(err: unknown): boolean {
     return /(429|rate limit|timeout|timed out|ECONNRESET|EAI_AGAIN|ENOTFOUND|ENETUNREACH|503|Service Unavailable)/i.test(message);
 }
 
-function injectDevAgentProvenanceBlock(prompt: string, runContext: {
-    runId: string;
-    role: string;
-    model: string;
-    startedAt: string;
-    taskId: string;
-}): string {
-    if (runContext.role !== "dev" || /##\s*Agent Provenance/i.test(prompt)) {
-        return prompt;
+function injectAsyncRunContext(prompt: string, runContext: AsyncRunContext): string {
+    const sections = [prompt];
+
+    if (!/##\s*Agent Provenance/i.test(prompt)) {
+        sections.push(
+            "",
+            "## Agent Provenance",
+            "",
+            `run-id: ${runContext.runId}`,
+            `task-id: ${runContext.taskId}`,
+            `role: ${runContext.role}`,
+            `dispatched: ${runContext.startedAt}`,
+            `model: ${runContext.model}`,
+        );
     }
-    return [
-        prompt,
-        "",
-        "## Agent Provenance",
-        "",
-        `run-id: ${runContext.runId}`,
-        `task-id: ${runContext.taskId}`,
-        "role: dev",
-        `dispatched: ${runContext.startedAt}`,
-        `model: ${runContext.model}`,
-    ].join("\n");
+
+    if (!/##\s*Async Run Context/i.test(prompt)) {
+        sections.push(
+            "",
+            "## Async Run Context",
+            "",
+            `progress-log-path: ${runContext.progressLogPath}`,
+            "progress-log-format: jsonl (one JSON object per line)",
+            "wrapper-progress: scripts/run-agent.ts appends lifecycle events to this file automatically",
+            "path-guarantee: this absolute path stays valid even if you change working directories or move into a sibling worktree",
+        );
+    }
+
+    if (runContext.agentMilestonesSupported && !/##\s*Optional Agent Milestones/i.test(prompt)) {
+        sections.push(
+            "",
+            "## Optional Agent Milestones",
+            "",
+            `semantic-progress-log-path: ${runContext.semanticProgressLogPath ?? "(not provisioned)"}`,
+            "instruction: if your tool surface allows workspace file writes, append concise markdown bullet milestones to the semantic progress file",
+            "suggested-markdown: - [2026-05-07T10:55:28.607Z] Implemented validation wiring",
+            "scope: task-specific milestones only; wrapper lifecycle events already go to the JSONL progress log",
+            "fallback: do not block or fail the task if you cannot update this optional file",
+        );
+    }
+
+    return sections.join("\n");
 }
 
 function inferTaskId(prompt: string, explicitTaskId?: string): string {
@@ -581,16 +769,30 @@ function extractChallenge(output: string): string {
 const runId = randomUUID();
 const startedAt = new Date().toISOString();
 const taskId = inferTaskId(prompt, taskIdArg);
+const progressLogPath = runProgressLogPath(runId);
 logInfo(`[run-agent] started  runId=${runId} role=${role} model=${model} at=${startedAt}`);
 logInfo(`[run-agent] routing  policy-model=${policyModel} policy-source=${policyModelSelection.source} model-source=${modelSource}`);
 if (!modelOverride && policyModelSelection.source === "fallback") {
     logInfo(`[run-agent] warning  unknown role='${role}' not found in routing table; using fallback model=${policyModel}`);
 }
 logInfo(`[run-agent] prompt   ${prompt.slice(0, 120).replace(/\n/g, " ")}${prompt.length > 120 ? "…" : ""}`);
+logInfo(`[run-agent] progress ${progressLogPath}`);
 
 const { tools, systemMessage } = readAgentMeta(role);
 const mcpServers = resolveAgentMcpServers(tools);
 const mcpKeys = Object.keys(mcpServers);
+const agentMilestonesSupported = supportsAgentMilestones(tools);
+const semanticProgressLogPath = agentMilestonesSupported ? runSemanticProgressLogPath(runId) : undefined;
+const asyncRunContext: AsyncRunContext = {
+    runId,
+    role,
+    model,
+    startedAt,
+    taskId,
+    progressLogPath,
+    agentMilestonesSupported,
+    ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
+};
 logInfo(`[run-agent] tools    ${tools.length > 0 ? tools.join(", ") : "(none)"}`);
 for (const [k, v] of Object.entries(mcpServers)) {
     const { headers, ...rest } = v as any;
@@ -605,8 +807,27 @@ for (const [k, v] of Object.entries(mcpServers)) {
 logInfo(`[run-agent] mcp      ${mcpKeys.length > 0 ? mcpKeys.join(", ") : "(none)"}`);
 logInfo(`[run-agent] system   ${systemMessage.slice(0, 80).replace(/\n/g, " ")}…`);
 logInfo(`[run-agent] flags    no-intro=${noIntro} output-format=${outputFormat}`);
+if (semanticProgressLogPath) {
+    logInfo(`[run-agent] semantic-progress ${semanticProgressLogPath}`);
+}
 
-persistRun({ runId, taskId, role, model, prompt: prompt.slice(0, 200), startedAt, status: "running" });
+ensureProgressLog(asyncRunContext);
+ensureSemanticProgressLog(asyncRunContext);
+persistRun({
+    runId,
+    taskId,
+    role,
+    model,
+    prompt: prompt.slice(0, 200),
+    startedAt,
+    status: "running",
+    progressLogPath,
+    semanticProgressSupported: agentMilestonesSupported,
+    ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
+    phase: "dispatched",
+    lastHeartbeatAt: startedAt,
+});
+recordRunProgress(asyncRunContext, "dispatched", "Run registered and awaiting Copilot session setup.", startedAt);
 
 let exitCode = 0;
 const client = new CopilotClient();
@@ -642,6 +863,13 @@ try {
         reasoningEffortSource: resolvedReasoningEffortSource,
         ...modelLookupRecord,
     });
+    recordRunProgress(
+        asyncRunContext,
+        "model-resolved",
+        modelLookupStatus === "ok"
+            ? `Model ${model} resolved with reasoning effort ${reasoningEffort} (${reasoningEffortSelection.source}).`
+            : `Model metadata lookup failed; using reasoning effort ${reasoningEffort} (${reasoningEffortSelection.source}).`,
+    );
     logInfo(
         `[run-agent] effort   model=${model} effort=${reasoningEffort} source=${reasoningEffortSelection.source}`
     );
@@ -667,21 +895,22 @@ try {
     });
 
     logInfo(`[run-agent] session  id=${session.sessionId}`);
+    recordRunProgress(asyncRunContext, "session-created", `Copilot session ${session.sessionId} created.`);
 
     if (preSleepMs > 0) {
         logInfo(`[run-agent] sleeping ${preSleepMs / 1000}s before sending prompt…`);
+        recordRunProgress(
+            asyncRunContext,
+            "waiting-before-send",
+            `Pre-sleep enabled for ${preSleepMs / 1000}s before sending the prompt.`,
+        );
         await new Promise((resolve) => setTimeout(resolve, preSleepMs));
     }
 
-    const promptWithProvenance = injectDevAgentProvenanceBlock(prompt, {
-        runId,
-        role,
-        model,
-        startedAt,
-        taskId,
-    });
-    const finalPrompt = noIntro ? promptWithProvenance : ROLE_INTRO_PREFIX + promptWithProvenance;
+    const promptWithRunContext = injectAsyncRunContext(prompt, asyncRunContext);
+    const finalPrompt = noIntro ? promptWithRunContext : ROLE_INTRO_PREFIX + promptWithRunContext;
     const runSession = session;
+    recordRunProgress(asyncRunContext, "waiting-for-agent", "Prompt sent to agent; waiting for the final response.");
     const result = await withRetry(
         () => runSession.sendAndWait({ prompt: finalPrompt }, TIMEOUT_MS),
         MAX_RETRIES,
@@ -693,12 +922,14 @@ try {
     const needsClarification = detectNeedsClarification(output);
     const challenge = needsClarification ? extractChallenge(output) : undefined;
     const status: RunStatus = needsClarification ? "pending-clarification" : "done";
+    const phase: RunPhase = needsClarification ? "needs-clarification" : "completed";
 
     const finishedAt = new Date().toISOString();
     persistRun({
         runId,
         taskId,
         status,
+        phase,
         finishedAt,
         output,
         ...(challenge ? { challenge } : {}),
@@ -707,6 +938,14 @@ try {
         modelLookupStatus,
         ...(modelLookupError ? { modelLookupError } : {}),
     });
+    recordRunProgress(
+        asyncRunContext,
+        phase,
+        needsClarification
+            ? "Agent returned a needs-clarification result."
+            : "Agent returned a final response.",
+        finishedAt,
+    );
     logInfo(`[run-agent] finished at=${finishedAt}`);
 
     if (outputFormat === "json") {
@@ -722,6 +961,10 @@ try {
                 startedAt,
                 finishedAt,
                 status,
+                phase,
+                progressLogPath,
+                semanticProgressSupported: agentMilestonesSupported,
+                ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
                 ...(challenge ? { challenge } : {}),
                 output,
             }) + "\n"
@@ -738,6 +981,7 @@ try {
         runId,
         taskId,
         status: "failed",
+        phase: "failed",
         finishedAt,
         error: err instanceof Error ? err.message : String(err),
         reasoningEffort: resolvedReasoningEffort,
@@ -745,6 +989,12 @@ try {
         modelLookupStatus,
         ...(modelLookupError ? { modelLookupError } : {}),
     });
+    recordRunProgress(
+        asyncRunContext,
+        "failed",
+        err instanceof Error ? err.message : String(err),
+        finishedAt,
+    );
     console.error(`[run-agent] failed:`, err instanceof Error ? err.message : err);
     exitCode = 1;
 } finally {

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -470,26 +470,32 @@ function resolveRunPhase(phase: unknown, fallback?: RunPhase): RunPhase | undefi
 }
 
 function ensureProgressLog(runContext: AsyncRunContext): void {
-    mkdirSync(RUNS_LOG_DIR, { recursive: true });
-    if (existsSync(runContext.progressLogPath)) {
-        return;
-    }
+    try {
+        mkdirSync(RUNS_LOG_DIR, { recursive: true });
+        if (existsSync(runContext.progressLogPath)) {
+            return;
+        }
 
-    writeFileSync(
-        runContext.progressLogPath,
-        JSON.stringify({
-            timestamp: runContext.startedAt,
-            source: "wrapper" as ProgressEventSource,
-            kind: "meta" as ProgressEventKind,
-            runId: runContext.runId,
-            taskId: runContext.taskId,
-            role: runContext.role,
-            model: runContext.model,
-            workspaceRoot: WORKSPACE_ROOT,
-            runRecordPath: runLogPath(runContext.runId),
-        }) + "\n",
-        "utf-8"
-    );
+        writeFileSync(
+            runContext.progressLogPath,
+            JSON.stringify({
+                timestamp: runContext.startedAt,
+                source: "wrapper" as ProgressEventSource,
+                kind: "meta" as ProgressEventKind,
+                runId: runContext.runId,
+                taskId: runContext.taskId,
+                role: runContext.role,
+                model: runContext.model,
+                workspaceRoot: WORKSPACE_ROOT,
+                runRecordPath: runLogPath(runContext.runId),
+            }) + "\n",
+            "utf-8"
+        );
+    } catch (err) {
+        console.error(
+            `[run-agent] warning: could not initialize progress log for run ${runContext.runId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
 }
 
 function ensureSemanticProgressLog(runContext: AsyncRunContext): void {
@@ -497,29 +503,35 @@ function ensureSemanticProgressLog(runContext: AsyncRunContext): void {
         return;
     }
 
-    mkdirSync(RUNS_LOG_DIR, { recursive: true });
-    if (existsSync(runContext.semanticProgressLogPath)) {
-        return;
-    }
+    try {
+        mkdirSync(RUNS_LOG_DIR, { recursive: true });
+        if (existsSync(runContext.semanticProgressLogPath)) {
+            return;
+        }
 
-    writeFileSync(
-        runContext.semanticProgressLogPath,
-        [
-            "# Async Agent Semantic Milestones",
-            "",
-            `run-id: ${runContext.runId}`,
-            `task-id: ${runContext.taskId}`,
-            `role: ${runContext.role}`,
-            `dispatched: ${runContext.startedAt}`,
-            `model: ${runContext.model}`,
-            `workspace-root: ${WORKSPACE_ROOT}`,
-            `wrapper-progress-log: ${runContext.progressLogPath}`,
-            "",
-            "## Milestones",
-            "",
-        ].join("\n"),
-        "utf-8"
-    );
+        writeFileSync(
+            runContext.semanticProgressLogPath,
+            [
+                "# Async Agent Semantic Milestones",
+                "",
+                `run-id: ${runContext.runId}`,
+                `task-id: ${runContext.taskId}`,
+                `role: ${runContext.role}`,
+                `dispatched: ${runContext.startedAt}`,
+                `model: ${runContext.model}`,
+                `workspace-root: ${WORKSPACE_ROOT}`,
+                `wrapper-progress-log: ${runContext.progressLogPath}`,
+                "",
+                "## Milestones",
+                "",
+            ].join("\n"),
+            "utf-8"
+        );
+    } catch (err) {
+        console.error(
+            `[run-agent] warning: could not initialize semantic progress log for run ${runContext.runId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
 }
 
 function supportsAgentMilestones(agentTools: string[]): boolean {
@@ -533,20 +545,26 @@ function appendProgressEvent(
     payload: Record<string, unknown>,
     timestamp = new Date().toISOString()
 ): void {
-    ensureProgressLog(runContext);
-    appendFileSync(
-        runContext.progressLogPath,
-        JSON.stringify({
-            timestamp,
-            source,
-            kind,
-            runId: runContext.runId,
-            taskId: runContext.taskId,
-            role: runContext.role,
-            ...payload,
-        }) + "\n",
-        "utf-8"
-    );
+    try {
+        ensureProgressLog(runContext);
+        appendFileSync(
+            runContext.progressLogPath,
+            JSON.stringify({
+                timestamp,
+                source,
+                kind,
+                runId: runContext.runId,
+                taskId: runContext.taskId,
+                role: runContext.role,
+                ...payload,
+            }) + "\n",
+            "utf-8"
+        );
+    } catch (err) {
+        console.error(
+            `[run-agent] warning: could not append progress event for run ${runContext.runId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
 }
 
 function recordRunProgress(

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -124,7 +124,7 @@ interface AsyncRunContext {
     startedAt: string;
     taskId: string;
     progressLogPath: string;
-    agentMilestonesSupported: boolean;
+    semanticProgressSupported: boolean;
     semanticProgressLogPath?: string;
 }
 
@@ -765,14 +765,14 @@ function injectAsyncRunContext(prompt: string, runContext: AsyncRunContext): str
         );
     }
 
-    if (runContext.agentMilestonesSupported && !/##\s*Optional Agent Milestones/i.test(prompt)) {
+    if (runContext.semanticProgressSupported && !/##\s*Optional Agent Milestones/i.test(prompt)) {
         sections.push(
             "",
             "## Optional Agent Milestones",
             "",
             `semantic-progress-log-path: ${runContext.semanticProgressLogPath ?? "(not provisioned)"}`,
             "instruction: if your tool surface allows workspace file writes, append concise markdown bullet milestones to the semantic progress file",
-            "suggested-markdown: - [2026-05-07T10:55:28.607Z] Implemented validation wiring",
+            "suggested-markdown: - [<ISO_TIMESTAMP>] Implemented validation wiring",
             "scope: task-specific milestones only; wrapper lifecycle events already go to the JSONL progress log",
             "fallback: do not block or fail the task if you cannot update this optional file",
         );
@@ -822,8 +822,8 @@ logInfo(`[run-agent] progress ${progressLogPath}`);
 const { tools, systemMessage } = readAgentMeta(role);
 const mcpServers = resolveAgentMcpServers(tools);
 const mcpKeys = Object.keys(mcpServers);
-const agentMilestonesSupported = supportsAgentMilestones(tools);
-const semanticProgressLogPath = agentMilestonesSupported ? runSemanticProgressLogPath(runId) : undefined;
+const semanticProgressSupported = supportsAgentMilestones(tools);
+const semanticProgressLogPath = semanticProgressSupported ? runSemanticProgressLogPath(runId) : undefined;
 const asyncRunContext: AsyncRunContext = {
     runId,
     role,
@@ -831,7 +831,7 @@ const asyncRunContext: AsyncRunContext = {
     startedAt,
     taskId,
     progressLogPath,
-    agentMilestonesSupported,
+    semanticProgressSupported,
     ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
 };
 logInfo(`[run-agent] tools    ${tools.length > 0 ? tools.join(", ") : "(none)"}`);
@@ -863,7 +863,7 @@ persistRun({
     startedAt,
     status: "running",
     progressLogPath,
-    semanticProgressSupported: agentMilestonesSupported,
+    semanticProgressSupported,
     ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
     phase: "dispatched",
     lastHeartbeatAt: startedAt,
@@ -1008,7 +1008,7 @@ try {
                 status,
                 phase,
                 progressLogPath,
-                semanticProgressSupported: agentMilestonesSupported,
+                semanticProgressSupported,
                 ...(semanticProgressLogPath ? { semanticProgressLogPath } : {}),
                 ...(challenge ? { challenge } : {}),
                 output,

--- a/scripts/run-agent.ts
+++ b/scripts/run-agent.ts
@@ -39,6 +39,17 @@ import {
 const TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 const MAX_RETRIES = 3;             // Retry sendAndWait on transient failures
 const RETRY_BASE_MS = 2_000;       // Exponential backoff base (2 s → 4 s → 8 s)
+const DEFAULT_WAIT_HEARTBEAT_MS = 60_000;
+
+const WAIT_HEARTBEAT_MS = (() => {
+    const raw = process.env.RUN_AGENT_WAIT_HEARTBEAT_MS;
+    if (!raw) {
+        return DEFAULT_WAIT_HEARTBEAT_MS;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_WAIT_HEARTBEAT_MS;
+})();
 
 // Prepended to every prompt so the agent always opens with a role introduction.
 // Skipped when --no-intro flag is passed (e.g. for structured @file prompts).
@@ -555,6 +566,36 @@ function recordRunProgress(
     });
 }
 
+function recordRunHeartbeat(
+    runContext: AsyncRunContext,
+    detail = "Still waiting for the final response.",
+    heartbeatAt = new Date().toISOString()
+): void {
+    const normalizedDetail = detail.replace(/\s+/g, " ").trim();
+    appendProgressEvent(
+        runContext,
+        "wrapper",
+        "lifecycle",
+        { phase: "waiting-for-agent", detail: normalizedDetail, heartbeat: true },
+        heartbeatAt,
+    );
+    persistRun({
+        runId: runContext.runId,
+        taskId: runContext.taskId,
+        progressLogPath: runContext.progressLogPath,
+        phase: "waiting-for-agent",
+        lastHeartbeatAt: heartbeatAt,
+    });
+}
+
+function startWaitHeartbeat(runContext: AsyncRunContext): NodeJS.Timeout {
+    const heartbeat = setInterval(() => {
+        recordRunHeartbeat(runContext);
+    }, WAIT_HEARTBEAT_MS);
+    heartbeat.unref();
+    return heartbeat;
+}
+
 function persistRunsIndex(runRecord: Record<string, unknown>): void {
     let lockAcquired = false;
     try {
@@ -836,6 +877,7 @@ let resolvedReasoningEffort: ReasoningEffort | undefined;
 let resolvedReasoningEffortSource: ReasoningEffortSource | undefined;
 let modelLookupStatus: "ok" | "failed" = "ok";
 let modelLookupError: string | undefined;
+let waitHeartbeat: NodeJS.Timeout | undefined;
 
 try {
     await client.start();
@@ -911,6 +953,7 @@ try {
     const finalPrompt = noIntro ? promptWithRunContext : ROLE_INTRO_PREFIX + promptWithRunContext;
     const runSession = session;
     recordRunProgress(asyncRunContext, "waiting-for-agent", "Prompt sent to agent; waiting for the final response.");
+    waitHeartbeat = startWaitHeartbeat(asyncRunContext);
     const result = await withRetry(
         () => runSession.sendAndWait({ prompt: finalPrompt }, TIMEOUT_MS),
         MAX_RETRIES,
@@ -918,6 +961,8 @@ try {
         "sendAndWait",
         isRetryableSendAndWaitError
     );
+    clearInterval(waitHeartbeat);
+    waitHeartbeat = undefined;
     const output = result?.data?.content ?? "(no output)";
     const needsClarification = detectNeedsClarification(output);
     const challenge = needsClarification ? extractChallenge(output) : undefined;
@@ -976,6 +1021,10 @@ try {
     }
 
 } catch (err) {
+    if (waitHeartbeat) {
+        clearInterval(waitHeartbeat);
+        waitHeartbeat = undefined;
+    }
     const finishedAt = new Date().toISOString();
     persistRun({
         runId,
@@ -998,6 +1047,10 @@ try {
     console.error(`[run-agent] failed:`, err instanceof Error ? err.message : err);
     exitCode = 1;
 } finally {
+    if (waitHeartbeat) {
+        clearInterval(waitHeartbeat);
+        waitHeartbeat = undefined;
+    }
     if (session) {
         try { await session.disconnect(); } catch { /* non-fatal */ }
     }


### PR DESCRIPTION
## Summary
- add wrapper-owned async run lifecycle logging in `scripts/run-agent.ts`
- persist machine-readable wrapper progress in JSONL and optional human-readable semantic milestones in Markdown
- document the async progress logging contract in shared protocol and dispatch skill docs

## Verification
- `npx tsc -p tsconfig.scripts.json --noEmit`
- dry-run async dispatch via `scripts/run-agent.ts` with `ux-agent`

Closes #218